### PR TITLE
Add Tier-B conversational initiative and voice responsiveness

### DIFF
--- a/nova_backend/src/brain_server.py
+++ b/nova_backend/src/brain_server.py
@@ -25,6 +25,9 @@ from src.gates.confirmation_gate import confirmation_gate
 from src.governor.governor_mediator import GovernorMediator, Invocation, Clarification
 from src.speech_state import speech_state
 from src.conversation.thought_store import ThoughtStore
+from src.conversation.complexity_heuristics import ComplexityHeuristics
+from src.voice.stt_pipeline import STTAckConfig, build_ack_payload
+from src.voice.tts_engine import resolve_speakable_text
 
 # -------------------------------------------------
 # App + Logging
@@ -62,11 +65,16 @@ app.include_router(stt_router)
 # -------------------------------------------------
 skill_registry = SkillRegistry()
 thought_store = ThoughtStore(ttl=300)
+conversation_heuristics = ComplexityHeuristics()
 
 # -------------------------------------------------
 # Security Constants
 # -------------------------------------------------
 WS_INPUT_MAX_BYTES = 4096
+CONVERSATIONAL_INITIATIVE_ENABLED = True
+VOICE_ACK_ENABLED = True
+VOICE_ACK_TEXT = "Got it."
+VOICE_ACK_CONFIG = STTAckConfig(enabled=VOICE_ACK_ENABLED, text=VOICE_ACK_TEXT)
 
 # -------------------------------------------------
 # Phase Status Endpoint
@@ -130,6 +138,7 @@ async def websocket_endpoint(ws: WebSocket):
         "pending_escalation": None,
         "last_input_channel": "text",
         "last_response": "",
+        "last_clarification_turn": None,
     }
 
     await send_chat_message(ws, "Hello. How can I help?")
@@ -171,6 +180,11 @@ async def websocket_endpoint(ws: WebSocket):
                 continue
 
             lowered = text.lower()
+
+            if channel == "voice" and msg_type == "chat":
+                ack_payload = build_ack_payload(VOICE_ACK_CONFIG)
+                if ack_payload is not None:
+                    await ws_send(ws, ack_payload)
 
             # --- Escalation handling (fixed: clear pending on all outcomes) ---
             if session_state["pending_escalation"]:
@@ -229,6 +243,12 @@ async def websocket_endpoint(ws: WebSocket):
                 await send_chat_done(ws)
                 continue
 
+            # --- Conversation layer (Tier-B, non-authorizing) ---
+            if CONVERSATIONAL_INITIATIVE_ENABLED:
+                conversation_snapshot = session_context[-6:]
+                conversational_signal = conversation_heuristics.assess(text, conversation_snapshot)
+                session_state["conversation_mode"] = conversational_signal.get("mode", "casual")
+
             # --- Governor mediation ---
             mediated_text = GovernorMediator.mediate(text)
 
@@ -256,9 +276,10 @@ async def websocket_endpoint(ws: WebSocket):
                 # Auto‑speak for voice input (only if not a TTS invocation)
                 if (session_state.get("last_input_channel") == "voice"
                         and action_result.success
-                        and action_result.message
                         and capability_id != 18):
-                    governor.handle_governed_invocation(18, {"text": action_result.message})
+                    speakable_text = resolve_speakable_text(action_result)
+                    if speakable_text:
+                        governor.handle_governed_invocation(18, {"text": speakable_text})
                 continue
 
             elif isinstance(inv_result, Clarification):
@@ -338,9 +359,14 @@ async def websocket_endpoint(ws: WebSocket):
 
                 # Auto‑speak for voice input (only if the skill result indicates success)
                 if (session_state.get("last_input_channel") == "voice"
-                        and getattr(skill_result, "success", True)
-                        and message):
-                    governor.handle_governed_invocation(18, {"text": message})
+                        and getattr(skill_result, "success", True)):
+                    speakable_text = ""
+                    if isinstance(result_data, dict):
+                        speakable_text = (result_data.get("speakable_text") or "").strip()
+                    if not speakable_text:
+                        speakable_text = message
+                    if speakable_text:
+                        governor.handle_governed_invocation(18, {"text": speakable_text})
 
                 session_context.extend([{"role": "user", "content": mediated_text}, {"role": "assistant", "content": message}])
                 session_context = session_context[-20:]

--- a/nova_backend/src/conversation/complexity_heuristics.py
+++ b/nova_backend/src/conversation/complexity_heuristics.py
@@ -41,6 +41,17 @@ class ComplexityHeuristics:
     ]
 
     SIMPLE_GREETINGS = {"hi", "hello", "hey", "good morning", "good afternoon"}
+    AMBIGUITY_PATTERNS = {
+        "this",
+        "that",
+        "it",
+        "something",
+        "stuff",
+        "help me",
+        "do it",
+    }
+    EXPLORATORY_CUES = {"ideas", "what if", "explore", "brainstorm", "options", "approach"}
+    TRANSACTIONAL_CUES = {"thanks", "thank you", "ok", "okay", "done", "yes", "no", "cancel"}
 
     @classmethod
     def assess(cls, user_message: str, context: List[Dict[str, str]]) -> Dict[str, Any]:
@@ -67,9 +78,54 @@ class ComplexityHeuristics:
         else:
             escalate = len(reasons) > 0
 
+        ambiguity_score = cls._ambiguity_score(text, word_count)
+        depth_score = cls._depth_opportunity_score(text, word_count, reasons)
+        exploratory = any(cue in text for cue in cls.EXPLORATORY_CUES)
+        transactional = text.strip() in cls.TRANSACTIONAL_CUES
+
         return {
             "escalate": escalate,
             "reason_codes": reasons,
             "confidence": 0.8 if escalate else 0.0,
             "suggested_max_tokens": 800 if escalate else 0,
+            "ambiguity_score": ambiguity_score,
+            "depth_opportunity_score": depth_score,
+            "expansion_candidate": depth_score >= 0.45,
+            "exploratory_intent": exploratory,
+            "transactional_query": transactional,
+            "mode": cls._mode_hint(text),
         }
+
+    @classmethod
+    def _ambiguity_score(cls, text: str, word_count: int) -> float:
+        score = 0.0
+        if word_count <= 4:
+            score += 0.25
+        if "?" not in text and word_count <= 6:
+            score += 0.15
+        if any(token in text.split() for token in cls.AMBIGUITY_PATTERNS):
+            score += 0.35
+        if text.strip() in {"help", "explain", "details"}:
+            score += 0.35
+        return min(score, 1.0)
+
+    @classmethod
+    def _depth_opportunity_score(cls, text: str, word_count: int, reasons: List[str]) -> float:
+        score = 0.15 if word_count > 15 else 0.0
+        if "DEPTH_KEYWORD" in reasons:
+            score += 0.45
+        if "DEEP_CONTEXT" in reasons:
+            score += 0.25
+        if any(cue in text for cue in cls.EXPLORATORY_CUES):
+            score += 0.25
+        return min(score, 1.0)
+
+    @classmethod
+    def _mode_hint(cls, text: str) -> str:
+        if any(cue in text for cue in ("ideas", "what if", "explore", "brainstorm")):
+            return "brainstorming"
+        if any(cue in text for cue in ("analyze", "analyse", "compare", "deep dive", "evaluate")):
+            return "analytical"
+        if any(cue in text for cue in ("implement", "write code", "modify", "file", "patch")):
+            return "implementation"
+        return "casual"

--- a/nova_backend/src/conversation/escalation_policy.py
+++ b/nova_backend/src/conversation/escalation_policy.py
@@ -11,12 +11,37 @@ class EscalationPolicy:
             "cooldown_turns": 2,
         }
 
+    def conversational_flags(
+        self,
+        heuristic_result: Dict[str, Any],
+        user_message: str,
+        session_state: dict,
+    ) -> Dict[str, bool]:
+        text = (user_message or "").strip().lower()
+        depth_score = float(heuristic_result.get("depth_opportunity_score", 0.0))
+        ambiguity_score = float(heuristic_result.get("ambiguity_score", 0.0))
+        exploratory = bool(heuristic_result.get("exploratory_intent", False))
+        transactional = bool(heuristic_result.get("transactional_query", False))
+
+        turn = int(session_state.get("turn_count", 0))
+        last_clarification_turn = session_state.get("last_clarification_turn")
+        clarification_on_cooldown = (last_clarification_turn is not None and turn == last_clarification_turn)
+
+        direct_execution = any(cmd in text for cmd in ("search ", "open ", "speak that", "read that", "say it"))
+
+        return {
+            "allow_clarification": ambiguity_score >= 0.5 and not clarification_on_cooldown and not transactional,
+            "allow_branch_suggestion": heuristic_result.get("expansion_candidate", False) and exploratory and not direct_execution,
+            "allow_depth_prompt": depth_score >= 0.6 and exploratory and not transactional and not direct_execution,
+        }
+
     def decide(
         self,
         heuristic_result: Dict[str, Any],
         user_message: str,
         session_state: dict,
     ) -> PolicyDecision:
+        """Execution escalation decision only (non-conversational)."""
         del user_message
 
         if not heuristic_result.get("escalate"):

--- a/nova_backend/src/conversation/response_formatter.py
+++ b/nova_backend/src/conversation/response_formatter.py
@@ -1,9 +1,24 @@
 import re
+from typing import Dict, Optional
 
 
 class ResponseFormatter:
+    CLARIFICATION_TEMPLATES = {
+        "casual": "Would you like a brief answer or a deeper breakdown?",
+        "analytical": "Do you want a high-level comparison or implementation detail?",
+        "implementation": "Should I stay conceptual, or break this into concrete steps?",
+        "brainstorming": "Do you want broad ideas or a narrower direction?",
+    }
+
+    DEPTH_PROMPTS = {
+        "casual": "If useful, I can break that into a few clear steps.",
+        "analytical": "If useful, I can go deeper on tradeoffs and assumptions.",
+        "implementation": "If useful, I can map this into an implementation sequence.",
+        "brainstorming": "If useful, I can branch this into a few neutral options.",
+    }
+
     @staticmethod
-    def format(text: str) -> str:
+    def format(text: str, mode: str = "casual") -> str:
         clean = (text or "").strip()
         clean = re.sub(r"  +", " ", clean)
         clean = re.sub(r"!+", ".", clean)
@@ -12,4 +27,38 @@ class ResponseFormatter:
         for filler in [r"\bwell\b", r"\bso\b", r"\byou see\b"]:
             clean = re.sub(filler, "", clean, flags=re.IGNORECASE)
 
+        clean = ResponseFormatter._tone_shape(clean, mode)
         return re.sub(r"\s{2,}", " ", clean).strip()
+
+    @staticmethod
+    def with_conversational_initiative(
+        base_text: str,
+        mode: str,
+        allow_clarification: bool = False,
+        allow_branch_suggestion: bool = False,
+        allow_depth_prompt: bool = False,
+    ) -> str:
+        text = ResponseFormatter.format(base_text, mode=mode)
+        add_ons = []
+
+        if allow_clarification:
+            add_ons.append(ResponseFormatter.CLARIFICATION_TEMPLATES.get(mode, ResponseFormatter.CLARIFICATION_TEMPLATES["casual"]))
+
+        if allow_branch_suggestion:
+            add_ons.append("We could approach this in a few ways: direct answer, stepwise plan, or side-by-side comparison.")
+
+        if allow_depth_prompt:
+            add_ons.append(ResponseFormatter.DEPTH_PROMPTS.get(mode, ResponseFormatter.DEPTH_PROMPTS["casual"]))
+
+        if add_ons:
+            text = f"{text}\n\n" + "\n".join(add_ons[:2])
+
+        return text.strip()
+
+    @staticmethod
+    def _tone_shape(text: str, mode: str) -> str:
+        if mode == "analytical":
+            return text.replace("I think", "The analysis indicates")
+        if mode == "implementation" and "\n" not in text and ". " in text:
+            return text.replace(". ", ".\n")
+        return text

--- a/nova_backend/src/governor/governor_mediator.py
+++ b/nova_backend/src/governor/governor_mediator.py
@@ -6,6 +6,7 @@ GovernorMediator – Phase‑4 ready parser shim with one‑strike clarification
 - Maintains ephemeral clarification state per session.
 - Returns structured dataclass instances to disambiguate invocation, clarification, or none.
 - Never creates ActionRequests. Never executes actions.
+- Conversation-layer initiative may shape language only; authority stays with Governor routing.
 """
 
 from __future__ import annotations

--- a/nova_backend/src/skills/general_chat.py
+++ b/nova_backend/src/skills/general_chat.py
@@ -41,18 +41,18 @@ class GeneralChatSkill(BaseSkill):
     )
 
     MODE_BLOCKS: Dict[str, str] = {
-        "concise": (
+        "casual": (
             "Communication style: Concise.\n"
             "- Answer in one or two short, complete sentences.\n"
             "- No additional commentary.\n"
         ),
-        "explanatory": (
+        "brainstorming": (
             "Communication style: Explanatory.\n"
             "- Explain clearly using cause and effect.\n"
             "- Use precise, straightforward language.\n"
             "- Avoid persuasive or motivational tone.\n"
         ),
-        "procedural": (
+        "implementation": (
             "Communication style: Procedural.\n"
             "- Provide ordered steps using direct address ('you').\n"
             "- Use composed, precise language.\n"
@@ -68,9 +68,9 @@ class GeneralChatSkill(BaseSkill):
     }
 
     MAX_TOKENS: Dict[str, int] = {
-        "concise": 150,
-        "explanatory": 500,
-        "procedural": 400,
+        "casual": 150,
+        "brainstorming": 500,
+        "implementation": 400,
         "analytical": 600,
     }
 
@@ -105,21 +105,21 @@ class GeneralChatSkill(BaseSkill):
     def _detect_mode(self, query: str) -> str:
         q = (query or "").strip().lower()
         if not q:
-            return "concise"
+            return "casual"
 
-        if any(phrase in q for phrase in ("step by step", "walk me through", "show me how", "what should i do", "how do i")):
-            return "procedural"
+        if any(word in q for word in ("ideas", "what if", "explore", "brainstorm", "directions")):
+            return "brainstorming"
 
-        if any(word in q for word in ("analyse", "analyze", "trade-off", "compare", "pros and cons", "evaluate", "strategy", "why would")):
+        if any(word in q for word in ("analyse", "analyze", "trade-off", "compare", "pros and cons", "evaluate", "strategy", "deep dive")):
             return "analytical"
 
-        if any(word in q for word in ("explain", "why does", "how does", "what causes", "reason", "mechanism", "architecture", "design")):
-            return "explanatory"
+        if any(phrase in q for phrase in ("step by step", "walk me through", "show me how", "how do i", "modify", "write code", "implement")):
+            return "implementation"
 
-        return "concise"
+        return "casual"
 
     def _build_system_prompt(self, mode: str) -> str:
-        mode_block = self.MODE_BLOCKS.get(mode, self.MODE_BLOCKS["concise"])
+        mode_block = self.MODE_BLOCKS.get(mode, self.MODE_BLOCKS["casual"])
         return f"{self.BASE_CONTRACT}\n{mode_block}".strip()
 
     def _sanitize_response(self, text: str) -> str:
@@ -143,7 +143,7 @@ class GeneralChatSkill(BaseSkill):
 
         mode = self._detect_mode(query)
         system_prompt = self._build_system_prompt(mode)
-        max_tokens = self.MAX_TOKENS.get(mode, self.MAX_TOKENS["concise"])
+        max_tokens = self.MAX_TOKENS.get(mode, self.MAX_TOKENS["casual"])
 
         try:
             response = await asyncio.to_thread(
@@ -170,6 +170,8 @@ class GeneralChatSkill(BaseSkill):
 
         heuristic_result = self.heuristics.assess(query, context)
         decision = self.policy.decide(heuristic_result, query, session_state)
+        mode = heuristic_result.get("mode") or self._detect_mode(query)
+        initiative = self.policy.conversational_flags(heuristic_result, query, session_state)
 
         if decision == "ASK_USER":
             return SkillResult(
@@ -201,7 +203,13 @@ class GeneralChatSkill(BaseSkill):
                 heuristic_result.get("suggested_max_tokens", 800),
             )
             safe = self.safety.filter(raw)
-            formatted = self.formatter.format(safe)
+            formatted = self.formatter.with_conversational_initiative(
+                safe,
+                mode=mode,
+                allow_clarification=initiative.get("allow_clarification", False),
+                allow_branch_suggestion=initiative.get("allow_branch_suggestion", False),
+                allow_depth_prompt=initiative.get("allow_depth_prompt", False),
+            )
             if session_state.get("show_thinking_hints", True):
                 formatted = f"Let me think…\n\n{formatted}"
 
@@ -217,6 +225,14 @@ class GeneralChatSkill(BaseSkill):
         if local is None:
             return None
 
-        local.message = self.formatter.format(local.message)
+        local.message = self.formatter.with_conversational_initiative(
+            local.message,
+            mode=mode,
+            allow_clarification=initiative.get("allow_clarification", False),
+            allow_branch_suggestion=initiative.get("allow_branch_suggestion", False),
+            allow_depth_prompt=initiative.get("allow_depth_prompt", False),
+        )
+        if initiative.get("allow_clarification"):
+            session_state["last_clarification_turn"] = session_state.get("turn_count", 0)
         local.data = {"escalation": {"escalated": False}}
         return local

--- a/nova_backend/src/voice/__init__.py
+++ b/nova_backend/src/voice/__init__.py
@@ -1,0 +1,1 @@
+"""Voice-layer helpers for Tier-B conversational responsiveness."""

--- a/nova_backend/src/voice/stt_pipeline.py
+++ b/nova_backend/src/voice/stt_pipeline.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class STTAckConfig:
+    enabled: bool = True
+    text: str = "Got it."
+
+
+def build_ack_payload(config: STTAckConfig) -> dict | None:
+    """Build a lightweight acknowledgement payload for STT interactions."""
+    if not config.enabled:
+        return None
+    return {"type": "ack", "message": config.text}

--- a/nova_backend/src/voice/tts_engine.py
+++ b/nova_backend/src/voice/tts_engine.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def resolve_speakable_text(action_result: Any) -> str:
+    """Resolve text suitable for speech output from an action result object."""
+    if action_result is None:
+        return ""
+
+    data: Dict[str, Any] = getattr(action_result, "data", {}) or {}
+    speakable = (data.get("speakable_text") or "").strip()
+    if speakable:
+        return speakable
+
+    message = getattr(action_result, "user_message", "") or getattr(action_result, "message", "")
+    return (message or "").strip()

--- a/nova_backend/tests/test_tierb_conversation.py
+++ b/nova_backend/tests/test_tierb_conversation.py
@@ -1,0 +1,38 @@
+from src.conversation.complexity_heuristics import ComplexityHeuristics
+from src.conversation.escalation_policy import EscalationPolicy
+from src.conversation.response_formatter import ResponseFormatter
+
+
+def test_heuristics_exposes_tierb_signals():
+    result = ComplexityHeuristics.assess("Can we brainstorm ideas and compare options?", [])
+    assert "ambiguity_score" in result
+    assert "depth_opportunity_score" in result
+    assert result["exploratory_intent"] is True
+    assert result["mode"] in {"brainstorming", "analytical", "implementation", "casual"}
+
+
+def test_policy_returns_non_authorizing_conversation_flags():
+    policy = EscalationPolicy()
+    heuristic = {
+        "depth_opportunity_score": 0.8,
+        "ambiguity_score": 0.7,
+        "expansion_candidate": True,
+        "exploratory_intent": True,
+        "transactional_query": False,
+    }
+    flags = policy.conversational_flags(heuristic, "explore options", {"turn_count": 1})
+    assert flags["allow_clarification"] is True
+    assert flags["allow_branch_suggestion"] is True
+    assert flags["allow_depth_prompt"] is True
+
+
+def test_formatter_adds_at_most_two_tierb_prompts():
+    text = ResponseFormatter.with_conversational_initiative(
+        "Baseline answer.",
+        mode="brainstorming",
+        allow_clarification=True,
+        allow_branch_suggestion=True,
+        allow_depth_prompt=True,
+    )
+    assert "Baseline answer." in text
+    assert text.count("\n") >= 2


### PR DESCRIPTION
### Motivation

- Introduce a Tier‑B conversational initiative layer to make Nova more natural and contextually helpful without changing governance or execution authority. 
- Surface heuristic signals (ambiguity, depth opportunity, exploratory intent, and soft mode hints) so conversation logic can suggest clarifications, depth prompts, or branching options when appropriate. 
- Improve STT→TTS responsiveness with a fast acknowledgement and safer speakable-text resolution for voice-mode flows.

### Description

- Add Tier‑B signals and scoring to `src/conversation/complexity_heuristics.py` including `ambiguity_score`, `depth_opportunity_score`, `exploratory_intent`, `transactional_query`, and a `mode` hint. 
- Add non‑authorizing conversational flags in `src/conversation/escalation_policy.py` via `conversational_flags()` (`allow_clarification`, `allow_branch_suggestion`, `allow_depth_prompt`) while leaving `decide()` as the execution-only escalation path. 
- Extend `src/conversation/response_formatter.py` with mode-sensitive templates and `with_conversational_initiative()` to append at-most-two neutral prompts (clarification/branch/depth) and tone shaping. 
- Apply initiative signals in the general chat skill (`src/skills/general_chat.py`) so allowed deep analyses use conversation templates and local model paths include initiative prompts without altering governor routing. 
- Update `src/brain_server.py` to run the conversation heuristics prior to governor mediation, add a `CONVERSATIONAL_INITIATIVE_ENABLED` toggle, emit fast STT ack payloads on voice input, and prefer `speakable_text` when auto‑invoking the TTS capability. 
- Add voice-layer helpers in `src/voice/stt_pipeline.py` and `src/voice/tts_engine.py` for ack payload construction and speakable text extraction, and add a clarifying comment in `src/governor/governor_mediator.py` that conversation initiative is advisory only. 
- Add tests `nova_backend/tests/test_tierb_conversation.py` validating heuristic signals, policy conversational flags, and response formatter initiative composition.

### Testing

- Ran the full test suite with `pytest -q` and all tests passed; after the change the suite reports `46 passed` (previous runs showed 43 then 46 after adding tests). 
- Created and ran targeted unit tests in `nova_backend/tests/test_tierb_conversation.py` which assert the new heuristic fields and policy flags and succeeded as part of the suite. 
- No runtime or governance tests were changed and the changes preserve existing Governor decision paths and execution behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a238b86a6c832698bba183c2af8cd4)