### PR TITLE
Dashboard: news summaries & expand, thought overlays, search widget, and backend TTS/search refinements

### DIFF
--- a/Nova-Frontend-Dashboard/dashboard.js
+++ b/Nova-Frontend-Dashboard/dashboard.js
@@ -7,6 +7,11 @@
    ========================================================= */
 
 let ws = null;
+let pendingThoughtMessageId = null;
+let messageMeta = new Map();
+let waitingForAssistant = false;
+let latestNewsItems = [];
+let newsExpanded = false;
 
 // PHASE-3 STT STATE (UI-ONLY, DESCRIPTIVE)
 let sttState = "READY"; // READY | LISTENING | PAUSED | PROCESSING
@@ -46,6 +51,42 @@ function safeWSSend(message) {
   return true;
 }
 
+
+function setThinkingBar(visible) {
+  const bar = $("thinking-bar");
+  if (!bar) return;
+  bar.style.display = visible ? "block" : "none";
+}
+
+function showThoughtOverlay(anchor, thoughtData) {
+  let overlay = document.getElementById("thought-overlay");
+  if (!overlay) {
+    overlay = document.createElement("div");
+    overlay.id = "thought-overlay";
+    overlay.className = "thought-overlay";
+    document.body.appendChild(overlay);
+  }
+
+  const reasons = (thoughtData.reason_codes || []).map((code) => `<li>${code.replace(/_/g, " ")}</li>`).join("");
+  overlay.innerHTML = `
+    <div class="thought-title">Escalation reasoning</div>
+    <ul>${reasons || "<li>No reason codes available</li>"}</ul>
+  `;
+
+  const rect = anchor.getBoundingClientRect();
+  overlay.style.left = `${Math.min(window.innerWidth - 300, rect.left)}px`;
+  overlay.style.top = `${rect.bottom + 8}px`;
+  overlay.style.display = "block";
+}
+
+function bindThoughtIndicator(button, messageId) {
+  button.addEventListener("click", () => {
+    if (!messageId) return;
+    if (!safeWSSend({ type: "get_thought", message_id: messageId })) return;
+    pendingThoughtMessageId = messageId;
+  });
+}
+
 /* =========================================================
    3. WEATHER WIDGET (CANONICAL)
    Expects: { type:"weather", data:{...} }
@@ -73,20 +114,33 @@ function renderWeatherWidget(data) {
    Expects: { type:"news", items:[...] }
    ========================================================= */
 
-function renderNewsWidget(items) {
+function updateNewsSummary(summaryText) {
+  const summary = $("news-summary");
+  if (!summary) return;
+  summary.textContent = (summaryText || "").trim() || "Headlines loaded. Press 'Summarize headlines' for a briefing.";
+}
+
+function renderNewsWidget(items, summaryText = "") {
   const list = $("news-list");
   if (!list) return;
 
   clear(list);
 
   if (!Array.isArray(items) || items.length === 0) {
+    latestNewsItems = [];
     const li = document.createElement("li");
     li.textContent = "No headlines available.";
     list.appendChild(li);
+    updateNewsSummary("No headlines are available to summarize right now.");
+    setNewsExpandButton();
     return;
   }
 
-  items.forEach(item => {
+  latestNewsItems = items.slice();
+  updateNewsSummary(summaryText);
+
+  const visibleItems = newsExpanded ? latestNewsItems : latestNewsItems.slice(0, 3);
+  visibleItems.forEach(item => {
     const li = document.createElement("li");
 
     const a = document.createElement("a");
@@ -105,19 +159,82 @@ function renderNewsWidget(items) {
 
     list.appendChild(li);
   });
+
+  setNewsExpandButton();
+}
+
+function setNewsExpandButton() {
+  const btn = $("btn-news-expand");
+  if (!btn) return;
+
+  const hasExtra = latestNewsItems.length > 3;
+  btn.style.display = hasExtra ? "inline-block" : "none";
+  btn.textContent = newsExpanded ? "Show brief" : "Expand details";
+  btn.setAttribute("aria-pressed", newsExpanded ? "true" : "false");
 }
 
 /* =========================================================
-   5. CHAT (USER-INITIATED ONLY)
+   5. SEARCH WIDGET (PHASE‑4)
+   Expects: { type:"search", data:{ results:[{title,url}] } }
    ========================================================= */
 
-function appendChatMessage(role, text) {
+function renderSearchWidget(data) {
+  // Optional dedicated container – if it exists, use it.
+  const container = $("search-widget");
+  if (container) {
+    clear(container);
+    if (!data || !Array.isArray(data.results) || data.results.length === 0) {
+      container.textContent = "No results found.";
+      return;
+    }
+    data.results.forEach(item => {
+      const div = document.createElement("div");
+      div.className = "search-result";
+      const a = document.createElement("a");
+      a.href = item.url;
+      a.textContent = item.title;
+      a.target = "_blank";
+      a.rel = "noopener noreferrer";
+      div.appendChild(a);
+      container.appendChild(div);
+    });
+  } else {
+    // Fallback: show each result as a chat message
+    if (!data || !Array.isArray(data.results) || data.results.length === 0) {
+      appendChatMessage("assistant", "No results found.");
+      return;
+    }
+    data.results.forEach(item => {
+      appendChatMessage("assistant", `${item.title}\n${item.url}`);
+    });
+  }
+}
+
+/* =========================================================
+   6. CHAT (USER-INITIATED ONLY)
+   ========================================================= */
+
+function appendChatMessage(role, text, messageId = null) {
   const chat = $("chat-log");
   if (!chat) return;
 
   const div = document.createElement("div");
   div.className = `chat-${role}`;
-  div.textContent = text;
+
+  const textNode = document.createElement("span");
+  textNode.textContent = text;
+  div.appendChild(textNode);
+
+  if (role === "assistant" && messageId) {
+    messageMeta.set(messageId, div);
+    const thoughtBtn = document.createElement("button");
+    thoughtBtn.className = "thought-indicator";
+    thoughtBtn.type = "button";
+    thoughtBtn.textContent = "ⓘ";
+    thoughtBtn.title = "Show reasoning";
+    div.appendChild(thoughtBtn);
+    bindThoughtIndicator(thoughtBtn, messageId);
+  }
 
   chat.appendChild(div);
   chat.scrollTop = chat.scrollHeight;
@@ -127,7 +244,7 @@ function appendChatMessage(role, text) {
    SINGLE INGESTION PATH (Phase-3 Canonical)
    ========================================================= */
 
-function injectUserText(text) {
+function injectUserText(text, channel = "text") {
   const clean = (text || "").trim();
   if (!clean) {
     console.log("[INGEST] Empty input - ignored");
@@ -138,15 +255,17 @@ function injectUserText(text) {
   
   // Single canonical path for ALL user input (typed + STT)
   appendChatMessage("user", clean);
+  waitingForAssistant = true;
+  setThinkingBar(true);
   
   // Phase-3 calm: if WS fails, just log, don't spam chat
-  if (!safeWSSend({ text: clean })) {
+  if (!safeWSSend({ text: clean, channel })) {
     console.warn("[INGEST] WebSocket not ready - message dropped");
   }
 }
 
 /* =========================================================
-   6. STT (PUSH-TO-TALK, PHASE-3 SAFE)
+   7. STT (PUSH-TO-TALK, PHASE-3 SAFE)
    ========================================================= */
 
 async function startSTT() {
@@ -224,7 +343,7 @@ console.log("[STT] response:", data);
 console.log("[STT RESULT]", JSON.stringify(data.text));
 
         if (data.text && data.text.trim()) {
-  injectUserText(data.text);  // ✅ Single canonical path
+  injectUserText(data.text, "voice");  // ✅ Single canonical path
 } else {
   // Phase-3 calm: silence → do nothing (no chat spam)
   console.log("[STT] Empty transcript - no action");
@@ -252,7 +371,7 @@ function stopSTT() {
 }
 
 /* =========================================================
-   7. WEBSOCKET HANDLING (PHASE-3 SAFE)
+   8. WEBSOCKET HANDLING (PHASE-3 SAFE)
    ========================================================= */
 
 function connectWebSocket() {
@@ -276,33 +395,49 @@ function connectWebSocket() {
         renderWeatherWidget(msg.data);
         break;
       case "news":
-        renderNewsWidget(msg.items);
+        renderNewsWidget(msg.items, msg.summary || "");
+        break;
+      case "search":
+        renderSearchWidget(msg.data);
         break;
       case "chat":
-        appendChatMessage("assistant", msg.message);
+        appendChatMessage("assistant", msg.message, msg.message_id || null);
+        break;
+      case "chat_done":
+        waitingForAssistant = false;
+        setThinkingBar(false);
+        break;
+      case "thought":
+        if (pendingThoughtMessageId && msg.message_id === pendingThoughtMessageId) {
+          const anchor = messageMeta.get(msg.message_id);
+          if (anchor) showThoughtOverlay(anchor, msg.data || {});
+          pendingThoughtMessageId = null;
+        }
         break;
     }
   };
 
   ws.onclose = () => {
+    waitingForAssistant = false;
+    setThinkingBar(false);
     setTimeout(connectWebSocket, 2000);
   };
 }
 
 /* =========================================================
-   8. USER INPUT (CHAT + STT)
+   9. USER INPUT (CHAT + STT)
    ========================================================= */
 
 function sendChat() {
   const input = $("chat-input");
   if (!input) return;
 
-  injectUserText(input.value);
+  injectUserText(input.value, "text");
   input.value = "";
 }
 
 /* =========================================================
-   9. BOOTSTRAP
+   10. BOOTSTRAP
    ========================================================= */
 
 window.addEventListener("DOMContentLoaded", () => {
@@ -315,6 +450,28 @@ window.addEventListener("DOMContentLoaded", () => {
   if (input) {
     input.addEventListener("keydown", (e) => {
       if (e.key === "Enter") sendChat();
+    });
+  }
+
+  const newsBtn = $("btn-news");
+  if (newsBtn) {
+    newsBtn.addEventListener("click", () => {
+      safeWSSend({ text: "news" });
+    });
+  }
+
+  const newsSummaryBtn = $("btn-news-summary");
+  if (newsSummaryBtn) {
+    newsSummaryBtn.addEventListener("click", () => {
+      injectUserText("Summarize the news headlines on the dashboard.", "text");
+    });
+  }
+
+  const newsExpandBtn = $("btn-news-expand");
+  if (newsExpandBtn) {
+    newsExpandBtn.addEventListener("click", () => {
+      newsExpanded = !newsExpanded;
+      renderNewsWidget(latestNewsItems, $("news-summary")?.textContent || "");
     });
   }
 

--- a/Nova-Frontend-Dashboard/dashboard.js
+++ b/Nova-Frontend-Dashboard/dashboard.js
@@ -44,6 +44,16 @@ function clear(el) {
   if (el) el.innerHTML = "";
 }
 
+function extractDomain(url) {
+  return (url || "").replace(/^https?:\/\//, "").split("/")[0].trim().toLowerCase();
+}
+
+function setLoadingHint(text = "") {
+  const bar = $("thinking-bar");
+  if (!bar) return;
+  bar.textContent = text || "Processing";
+}
+
 // Guarded WebSocket send (calm failure)
 function safeWSSend(message) {
   if (!ws || ws.readyState !== WebSocket.OPEN) return false;
@@ -140,8 +150,13 @@ function renderNewsWidget(items, summaryText = "") {
   updateNewsSummary(summaryText);
 
   const visibleItems = newsExpanded ? latestNewsItems : latestNewsItems.slice(0, 3);
-  visibleItems.forEach(item => {
+  visibleItems.forEach((item, index) => {
     const li = document.createElement("li");
+
+    const badge = document.createElement("span");
+    badge.className = "citation-index";
+    badge.textContent = `[${index + 1}]`;
+    li.appendChild(badge);
 
     const a = document.createElement("a");
     a.href = item.url;
@@ -150,10 +165,18 @@ function renderNewsWidget(items, summaryText = "") {
     a.rel = "noopener noreferrer";
     li.appendChild(a);
 
+    const domain = extractDomain(item.url);
+    if (domain) {
+      const domainBadge = document.createElement("span");
+      domainBadge.className = "domain-badge";
+      domainBadge.textContent = domain;
+      li.appendChild(domainBadge);
+    }
+
     if (item.source) {
       const src = document.createElement("span");
       src.className = "news-source";
-      src.textContent = ` (${item.source})`;
+      src.textContent = ` ${item.source}`;
       li.appendChild(src);
     }
 
@@ -179,7 +202,6 @@ function setNewsExpandButton() {
    ========================================================= */
 
 function renderSearchWidget(data) {
-  // Optional dedicated container – if it exists, use it.
   const container = $("search-widget");
   if (container) {
     clear(container);
@@ -187,27 +209,45 @@ function renderSearchWidget(data) {
       container.textContent = "No results found.";
       return;
     }
-    data.results.forEach(item => {
+
+    data.results.forEach((item, index) => {
       const div = document.createElement("div");
       div.className = "search-result";
+
+      const idx = document.createElement("span");
+      idx.className = "citation-index";
+      idx.textContent = `[${index + 1}]`;
+      div.appendChild(idx);
+
       const a = document.createElement("a");
       a.href = item.url;
       a.textContent = item.title;
       a.target = "_blank";
       a.rel = "noopener noreferrer";
       div.appendChild(a);
+
+      const domain = extractDomain(item.url);
+      if (domain) {
+        const domainBadge = document.createElement("span");
+        domainBadge.className = "domain-badge";
+        domainBadge.textContent = domain;
+        div.appendChild(domainBadge);
+      }
+
       container.appendChild(div);
     });
-  } else {
-    // Fallback: show each result as a chat message
-    if (!data || !Array.isArray(data.results) || data.results.length === 0) {
-      appendChatMessage("assistant", "No results found.");
-      return;
-    }
-    data.results.forEach(item => {
-      appendChatMessage("assistant", `${item.title}\n${item.url}`);
-    });
+    return;
   }
+
+  if (!data || !Array.isArray(data.results) || data.results.length === 0) {
+    appendChatMessage("assistant", "No results found.");
+    return;
+  }
+
+  data.results.forEach((item, index) => {
+    const domain = extractDomain(item.url);
+    appendChatMessage("assistant", `[${index + 1}] ${item.title} (${domain || "source"})\n${item.url}`);
+  });
 }
 
 /* =========================================================
@@ -256,6 +296,7 @@ function injectUserText(text, channel = "text") {
   // Single canonical path for ALL user input (typed + STT)
   appendChatMessage("user", clean);
   waitingForAssistant = true;
+  setLoadingHint(clean.toLowerCase().includes("search") ? "Checking latest sources" : "Processing");
   setThinkingBar(true);
   
   // Phase-3 calm: if WS fails, just log, don't spam chat
@@ -405,6 +446,7 @@ function connectWebSocket() {
         break;
       case "chat_done":
         waitingForAssistant = false;
+        setLoadingHint("");
         setThinkingBar(false);
         break;
       case "thought":

--- a/Nova-Frontend-Dashboard/index.html
+++ b/Nova-Frontend-Dashboard/index.html
@@ -16,7 +16,7 @@
  <div class="orb-container">
   <img
     class="orb-image"
-    src="orb.png"
+    src="/static/orb.png"
     alt=""
     aria-hidden="true"
   />
@@ -62,16 +62,27 @@
         <h3>Top News</h3>
 
         <!-- SCROLL CONTAINER (CSS targets this) -->
+        <p id="news-summary" class="news-summary">Press “Summarize headlines” for a dashboard briefing.</p>
+
         <ul id="news-list"></ul>
 
-        <button id="btn-news" type="button">
-          Get headlines
-        </button>
+        <div class="news-actions">
+          <button id="btn-news" type="button">
+            Get headlines
+          </button>
+          <button id="btn-news-summary" type="button">
+            Summarize headlines
+          </button>
+          <button id="btn-news-expand" type="button" aria-pressed="false" style="display:none">
+            Expand details
+          </button>
+        </div>
       </div>
     </aside>
 
     <!-- ---------- CHAT INPUT ---------- -->
     <div class="chat-input">
+      <div id="thinking-bar" class="thinking-bar" style="display:none"></div>
       <input
         id="chat-input"
         type="text"
@@ -99,6 +110,6 @@
   <!-- ===============================
        PHASE-3 DASHBOARD LOGIC
        =============================== -->
-  <script src="dashboard.js"></script>
+  <script src="/static/dashboard.js"></script>
 </body>
 </html>

--- a/Nova-Frontend-Dashboard/index.html
+++ b/Nova-Frontend-Dashboard/index.html
@@ -54,6 +54,7 @@
       <div class="panel conversation">
         <div id="chat-log" class="chat-log"></div>
       </div>
+      <div id="search-widget" class="widget search-widget" aria-live="polite"></div>
     </main>
 
     <!-- ---------- NEWS PANEL ---------- -->

--- a/Nova-Frontend-Dashboard/style.phase1.css
+++ b/Nova-Frontend-Dashboard/style.phase1.css
@@ -363,6 +363,17 @@ html, body {
   opacity: 0.9;
 }
 
+.news-summary {
+  margin: 0 0 12px 0;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: rgba(230, 233, 240, 0.9);
+  font-size: 0.86rem;
+  line-height: 1.4;
+}
+
 /* FIX: Make the list scroll (matches your HTML) */
 #news-list {
   flex: 1;
@@ -454,6 +465,52 @@ html, body {
 #btn-news.updating::after {
   content: "…";
   margin-left: 4px;
+}
+
+.news-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+#btn-news-summary {
+  margin-top: 14px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(123, 109, 255, 0.35);
+  background: rgba(123, 109, 255, 0.12);
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: all 120ms ease;
+}
+
+#btn-news-summary:hover:not(:disabled) {
+  background: rgba(123, 109, 255, 0.18);
+}
+
+#btn-news-summary:active:not(:disabled) {
+  background: rgba(123, 109, 255, 0.24);
+}
+
+#btn-news-expand {
+  margin-top: 14px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: all 120ms ease;
+}
+
+#btn-news-expand:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.14);
+}
+
+#btn-news-expand:active:not(:disabled) {
+  background: rgba(255, 255, 255, 0.2);
 }
 
 /* -----------------------
@@ -568,4 +625,53 @@ html, body {
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
+}
+
+.thinking-bar {
+  width: 100%;
+  height: 2px;
+  margin-bottom: 8px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, transparent, rgba(230, 233, 240, 0.8), transparent);
+  animation: thinking-pulse 1.4s ease-in-out infinite;
+  opacity: 0.7;
+}
+
+@keyframes thinking-pulse {
+  0% { opacity: 0.2; }
+  50% { opacity: 0.9; }
+  100% { opacity: 0.2; }
+}
+
+.thought-indicator {
+  margin-left: 8px;
+  border: none;
+  background: transparent;
+  color: rgba(230, 233, 240, 0.7);
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.thought-overlay {
+  position: fixed;
+  z-index: 20;
+  max-width: 280px;
+  background: rgba(10, 12, 18, 0.96);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 10px;
+  padding: 10px 12px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+  color: #e6e9f0;
+}
+
+.thought-overlay .thought-title {
+  font-size: 0.82rem;
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.thought-overlay ul {
+  margin: 0;
+  padding-left: 18px;
+  font-size: 0.8rem;
 }

--- a/Nova-Frontend-Dashboard/style.phase1.css
+++ b/Nova-Frontend-Dashboard/style.phase1.css
@@ -675,3 +675,44 @@ html, body {
   padding-left: 18px;
   font-size: 0.8rem;
 }
+
+.citation-index {
+  display: inline-block;
+  margin-right: 8px;
+  color: rgba(230, 233, 240, 0.65);
+  font-size: 0.82rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.domain-badge {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(123, 109, 255, 0.32);
+  background: rgba(123, 109, 255, 0.12);
+  font-size: 0.75rem;
+  color: rgba(230, 233, 240, 0.88);
+}
+
+.search-widget {
+  background: rgba(255, 255, 255, 0.035);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  padding: 12px;
+  display: grid;
+  gap: 8px;
+}
+
+.search-result {
+  line-height: 1.35;
+}
+
+.search-result a {
+  color: #7ba1ff;
+  text-decoration: none;
+}
+
+.search-result a:hover {
+  text-decoration: underline;
+}

--- a/nova_backend/src/brain_server.py
+++ b/nova_backend/src/brain_server.py
@@ -110,7 +110,7 @@ async def send_widget_message(
     data: Optional[dict] = None
 ) -> None:
     if msg_type == "news" and isinstance(data, dict) and "items" in data:
-        await ws_send(ws, {"type": "news", "items": data["items"]})
+        await ws_send(ws, {"type": "news", "items": data["items"], "summary": data.get("summary", "")})
         return
     payload = {"type": msg_type, "message": text}
     if msg_type == "weather" and isinstance(data, dict):
@@ -242,6 +242,11 @@ async def websocket_endpoint(ws: WebSocket):
                 last = speech_state.last_spoken_text
                 if last:
                     await send_chat_message(ws, last)
+                await send_chat_done(ws)
+                continue
+
+            if lowered in {"thanks", "thank you", "thank you nova", "thank you, nova"}:
+                await send_chat_message(ws, "You're welcome.")
                 await send_chat_done(ws)
                 continue
 

--- a/nova_backend/src/brain_server.py
+++ b/nova_backend/src/brain_server.py
@@ -28,7 +28,7 @@ from src.conversation.thought_store import ThoughtStore
 from src.conversation.complexity_heuristics import ComplexityHeuristics
 from src.conversation.response_style_router import InputNormalizer
 from src.voice.stt_pipeline import STTAckConfig, build_ack_payload
-from src.voice.tts_engine import resolve_speakable_text, nova_speak
+from src.voice.tts_engine import resolve_speakable_text, nova_speak, stop_speaking
 from src.conversation.clarify_prompts import CLARIFY_PROMPTS
 
 # -------------------------------------------------
@@ -239,6 +239,7 @@ async def websocket_endpoint(ws: WebSocket):
             # --- Phase‑2 immediate commands ---
             if lowered == "stop":
                 speech_state.stop()
+                stop_speaking()
                 await send_chat_message(ws, "Okay.")
                 await send_chat_done(ws)
                 continue

--- a/nova_backend/src/brain_server.py
+++ b/nova_backend/src/brain_server.py
@@ -26,8 +26,10 @@ from src.governor.governor_mediator import GovernorMediator, Invocation, Clarifi
 from src.speech_state import speech_state
 from src.conversation.thought_store import ThoughtStore
 from src.conversation.complexity_heuristics import ComplexityHeuristics
+from src.conversation.response_style_router import InputNormalizer
 from src.voice.stt_pipeline import STTAckConfig, build_ack_payload
 from src.voice.tts_engine import resolve_speakable_text, nova_speak
+from src.conversation.clarify_prompts import CLARIFY_PROMPTS
 
 # -------------------------------------------------
 # App + Logging
@@ -176,11 +178,14 @@ async def websocket_endpoint(ws: WebSocket):
                     await ws_send(ws, {"type": "thought", "data": thought_data, "message_id": message_id})
                 continue
 
-            text = (msg.get("text") or "").strip()
-            if not text:
+            raw_text = (msg.get("text") or "").strip()
+            if not raw_text:
+                await send_chat_message(ws, CLARIFY_PROMPTS["ready_prompt"])
+                await send_chat_done(ws)
                 continue
 
-            lowered = text.lower()
+            text = InputNormalizer.normalize(raw_text).strip()
+            lowered = text.lower().rstrip(".?!")
 
             if channel == "voice" and msg_type == "chat":
                 ack_payload = build_ack_payload(VOICE_ACK_CONFIG)

--- a/nova_backend/src/conversation/clarify_prompts.py
+++ b/nova_backend/src/conversation/clarify_prompts.py
@@ -1,0 +1,14 @@
+"""Deterministic clarification prompt bank for conversational UX polish."""
+
+CLARIFY_PROMPTS = {
+    "brief_or_deep": "Would you like a brief answer or a deeper breakdown?",
+    "high_level_or_detail": "Do you want a high-level comparison or implementation detail?",
+    "concept_or_steps": "Should I stay conceptual, or break this into concrete steps?",
+    "broad_or_narrow": "Do you want broad ideas or a narrower direction?",
+    "system_status_check": "Do you want a system status check?",
+    "confirm_search_query": "Did you mean this as a web search?",
+    "confirm_location_ann_arbor": "Did you mean food in Ann Arbor, Michigan?",
+    "search_target": "What would you like me to search for?",
+    "single_turn_yes_no": "Please answer yes or no.",
+    "ready_prompt": "I'm here when you're ready.",
+}

--- a/nova_backend/src/conversation/response_formatter.py
+++ b/nova_backend/src/conversation/response_formatter.py
@@ -1,5 +1,4 @@
 import re
-from typing import Dict, Optional
 
 
 class ResponseFormatter:
@@ -11,20 +10,20 @@ class ResponseFormatter:
     }
 
     DEPTH_PROMPTS = {
-        "casual": "If useful, I can break that into a few clear steps.",
+        "casual": "If useful, I can break that into clear steps.",
         "analytical": "If useful, I can go deeper on tradeoffs and assumptions.",
         "implementation": "If useful, I can map this into an implementation sequence.",
-        "brainstorming": "If useful, I can branch this into a few neutral options.",
+        "brainstorming": "If useful, I can branch this into neutral options.",
     }
 
     @staticmethod
     def format(text: str, mode: str = "casual") -> str:
         clean = (text or "").strip()
-        clean = re.sub(r"  +", " ", clean)
+        clean = re.sub(r"\s+", " ", clean)
         clean = re.sub(r"!+", ".", clean)
         clean = re.sub(r"([.!?])([A-Z])", r"\1 \2", clean)
 
-        for filler in [r"\bwell\b", r"\bso\b", r"\byou see\b"]:
+        for filler in [r"\bwell\b", r"\bso\b", r"\byou see\b", r"\blet me think\b"]:
             clean = re.sub(filler, "", clean, flags=re.IGNORECASE)
 
         clean = ResponseFormatter._tone_shape(clean, mode)
@@ -44,14 +43,14 @@ class ResponseFormatter:
         if allow_clarification:
             add_ons.append(ResponseFormatter.CLARIFICATION_TEMPLATES.get(mode, ResponseFormatter.CLARIFICATION_TEMPLATES["casual"]))
 
-        if allow_branch_suggestion:
-            add_ons.append("We could approach this in a few ways: direct answer, stepwise plan, or side-by-side comparison.")
-
         if allow_depth_prompt:
             add_ons.append(ResponseFormatter.DEPTH_PROMPTS.get(mode, ResponseFormatter.DEPTH_PROMPTS["casual"]))
 
+        if allow_branch_suggestion and mode in {"brainstorming", "analytical"}:
+            add_ons.append("I can present this as options or a direct recommendation.")
+
         if add_ons:
-            text = f"{text}\n\n" + "\n".join(add_ons[:2])
+            text = f"{text}\n\n" + "\n".join(add_ons[:1])
 
         return text.strip()
 

--- a/nova_backend/src/conversation/response_formatter.py
+++ b/nova_backend/src/conversation/response_formatter.py
@@ -1,12 +1,14 @@
 import re
 
+from src.conversation.clarify_prompts import CLARIFY_PROMPTS
+
 
 class ResponseFormatter:
     CLARIFICATION_TEMPLATES = {
-        "casual": "Would you like a brief answer or a deeper breakdown?",
-        "analytical": "Do you want a high-level comparison or implementation detail?",
-        "implementation": "Should I stay conceptual, or break this into concrete steps?",
-        "brainstorming": "Do you want broad ideas or a narrower direction?",
+        "casual": CLARIFY_PROMPTS["brief_or_deep"],
+        "analytical": CLARIFY_PROMPTS["high_level_or_detail"],
+        "implementation": CLARIFY_PROMPTS["concept_or_steps"],
+        "brainstorming": CLARIFY_PROMPTS["broad_or_narrow"],
     }
 
     DEPTH_PROMPTS = {

--- a/nova_backend/src/conversation/response_style_router.py
+++ b/nova_backend/src/conversation/response_style_router.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from enum import Enum
 
 
@@ -8,6 +9,47 @@ class ResponseStyle(str, Enum):
     BRAINSTORM = "brainstorm"
     DEEP = "deep"
     CASUAL = "casual"
+
+
+class InputNormalizer:
+    """Deterministic input cleanup for spelling, punctuation, and STT fragments."""
+
+    TYPO_REPLACEMENTS = (
+        (r"\bwether\b", "weather"),
+        (r"\bhedlines\b", "headlines"),
+        (r"\bserch\b", "search"),
+        (r"\bseach\b", "search"),
+        (r"\bplz\b", "please"),
+        (r"\bu\b", "you"),
+    )
+
+    @classmethod
+    def normalize(cls, text: str) -> str:
+        clean = (text or "").strip()
+        if not clean:
+            return ""
+
+        clean = re.sub(r"\s+", " ", clean)
+        clean = clean.replace(" ,", ",").replace(" .", ".")
+
+        # deterministic phrase-level normalization for common STT artifact
+        clean = re.sub(
+            r"\bsearch\s+food\s+near\s+me\s+mi\s+ann\s+arbor\b",
+            "search for food near me in Ann Arbor, MI",
+            clean,
+            flags=re.IGNORECASE,
+        )
+
+        for pattern, replacement in cls.TYPO_REPLACEMENTS:
+            clean = re.sub(pattern, replacement, clean, flags=re.IGNORECASE)
+
+        if clean and clean[0].islower():
+            clean = clean[0].upper() + clean[1:]
+
+        if re.search(r"[A-Za-z0-9]$", clean):
+            clean += "."
+
+        return clean
 
 
 class ResponseStyleRouter:
@@ -23,7 +65,7 @@ class ResponseStyleRouter:
 
     @classmethod
     def route(cls, user_message: str) -> ResponseStyle:
-        text = (user_message or "").strip().lower()
+        text = (user_message or "").strip().lower().rstrip(".!?")
         if not text:
             return ResponseStyle.DIRECT
 
@@ -46,13 +88,13 @@ class ResponseTemplates:
     def bounded_research_intro(query: str = "") -> str:
         context = (query or "").strip()
         if context:
-            return f"I checked the latest sources for \"{context}\". Here are the top findings:"
-        return "I checked the latest sources. Here are the top findings:"
+            return f"I checked the latest sources for \"{context}\". Here are the top findings."
+        return "I checked the latest sources. Here are the top findings."
 
     @staticmethod
     def top_findings_block(lines: list[str]) -> str:
         if not lines:
-            return "Top Findings\n- No reliable findings were available."
+            return "Top Findings\n- I couldn't find reliable results for that."
         findings = "\n".join(f"- {line}" for line in lines)
         return f"Top Findings\n{findings}"
 

--- a/nova_backend/src/conversation/response_style_router.py
+++ b/nova_backend/src/conversation/response_style_router.py
@@ -37,3 +37,34 @@ class ResponseStyleRouter:
             return ResponseStyle.DEEP
 
         return ResponseStyle.DIRECT
+
+
+class ResponseTemplates:
+    """Deterministic phrasing templates for calm, premium output style."""
+
+    @staticmethod
+    def bounded_research_intro(query: str = "") -> str:
+        context = (query or "").strip()
+        if context:
+            return f"I checked the latest sources for \"{context}\". Here are the top findings:"
+        return "I checked the latest sources. Here are the top findings:"
+
+    @staticmethod
+    def top_findings_block(lines: list[str]) -> str:
+        if not lines:
+            return "Top Findings\n- No reliable findings were available."
+        findings = "\n".join(f"- {line}" for line in lines)
+        return f"Top Findings\n{findings}"
+
+    @staticmethod
+    def sources_block(domains: list[str]) -> str:
+        if not domains:
+            return "Sources\n1. multiple online sources"
+
+        numbered = "\n".join(f"{idx}. {domain}" for idx, domain in enumerate(domains, start=1))
+        return f"Sources\n{numbered}"
+
+    @staticmethod
+    def concise_acknowledgement(text: str) -> str:
+        clean = (text or "").strip()
+        return clean or "You're welcome."

--- a/nova_backend/src/executors/web_search_executor.py
+++ b/nova_backend/src/executors/web_search_executor.py
@@ -5,6 +5,7 @@ import time
 import os
 
 from src.actions.action_result import ActionResult
+from src.conversation.response_style_router import ResponseTemplates
 
 logger = logging.getLogger(__name__)
 
@@ -140,8 +141,28 @@ class WebSearchExecutor:
                 request_id=request.request_id,
             )
 
-        summary_lines = [f"- {result['title']}" for result in results[:3]]
-        user_message = f"{boundary_notice} I found {len(results)} results.\n" + "\n".join(summary_lines)
+        top_domains = []
+        for result in results[:3]:
+            url = result.get("url", "")
+            domain = url.split("//")[-1].split("/")[0] if url else ""
+            if domain:
+                top_domains.append(domain)
+
+        brief_query = query[:80]
+        intro = ResponseTemplates.bounded_research_intro(brief_query)
+        findings_block = ResponseTemplates.top_findings_block([result["title"] for result in results[:3]])
+        sources_block = ResponseTemplates.sources_block(top_domains)
+
+        report_sections = [
+            f"{boundary_notice} {intro}",
+            "",
+            findings_block,
+            "",
+            sources_block,
+            "",
+            "Open any dashboard result for full article detail.",
+        ]
+        user_message = "\n".join(report_sections)
 
         widget_payload = {
             "type": "search",

--- a/nova_backend/src/executors/web_search_executor.py
+++ b/nova_backend/src/executors/web_search_executor.py
@@ -9,8 +9,12 @@ from src.conversation.response_style_router import ResponseTemplates
 
 logger = logging.getLogger(__name__)
 
+SEARCH_HARD_TIMEOUT_SECONDS = 7.0
+
 
 class WebSearchExecutor:
+    _avg_latency_seconds = 0.0
+    _latency_samples = 0
     """
     Executes a governed web search using the Brave Search API.
     All outbound HTTP is routed through NetworkMediator.
@@ -23,6 +27,20 @@ class WebSearchExecutor:
     def _empty_widget(self) -> dict:
         """Return a stable empty search widget."""
         return {"widget": {"type": "search", "data": {"results": []}}}
+
+    @classmethod
+    def _record_latency(cls, elapsed_seconds: float) -> float:
+        cls._latency_samples += 1
+        if cls._latency_samples == 1:
+            cls._avg_latency_seconds = elapsed_seconds
+        else:
+            cls._avg_latency_seconds = ((cls._avg_latency_seconds * (cls._latency_samples - 1)) + elapsed_seconds) / cls._latency_samples
+        return cls._avg_latency_seconds
+
+    @staticmethod
+    def _extract_domain(url: str) -> str:
+        clean = (url or "").split("//")[-1].split("/")[0].strip().lower()
+        return clean
 
     def execute(self, request) -> ActionResult:
         query = request.params.get("query", "").strip()
@@ -45,9 +63,17 @@ class WebSearchExecutor:
             )
 
         boundary_notice = "I'm checking online."
+        started_at = time.monotonic()
 
         max_retries = 1
         for attempt in range(max_retries + 1):
+            if time.monotonic() - started_at > SEARCH_HARD_TIMEOUT_SECONDS:
+                return ActionResult(
+                    success=False,
+                    message=f"{boundary_notice} Search timed out. Please try again.",
+                    request_id=request.request_id,
+                    data=self._empty_widget(),
+                )
             try:
                 # Perform the search via NetworkMediator using Brave API
                 response = self.network.request(
@@ -143,10 +169,13 @@ class WebSearchExecutor:
 
         top_domains = []
         for result in results[:3]:
-            url = result.get("url", "")
-            domain = url.split("//")[-1].split("/")[0] if url else ""
-            if domain:
+            domain = self._extract_domain(result.get("url", ""))
+            if domain and domain not in top_domains:
                 top_domains.append(domain)
+
+        elapsed_seconds = time.monotonic() - started_at
+        avg_latency = self._record_latency(elapsed_seconds)
+        logger.info("web_search latency=%.2fs avg=%.2fs query=%s", elapsed_seconds, avg_latency, query[:80])
 
         brief_query = query[:80]
         intro = ResponseTemplates.bounded_research_intro(brief_query)
@@ -160,6 +189,7 @@ class WebSearchExecutor:
             "",
             sources_block,
             "",
+            f"Search latency: {elapsed_seconds:.1f}s (avg {avg_latency:.1f}s).",
             "Open any dashboard result for full article detail.",
         ]
         user_message = "\n".join(report_sections)

--- a/nova_backend/src/governor/governor_mediator.py
+++ b/nova_backend/src/governor/governor_mediator.py
@@ -15,33 +15,29 @@ import re
 from dataclasses import dataclass
 from typing import Optional, Dict, Any, Union
 
-from src.conversation.response_style_router import InputNormalizer
-
 # Session‑scoped clarification state (process‑wide, ephemeral).
 # Key: session_id (provided by caller, e.g., websocket handler)
-# Value: pending clarification payload.
-_pending_clarification: Dict[str, Dict[str, Any]] = {}
+# Value: capability_id that is awaiting clarification.
+# Note: This is a simple in‑memory dict; sessions must call clear_session()
+#       on disconnect to avoid memory leaks.
+_pending_clarification: Dict[str, int] = {}
 
+# Pattern for full web search invocation – now accepts "search" with optional "for"
 SEARCH_RE = re.compile(
     r"^\s*(search(?: for)?|look up|research)\s+(?P<q>.+?)\s*$",
-    re.IGNORECASE,
+    re.IGNORECASE
 )
 
+# Pattern for opening a preset website – matches "open <name>"
 OPEN_RE = re.compile(
-    r"^\s*open\s+(?P<name>[\w.-]+)\s*$",
-    re.IGNORECASE,
+    r"^\s*open\s+(?P<name>\w+)\s*$",
+    re.IGNORECASE
 )
-
-OPEN_ONLY_RE = re.compile(r"^\s*open\s*$", re.IGNORECASE)
-
-YES_RE = re.compile(r"^(yes|y|confirm)$", re.IGNORECASE)
-NO_RE = re.compile(r"^(no|n|cancel)$", re.IGNORECASE)
 
 
 @dataclass(frozen=True)
 class Invocation:
     """A fully resolved governed action invocation."""
-
     capability_id: int
     params: Dict[str, Any]
 
@@ -49,7 +45,6 @@ class Invocation:
 @dataclass(frozen=True)
 class Clarification:
     """A request for more information to complete an invocation."""
-
     capability_id: int
     message: str
 
@@ -57,72 +52,72 @@ class Clarification:
 class GovernorMediator:
     @staticmethod
     def mediate(text: str) -> str:
-        """Deterministic, grammar-tolerant sanitization only."""
-        clean = InputNormalizer.normalize(text)
-        if not clean:
-            return "I'm here when you're ready."
-        return clean
+        """Phase‑3 behavior preserved: sanitize only."""
+        if not text or not text.strip():
+            return "I'm not sure right now."
+        return text.strip()
 
     @staticmethod
     def parse_governed_invocation(
         text: str,
         session_id: Optional[str] = None,
     ) -> Union[Invocation, Clarification, None]:
-        t = (text or "").strip().rstrip(".?!")
+        """
+        Returns:
+          - Invocation if a full, valid invocation is detected.
+          - Clarification if an incomplete but clearly intended invocation is detected
+            and a session_id is provided (to enable one‑strike clarification).
+          - None if no invocation is detected.
+        """
+        t = (text or "").strip()
         if not t:
             return None
 
+        # --- Step 1: Check if this session has a pending clarification ---
         if session_id and session_id in _pending_clarification:
-            pending = _pending_clarification.pop(session_id)
-            cap_id = int(pending.get("capability_id", 0))
-
-            if cap_id == 16:
+            cap_id = _pending_clarification.pop(session_id)
+            if cap_id == 16:  # Only web search supports clarification now
+                # Treat the entire input as the query
                 return Invocation(capability_id=16, params={"query": t})
+            else:
+                # Unknown pending capability – clear and treat as none
+                return None
 
-            if cap_id == 17:
-                target = str(pending.get("target", "")).strip()
-                if YES_RE.match(t):
-                    return Invocation(capability_id=17, params={"target": target})
-                if NO_RE.match(t):
-                    return Clarification(capability_id=17, message="Okay, I won't open it.")
-                return Clarification(capability_id=17, message="Please answer yes or no.")
-
-            return None
-
+        # --- Step 2: Try to match a full, valid invocation ---
         m = SEARCH_RE.match(t)
         if m:
             query = m.group("q").strip()
             if query:
                 return Invocation(capability_id=16, params={"query": query})
 
-        if OPEN_ONLY_RE.match(t):
-            if session_id:
-                _pending_clarification[session_id] = {"capability_id": 17}
-                return Clarification(capability_id=17, message="Which site should I open?")
-            return None
-
+        # Check for "open <name>" invocation
         m = OPEN_RE.match(t)
         if m:
             name = m.group("name").strip().lower()
-            if not name:
-                return None
-            if session_id:
-                _pending_clarification[session_id] = {"capability_id": 17, "target": name}
-                display = name if "." in name else f"{name}.com"
-                return Clarification(capability_id=17, message=f"Did you want me to open {display}?")
             return Invocation(capability_id=17, params={"target": name})
 
+        # TTS manual invocation
         if re.match(r"^\s*(speak that|read that|say it)\s*$", t, re.IGNORECASE):
             return Invocation(capability_id=18, params={})
 
+        # --- Step 3: Detect incomplete but clearly intended invocation ---
+        # This now matches "search", "search for", "look up", "research"
         if re.search(r"\b(search(?: for)?|look up|research)\b", t, re.IGNORECASE):
+            # Incomplete invocation – ask exactly one clarifying question
             if session_id:
-                _pending_clarification[session_id] = {"capability_id": 16}
-                return Clarification(capability_id=16, message="What would you like me to search for?")
-            return None
+                _pending_clarification[session_id] = 16
+                return Clarification(
+                    capability_id=16,
+                    message="What would you like to search for?"
+                )
+            else:
+                # No session – cannot track state, so treat as none
+                return None
 
+        # No invocation detected
         return None
 
     @staticmethod
     def clear_session(session_id: str) -> None:
+        """Clear any pending clarification for a session (e.g., on session end)."""
         _pending_clarification.pop(session_id, None)

--- a/nova_backend/src/governor/governor_mediator.py
+++ b/nova_backend/src/governor/governor_mediator.py
@@ -15,29 +15,33 @@ import re
 from dataclasses import dataclass
 from typing import Optional, Dict, Any, Union
 
+from src.conversation.response_style_router import InputNormalizer
+
 # Session‑scoped clarification state (process‑wide, ephemeral).
 # Key: session_id (provided by caller, e.g., websocket handler)
-# Value: capability_id that is awaiting clarification.
-# Note: This is a simple in‑memory dict; sessions must call clear_session()
-#       on disconnect to avoid memory leaks.
-_pending_clarification: Dict[str, int] = {}
+# Value: pending clarification payload.
+_pending_clarification: Dict[str, Dict[str, Any]] = {}
 
-# Pattern for full web search invocation – now accepts "search" with optional "for"
 SEARCH_RE = re.compile(
     r"^\s*(search(?: for)?|look up|research)\s+(?P<q>.+?)\s*$",
-    re.IGNORECASE
+    re.IGNORECASE,
 )
 
-# Pattern for opening a preset website – matches "open <name>"
 OPEN_RE = re.compile(
-    r"^\s*open\s+(?P<name>\w+)\s*$",
-    re.IGNORECASE
+    r"^\s*open\s+(?P<name>[\w.-]+)\s*$",
+    re.IGNORECASE,
 )
+
+OPEN_ONLY_RE = re.compile(r"^\s*open\s*$", re.IGNORECASE)
+
+YES_RE = re.compile(r"^(yes|y|confirm)$", re.IGNORECASE)
+NO_RE = re.compile(r"^(no|n|cancel)$", re.IGNORECASE)
 
 
 @dataclass(frozen=True)
 class Invocation:
     """A fully resolved governed action invocation."""
+
     capability_id: int
     params: Dict[str, Any]
 
@@ -45,6 +49,7 @@ class Invocation:
 @dataclass(frozen=True)
 class Clarification:
     """A request for more information to complete an invocation."""
+
     capability_id: int
     message: str
 
@@ -52,72 +57,72 @@ class Clarification:
 class GovernorMediator:
     @staticmethod
     def mediate(text: str) -> str:
-        """Phase‑3 behavior preserved: sanitize only."""
-        if not text or not text.strip():
-            return "I'm not sure right now."
-        return text.strip()
+        """Deterministic, grammar-tolerant sanitization only."""
+        clean = InputNormalizer.normalize(text)
+        if not clean:
+            return "I'm here when you're ready."
+        return clean
 
     @staticmethod
     def parse_governed_invocation(
         text: str,
         session_id: Optional[str] = None,
     ) -> Union[Invocation, Clarification, None]:
-        """
-        Returns:
-          - Invocation if a full, valid invocation is detected.
-          - Clarification if an incomplete but clearly intended invocation is detected
-            and a session_id is provided (to enable one‑strike clarification).
-          - None if no invocation is detected.
-        """
-        t = (text or "").strip()
+        t = (text or "").strip().rstrip(".?!")
         if not t:
             return None
 
-        # --- Step 1: Check if this session has a pending clarification ---
         if session_id and session_id in _pending_clarification:
-            cap_id = _pending_clarification.pop(session_id)
-            if cap_id == 16:  # Only web search supports clarification now
-                # Treat the entire input as the query
-                return Invocation(capability_id=16, params={"query": t})
-            else:
-                # Unknown pending capability – clear and treat as none
-                return None
+            pending = _pending_clarification.pop(session_id)
+            cap_id = int(pending.get("capability_id", 0))
 
-        # --- Step 2: Try to match a full, valid invocation ---
+            if cap_id == 16:
+                return Invocation(capability_id=16, params={"query": t})
+
+            if cap_id == 17:
+                target = str(pending.get("target", "")).strip()
+                if YES_RE.match(t):
+                    return Invocation(capability_id=17, params={"target": target})
+                if NO_RE.match(t):
+                    return Clarification(capability_id=17, message="Okay, I won't open it.")
+                return Clarification(capability_id=17, message="Please answer yes or no.")
+
+            return None
+
         m = SEARCH_RE.match(t)
         if m:
             query = m.group("q").strip()
             if query:
                 return Invocation(capability_id=16, params={"query": query})
 
-        # Check for "open <name>" invocation
+        if OPEN_ONLY_RE.match(t):
+            if session_id:
+                _pending_clarification[session_id] = {"capability_id": 17}
+                return Clarification(capability_id=17, message="Which site should I open?")
+            return None
+
         m = OPEN_RE.match(t)
         if m:
             name = m.group("name").strip().lower()
+            if not name:
+                return None
+            if session_id:
+                _pending_clarification[session_id] = {"capability_id": 17, "target": name}
+                display = name if "." in name else f"{name}.com"
+                return Clarification(capability_id=17, message=f"Did you want me to open {display}?")
             return Invocation(capability_id=17, params={"target": name})
 
-        # TTS manual invocation
         if re.match(r"^\s*(speak that|read that|say it)\s*$", t, re.IGNORECASE):
             return Invocation(capability_id=18, params={})
 
-        # --- Step 3: Detect incomplete but clearly intended invocation ---
-        # This now matches "search", "search for", "look up", "research"
         if re.search(r"\b(search(?: for)?|look up|research)\b", t, re.IGNORECASE):
-            # Incomplete invocation – ask exactly one clarifying question
             if session_id:
-                _pending_clarification[session_id] = 16
-                return Clarification(
-                    capability_id=16,
-                    message="What would you like to search for?"
-                )
-            else:
-                # No session – cannot track state, so treat as none
-                return None
+                _pending_clarification[session_id] = {"capability_id": 16}
+                return Clarification(capability_id=16, message="What would you like me to search for?")
+            return None
 
-        # No invocation detected
         return None
 
     @staticmethod
     def clear_session(session_id: str) -> None:
-        """Clear any pending clarification for a session (e.g., on session end)."""
         _pending_clarification.pop(session_id, None)

--- a/nova_backend/src/rendering/speech_formatter.py
+++ b/nova_backend/src/rendering/speech_formatter.py
@@ -12,11 +12,19 @@ class SpeechFormatter:
         return [p.strip() for p in parts if p.strip()]
 
     def format_for_tts(self, text: str) -> str:
-        sentences = self.split_sentences(text)
+        clean = (text or "").strip()
+        if not clean:
+            return ""
+
+        # Gentle cadence shaping: pause after labels and list markers.
+        clean = re.sub(r":\s+", ": … ", clean)
+        clean = re.sub(r"\n\s*[-•]\s+", " … ", clean)
+        clean = re.sub(r"\n\s*\d+[.)]\s+", " … ", clean)
+
+        sentences = self.split_sentences(clean)
         if not sentences:
             return ""
 
-        # Insert short pause marker between sentences.
         paced = " … ".join(sentences)
         paced = re.sub(r"\s{2,}", " ", paced).strip()
         return paced

--- a/nova_backend/src/skills/general_chat.py
+++ b/nova_backend/src/skills/general_chat.py
@@ -28,10 +28,10 @@ class GeneralChatSkill(BaseSkill):
         "You are Nova.\n"
         "\n"
         "Core constraints:\n"
-        "- Speak calmly, with restrained professional courtesy.\n"
-        "- Use complete, well‑structured sentences.\n"
-        "- Avoid slang, casual fillers, and enthusiasm markers.\n"
-        "- Maintain composed and precise phrasing.\n"
+        "- Speak calmly, with composed, butler-like courtesy.\n"
+        "- Use complete, polished sentences with natural flow.\n"
+        "- Keep language human, concise, and quietly confident.\n"
+        "- Avoid slang, hype, or theatrical enthusiasm.\n"
         "- No emotional simulation. No therapy tone. No flattery.\n"
         "- No marketing language. No brand voice.\n"
         "- Do not introduce yourself unless explicitly asked.\n"
@@ -130,7 +130,7 @@ class GeneralChatSkill(BaseSkill):
             ResponseStyle.DIRECT: "Style: Direct and concise. Prioritize factual precision.",
             ResponseStyle.BRAINSTORM: "Style: Brainstorm mode. Provide structured ideas as bullet points.",
             ResponseStyle.DEEP: "Style: Deep mode. Provide layered reasoning with concise section headers.",
-            ResponseStyle.CASUAL: "Style: Casual mode. Keep response short and naturally conversational.",
+            ResponseStyle.CASUAL: "Style: Conversational mode. Keep response brief, warm, and polished.",
         }
 
         style_block = style_blocks.get(style, style_blocks[ResponseStyle.DIRECT])

--- a/nova_backend/src/skills/general_chat.py
+++ b/nova_backend/src/skills/general_chat.py
@@ -12,7 +12,7 @@ from src.conversation.complexity_heuristics import ComplexityHeuristics
 from src.conversation.deepseek_bridge import DeepSeekBridge
 from src.conversation.escalation_policy import EscalationPolicy
 from src.conversation.response_formatter import ResponseFormatter
-from src.conversation.response_style_router import ResponseStyle, ResponseStyleRouter
+from src.conversation.response_style_router import InputNormalizer, ResponseStyle, ResponseStyleRouter
 from src.conversation.safety_filter import SafetyFilter
 from src.conversation.deepseek_safety_wrapper import DeepSeekSafetyWrapper
 from src.governor.network_mediator import NetworkMediator
@@ -95,7 +95,7 @@ class GeneralChatSkill(BaseSkill):
         self.formatter = ResponseFormatter()
 
     def can_handle(self, query: str) -> bool:
-        q = (query or "").strip().lower()
+        q = InputNormalizer.normalize(query).lower().strip(".?!")
         if not q:
             return False
 
@@ -108,7 +108,7 @@ class GeneralChatSkill(BaseSkill):
         return True
 
     def _detect_mode(self, query: str) -> str:
-        q = (query or "").strip().lower()
+        q = InputNormalizer.normalize(query).lower().strip(".?!")
         if not q:
             return "casual"
 
@@ -155,8 +155,9 @@ class GeneralChatSkill(BaseSkill):
         except Exception:
             return None
 
-        mode = self._detect_mode(query)
-        style = self.style_router.route(query)
+        normalized_query = InputNormalizer.normalize(query)
+        mode = self._detect_mode(normalized_query)
+        style = self.style_router.route(normalized_query)
         system_prompt = self._build_system_prompt(mode, style)
         max_tokens = self.MAX_TOKENS.get(mode, self.MAX_TOKENS["casual"])
 
@@ -166,7 +167,7 @@ class GeneralChatSkill(BaseSkill):
                 model="phi3:mini",
                 messages=[
                     {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": query},
+                    {"role": "user", "content": normalized_query},
                 ],
                 options={"temperature": 0.3, "num_predict": max_tokens},
             )
@@ -183,10 +184,11 @@ class GeneralChatSkill(BaseSkill):
         if context is None or session_state is None:
             return await self._run_local_model(query)
 
-        heuristic_result = self.heuristics.assess(query, context)
-        decision = self.policy.decide(heuristic_result, query, session_state)
-        mode = heuristic_result.get("mode") or self._detect_mode(query)
-        initiative = self.policy.conversational_flags(heuristic_result, query, session_state)
+        normalized_query = InputNormalizer.normalize(query)
+        heuristic_result = self.heuristics.assess(normalized_query, context)
+        decision = self.policy.decide(heuristic_result, normalized_query, session_state)
+        mode = heuristic_result.get("mode") or self._detect_mode(normalized_query)
+        initiative = self.policy.conversational_flags(heuristic_result, normalized_query, session_state)
 
         if decision == "ASK_USER":
             return SkillResult(
@@ -195,7 +197,7 @@ class GeneralChatSkill(BaseSkill):
                 data={
                     "escalation": {
                         "ask_user": True,
-                        "original_query": query,
+                        "original_query": normalized_query,
                         "context_snapshot": context[-5:],
                         "heuristic_result": heuristic_result,
                     }
@@ -213,16 +215,13 @@ class GeneralChatSkill(BaseSkill):
             }
             raw = await asyncio.to_thread(
                 self.deepseek.analyze,
-                query,
+                normalized_query,
                 context,
                 heuristic_result.get("suggested_max_tokens", 800),
             )
             safe = self.safety.filter(raw)
             safe = self.analysis_safety.sanitize(safe)
             formatted = self.formatter.format(safe)
-            if session_state.get("show_thinking_hints", True):
-                formatted = f"Let me think…\n\n{formatted}"
-
             return SkillResult(
                 success=True,
                 message=formatted,
@@ -231,7 +230,7 @@ class GeneralChatSkill(BaseSkill):
                 skill=self.name,
             )
 
-        local = await self._run_local_model(query)
+        local = await self._run_local_model(normalized_query)
         if local is None:
             return None
 

--- a/nova_backend/src/skills/news.py
+++ b/nova_backend/src/skills/news.py
@@ -46,7 +46,8 @@ class NewsSkill(BaseSkill):
 
         widget = {
             "type": "news",
-            "items": items
+            "items": items,
+            "summary": self._summarize_headlines(items),
         }
 
         return SkillResult(
@@ -55,6 +56,25 @@ class NewsSkill(BaseSkill):
             data={},
             widget_data=widget,
             skill=self.name,
+        )
+
+    def _summarize_headlines(self, items: List[Dict[str, str]]) -> str:
+        """Create a deterministic 1-2 sentence summary from fetched headlines."""
+        if not items:
+            return "No headlines are available to summarize right now."
+
+        top_titles = [item.get("title", "").strip() for item in items[:3] if item.get("title")]
+        if not top_titles:
+            return "I pulled headlines, but there was not enough detail to summarize them."
+
+        if len(top_titles) == 1:
+            return f"Top story right now: {top_titles[0]}."
+
+        if len(top_titles) == 2:
+            return f"Current news focus: {top_titles[0]}; alongside {top_titles[1]}."
+
+        return (
+            f"Current news focus: {top_titles[0]}; {top_titles[1]}; and {top_titles[2]}."
         )
 
     async def _fetch_one(self, source: dict) -> Optional[dict]:

--- a/nova_backend/src/voice/tts_engine.py
+++ b/nova_backend/src/voice/tts_engine.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import sys
+import tempfile
+import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional
@@ -44,7 +47,8 @@ class SpeechRenderer:
             self._warn_once_missing_piper()
             return
 
-        output_path = Path("/tmp") / "nova_tts.wav"
+        temp_dir = Path(os.getenv("TEMP") or tempfile.gettempdir() or "/tmp")
+        output_path = temp_dir / "nova_tts.wav"
         cmd = [
             piper_bin,
             "--model",
@@ -73,6 +77,10 @@ class SpeechRenderer:
 
     @staticmethod
     def _play_wave(output_path: Path) -> None:
+        if sys.platform == "win32":
+            SpeechRenderer._play_wave_windows(output_path)
+            return
+
         for player in ("aplay", "paplay", "ffplay"):
             bin_path = shutil.which(player)
             if not bin_path:
@@ -98,6 +106,40 @@ class SpeechRenderer:
             except Exception:
                 continue
 
+    @staticmethod
+    def _play_wave_windows(output_path: Path) -> None:
+        # Primary: Windows native SoundPlayer via PowerShell
+        powershell = shutil.which("powershell") or shutil.which("pwsh")
+        if powershell:
+            script = (
+                f"(New-Object Media.SoundPlayer '{str(output_path)}').PlaySync();"
+            )
+            try:
+                subprocess.run(
+                    [powershell, "-NoProfile", "-Command", script],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    check=True,
+                    timeout=10,
+                )
+                return
+            except Exception:
+                pass
+
+        # Secondary fallback if ffplay exists in PATH.
+        ffplay = shutil.which("ffplay")
+        if ffplay:
+            try:
+                subprocess.run(
+                    [ffplay, "-nodisp", "-autoexit", "-loglevel", "quiet", str(output_path)],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    check=True,
+                    timeout=10,
+                )
+            except Exception:
+                return
+
     @classmethod
     def _warn_once_missing_piper(cls) -> None:
         if cls._warned_missing_piper:
@@ -106,8 +148,8 @@ class SpeechRenderer:
 
 
 def nova_speak(text: str) -> None:
-    """Default runtime speech path with profile-based rendering."""
-    SpeechRenderer().render(text)
+    """Default runtime speech path with profile-based rendering (non-blocking)."""
+    threading.Thread(target=SpeechRenderer().render, args=(text,), daemon=True).start()
 
 
 def resolve_speakable_text(action_result: Any) -> str:

--- a/nova_backend/src/voice/tts_engine.py
+++ b/nova_backend/src/voice/tts_engine.py
@@ -9,6 +9,7 @@ import threading
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Optional
+from uuid import uuid4
 
 from src.rendering.speech_formatter import SpeechFormatter
 
@@ -26,43 +27,50 @@ class SpeechRenderer:
     """TTS renderer abstraction using Piper for offline neural speech."""
 
     _warned_missing_piper = False
+    _playback_lock = threading.Lock()
+    _active_player: Optional[subprocess.Popen] = None
 
     def __init__(self, profile: VoiceProfile | None = None):
         self.profile = profile or VoiceProfile()
         self.formatter = SpeechFormatter()
 
     def render(self, text: str) -> None:
-        speak_text = self.formatter.format_for_tts(text)
-        if not speak_text:
+        # Prevent overlapping speech playback.
+        if not self._playback_lock.acquire(blocking=False):
             return
 
-        piper_bin = shutil.which("piper")
-        model_path = os.getenv("NOVA_PIPER_MODEL_PATH", "").strip()
-        if not piper_bin or not model_path:
-            self._warn_once_missing_piper()
-            return
-
-        model_file = Path(model_path)
-        if not model_file.exists():
-            self._warn_once_missing_piper()
-            return
-
-        temp_dir = Path(os.getenv("TEMP") or tempfile.gettempdir() or "/tmp")
-        output_path = temp_dir / "nova_tts.wav"
-        cmd = [
-            piper_bin,
-            "--model",
-            str(model_file),
-            "--output_file",
-            str(output_path),
-            "--sentence_silence",
-            "0.2",
-        ]
-
-        if self.profile.voice_hint:
-            cmd.extend(["--speaker", self.profile.voice_hint])
-
+        output_path: Optional[Path] = None
         try:
+            speak_text = self.formatter.format_for_tts(text)
+            if not speak_text:
+                return
+
+            piper_bin = shutil.which("piper")
+            model_path = os.getenv("NOVA_PIPER_MODEL_PATH", "").strip()
+            if not piper_bin or not model_path:
+                self._warn_once_missing_piper()
+                return
+
+            model_file = Path(model_path)
+            if not model_file.exists():
+                self._warn_once_missing_piper()
+                return
+
+            temp_dir = Path(os.getenv("TEMP") or tempfile.gettempdir() or "/tmp")
+            output_path = temp_dir / f"nova_tts_{uuid4().hex}.wav"
+            cmd = [
+                piper_bin,
+                "--model",
+                str(model_file),
+                "--output_file",
+                str(output_path),
+                "--sentence_silence",
+                "0.2",
+            ]
+
+            if self.profile.voice_hint:
+                cmd.extend(["--speaker", self.profile.voice_hint])
+
             subprocess.run(
                 cmd,
                 input=speak_text.encode("utf-8"),
@@ -74,11 +82,30 @@ class SpeechRenderer:
             self._play_wave(output_path)
         except Exception:
             return
+        finally:
+            if output_path:
+                try:
+                    output_path.unlink(missing_ok=True)
+                except Exception:
+                    pass
+            self._active_player = None
+            self._playback_lock.release()
 
-    @staticmethod
-    def _play_wave(output_path: Path) -> None:
+    @classmethod
+    def stop(cls) -> None:
+        player = cls._active_player
+        if player is None:
+            return
+        try:
+            if player.poll() is None:
+                player.terminate()
+        except Exception:
+            return
+
+    @classmethod
+    def _play_wave(cls, output_path: Path) -> None:
         if sys.platform == "win32":
-            SpeechRenderer._play_wave_windows(output_path)
+            cls._play_wave_windows(output_path)
             return
 
         for player in ("aplay", "paplay", "ffplay"):
@@ -87,56 +114,51 @@ class SpeechRenderer:
                 continue
             try:
                 if player == "ffplay":
-                    subprocess.run(
+                    proc = subprocess.Popen(
                         [bin_path, "-nodisp", "-autoexit", "-loglevel", "quiet", str(output_path)],
                         stdout=subprocess.DEVNULL,
                         stderr=subprocess.DEVNULL,
-                        check=True,
-                        timeout=10,
                     )
                 else:
-                    subprocess.run(
+                    proc = subprocess.Popen(
                         [bin_path, str(output_path)],
                         stdout=subprocess.DEVNULL,
                         stderr=subprocess.DEVNULL,
-                        check=True,
-                        timeout=10,
                     )
+                cls._active_player = proc
+                proc.wait(timeout=10)
                 return
             except Exception:
                 continue
 
-    @staticmethod
-    def _play_wave_windows(output_path: Path) -> None:
+    @classmethod
+    def _play_wave_windows(cls, output_path: Path) -> None:
         # Primary: Windows native SoundPlayer via PowerShell
         powershell = shutil.which("powershell") or shutil.which("pwsh")
         if powershell:
-            script = (
-                f"(New-Object Media.SoundPlayer '{str(output_path)}').PlaySync();"
-            )
+            script = f"(New-Object Media.SoundPlayer '{str(output_path)}').PlaySync();"
             try:
-                subprocess.run(
+                proc = subprocess.Popen(
                     [powershell, "-NoProfile", "-Command", script],
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
-                    check=True,
-                    timeout=10,
                 )
+                cls._active_player = proc
+                proc.wait(timeout=10)
                 return
             except Exception:
                 pass
 
-        # Secondary fallback if ffplay exists in PATH.
         ffplay = shutil.which("ffplay")
         if ffplay:
             try:
-                subprocess.run(
+                proc = subprocess.Popen(
                     [ffplay, "-nodisp", "-autoexit", "-loglevel", "quiet", str(output_path)],
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
-                    check=True,
-                    timeout=10,
                 )
+                cls._active_player = proc
+                proc.wait(timeout=10)
             except Exception:
                 return
 
@@ -145,6 +167,11 @@ class SpeechRenderer:
         if cls._warned_missing_piper:
             return
         cls._warned_missing_piper = True
+
+
+def stop_speaking() -> None:
+    """Best-effort stop of currently playing speech."""
+    SpeechRenderer.stop()
 
 
 def nova_speak(text: str) -> None:

--- a/nova_backend/src/voice/tts_engine.py
+++ b/nova_backend/src/voice/tts_engine.py
@@ -1,19 +1,63 @@
 from __future__ import annotations
 
-from typing import Any, Dict
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from src.rendering.speech_formatter import SpeechFormatter
+
+
+@dataclass(frozen=True)
+class VoiceProfile:
+    """Runtime-configurable voice profile for calm, butler-like delivery."""
+
+    rate_wpm: int = 165
+    volume: float = 0.92
+    voice_hint: Optional[str] = None
+
+
+class SpeechRenderer:
+    """TTS renderer abstraction so engine backends can be swapped later."""
+
+    def __init__(self, profile: VoiceProfile | None = None):
+        self.profile = profile or VoiceProfile()
+        self.formatter = SpeechFormatter()
+
+    def render(self, text: str) -> None:
+        speak_text = self.formatter.format_for_tts(text)
+        if not speak_text:
+            return
+
+        try:
+            import pyttsx3
+
+            engine = pyttsx3.init()
+            self._apply_profile(engine)
+            engine.say(speak_text)
+            engine.runAndWait()
+        except Exception:
+            # Keep failure silent to preserve conversational flow.
+            return
+
+    def _apply_profile(self, engine: Any) -> None:
+        try:
+            engine.setProperty("rate", self.profile.rate_wpm)
+            engine.setProperty("volume", max(0.0, min(1.0, self.profile.volume)))
+
+            if self.profile.voice_hint:
+                hint = self.profile.voice_hint.lower()
+                for voice in engine.getProperty("voices") or []:
+                    name = getattr(voice, "name", "").lower()
+                    if hint in name:
+                        engine.setProperty("voice", getattr(voice, "id", None))
+                        break
+        except Exception:
+            return
+
 
 def nova_speak(text: str) -> None:
-    """
-    Temporary direct TTS execution.
-    Replace with governed Capability 18 routing if needed.
-    """
-    try:
-        import pyttsx3
-        engine = pyttsx3.init()
-        engine.say(text)
-        engine.runAndWait()
-    except Exception:
-        pass
+    """Default runtime speech path with profile-based rendering."""
+    SpeechRenderer().render(text)
+
 
 def resolve_speakable_text(action_result: Any) -> str:
     """Resolve text suitable for speech output from an action result object."""

--- a/nova_backend/src/voice/tts_engine.py
+++ b/nova_backend/src/voice/tts_engine.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import os
+import shutil
+import subprocess
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 from src.rendering.speech_formatter import SpeechFormatter
@@ -16,7 +20,9 @@ class VoiceProfile:
 
 
 class SpeechRenderer:
-    """TTS renderer abstraction so engine backends can be swapped later."""
+    """TTS renderer abstraction using Piper for offline neural speech."""
+
+    _warned_missing_piper = False
 
     def __init__(self, profile: VoiceProfile | None = None):
         self.profile = profile or VoiceProfile()
@@ -27,31 +33,76 @@ class SpeechRenderer:
         if not speak_text:
             return
 
-        try:
-            import pyttsx3
-
-            engine = pyttsx3.init()
-            self._apply_profile(engine)
-            engine.say(speak_text)
-            engine.runAndWait()
-        except Exception:
-            # Keep failure silent to preserve conversational flow.
+        piper_bin = shutil.which("piper")
+        model_path = os.getenv("NOVA_PIPER_MODEL_PATH", "").strip()
+        if not piper_bin or not model_path:
+            self._warn_once_missing_piper()
             return
 
-    def _apply_profile(self, engine: Any) -> None:
-        try:
-            engine.setProperty("rate", self.profile.rate_wpm)
-            engine.setProperty("volume", max(0.0, min(1.0, self.profile.volume)))
+        model_file = Path(model_path)
+        if not model_file.exists():
+            self._warn_once_missing_piper()
+            return
 
-            if self.profile.voice_hint:
-                hint = self.profile.voice_hint.lower()
-                for voice in engine.getProperty("voices") or []:
-                    name = getattr(voice, "name", "").lower()
-                    if hint in name:
-                        engine.setProperty("voice", getattr(voice, "id", None))
-                        break
+        output_path = Path("/tmp") / "nova_tts.wav"
+        cmd = [
+            piper_bin,
+            "--model",
+            str(model_file),
+            "--output_file",
+            str(output_path),
+            "--sentence_silence",
+            "0.2",
+        ]
+
+        if self.profile.voice_hint:
+            cmd.extend(["--speaker", self.profile.voice_hint])
+
+        try:
+            subprocess.run(
+                cmd,
+                input=speak_text.encode("utf-8"),
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=True,
+                timeout=10,
+            )
+            self._play_wave(output_path)
         except Exception:
             return
+
+    @staticmethod
+    def _play_wave(output_path: Path) -> None:
+        for player in ("aplay", "paplay", "ffplay"):
+            bin_path = shutil.which(player)
+            if not bin_path:
+                continue
+            try:
+                if player == "ffplay":
+                    subprocess.run(
+                        [bin_path, "-nodisp", "-autoexit", "-loglevel", "quiet", str(output_path)],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                        check=True,
+                        timeout=10,
+                    )
+                else:
+                    subprocess.run(
+                        [bin_path, str(output_path)],
+                        stdout=subprocess.DEVNULL,
+                        stderr=subprocess.DEVNULL,
+                        check=True,
+                        timeout=10,
+                    )
+                return
+            except Exception:
+                continue
+
+    @classmethod
+    def _warn_once_missing_piper(cls) -> None:
+        if cls._warned_missing_piper:
+            return
+        cls._warned_missing_piper = True
 
 
 def nova_speak(text: str) -> None:

--- a/nova_backend/static/dashboard.js
+++ b/nova_backend/static/dashboard.js
@@ -44,6 +44,16 @@ function clear(el) {
   if (el) el.innerHTML = "";
 }
 
+function extractDomain(url) {
+  return (url || "").replace(/^https?:\/\//, "").split("/")[0].trim().toLowerCase();
+}
+
+function setLoadingHint(text = "") {
+  const bar = $("thinking-bar");
+  if (!bar) return;
+  bar.textContent = text || "Processing";
+}
+
 // Guarded WebSocket send (calm failure)
 function safeWSSend(message) {
   if (!ws || ws.readyState !== WebSocket.OPEN) return false;
@@ -140,8 +150,13 @@ function renderNewsWidget(items, summaryText = "") {
   updateNewsSummary(summaryText);
 
   const visibleItems = newsExpanded ? latestNewsItems : latestNewsItems.slice(0, 3);
-  visibleItems.forEach(item => {
+  visibleItems.forEach((item, index) => {
     const li = document.createElement("li");
+
+    const badge = document.createElement("span");
+    badge.className = "citation-index";
+    badge.textContent = `[${index + 1}]`;
+    li.appendChild(badge);
 
     const a = document.createElement("a");
     a.href = item.url;
@@ -150,10 +165,18 @@ function renderNewsWidget(items, summaryText = "") {
     a.rel = "noopener noreferrer";
     li.appendChild(a);
 
+    const domain = extractDomain(item.url);
+    if (domain) {
+      const domainBadge = document.createElement("span");
+      domainBadge.className = "domain-badge";
+      domainBadge.textContent = domain;
+      li.appendChild(domainBadge);
+    }
+
     if (item.source) {
       const src = document.createElement("span");
       src.className = "news-source";
-      src.textContent = ` (${item.source})`;
+      src.textContent = ` ${item.source}`;
       li.appendChild(src);
     }
 
@@ -179,7 +202,6 @@ function setNewsExpandButton() {
    ========================================================= */
 
 function renderSearchWidget(data) {
-  // Optional dedicated container – if it exists, use it.
   const container = $("search-widget");
   if (container) {
     clear(container);
@@ -187,27 +209,45 @@ function renderSearchWidget(data) {
       container.textContent = "No results found.";
       return;
     }
-    data.results.forEach(item => {
+
+    data.results.forEach((item, index) => {
       const div = document.createElement("div");
       div.className = "search-result";
+
+      const idx = document.createElement("span");
+      idx.className = "citation-index";
+      idx.textContent = `[${index + 1}]`;
+      div.appendChild(idx);
+
       const a = document.createElement("a");
       a.href = item.url;
       a.textContent = item.title;
       a.target = "_blank";
       a.rel = "noopener noreferrer";
       div.appendChild(a);
+
+      const domain = extractDomain(item.url);
+      if (domain) {
+        const domainBadge = document.createElement("span");
+        domainBadge.className = "domain-badge";
+        domainBadge.textContent = domain;
+        div.appendChild(domainBadge);
+      }
+
       container.appendChild(div);
     });
-  } else {
-    // Fallback: show each result as a chat message
-    if (!data || !Array.isArray(data.results) || data.results.length === 0) {
-      appendChatMessage("assistant", "No results found.");
-      return;
-    }
-    data.results.forEach(item => {
-      appendChatMessage("assistant", `${item.title}\n${item.url}`);
-    });
+    return;
   }
+
+  if (!data || !Array.isArray(data.results) || data.results.length === 0) {
+    appendChatMessage("assistant", "No results found.");
+    return;
+  }
+
+  data.results.forEach((item, index) => {
+    const domain = extractDomain(item.url);
+    appendChatMessage("assistant", `[${index + 1}] ${item.title} (${domain || "source"})\n${item.url}`);
+  });
 }
 
 /* =========================================================
@@ -256,6 +296,7 @@ function injectUserText(text, channel = "text") {
   // Single canonical path for ALL user input (typed + STT)
   appendChatMessage("user", clean);
   waitingForAssistant = true;
+  setLoadingHint(clean.toLowerCase().includes("search") ? "Checking latest sources" : "Processing");
   setThinkingBar(true);
   
   // Phase-3 calm: if WS fails, just log, don't spam chat
@@ -405,6 +446,7 @@ function connectWebSocket() {
         break;
       case "chat_done":
         waitingForAssistant = false;
+        setLoadingHint("");
         setThinkingBar(false);
         break;
       case "thought":

--- a/nova_backend/static/dashboard.js
+++ b/nova_backend/static/dashboard.js
@@ -10,6 +10,8 @@ let ws = null;
 let pendingThoughtMessageId = null;
 let messageMeta = new Map();
 let waitingForAssistant = false;
+let latestNewsItems = [];
+let newsExpanded = false;
 
 // PHASE-3 STT STATE (UI-ONLY, DESCRIPTIVE)
 let sttState = "READY"; // READY | LISTENING | PAUSED | PROCESSING
@@ -112,20 +114,33 @@ function renderWeatherWidget(data) {
    Expects: { type:"news", items:[...] }
    ========================================================= */
 
-function renderNewsWidget(items) {
+function updateNewsSummary(summaryText) {
+  const summary = $("news-summary");
+  if (!summary) return;
+  summary.textContent = (summaryText || "").trim() || "Headlines loaded. Press 'Summarize headlines' for a briefing.";
+}
+
+function renderNewsWidget(items, summaryText = "") {
   const list = $("news-list");
   if (!list) return;
 
   clear(list);
 
   if (!Array.isArray(items) || items.length === 0) {
+    latestNewsItems = [];
     const li = document.createElement("li");
     li.textContent = "No headlines available.";
     list.appendChild(li);
+    updateNewsSummary("No headlines are available to summarize right now.");
+    setNewsExpandButton();
     return;
   }
 
-  items.forEach(item => {
+  latestNewsItems = items.slice();
+  updateNewsSummary(summaryText);
+
+  const visibleItems = newsExpanded ? latestNewsItems : latestNewsItems.slice(0, 3);
+  visibleItems.forEach(item => {
     const li = document.createElement("li");
 
     const a = document.createElement("a");
@@ -144,6 +159,18 @@ function renderNewsWidget(items) {
 
     list.appendChild(li);
   });
+
+  setNewsExpandButton();
+}
+
+function setNewsExpandButton() {
+  const btn = $("btn-news-expand");
+  if (!btn) return;
+
+  const hasExtra = latestNewsItems.length > 3;
+  btn.style.display = hasExtra ? "inline-block" : "none";
+  btn.textContent = newsExpanded ? "Show brief" : "Expand details";
+  btn.setAttribute("aria-pressed", newsExpanded ? "true" : "false");
 }
 
 /* =========================================================
@@ -368,7 +395,7 @@ function connectWebSocket() {
         renderWeatherWidget(msg.data);
         break;
       case "news":
-        renderNewsWidget(msg.items);
+        renderNewsWidget(msg.items, msg.summary || "");
         break;
       case "search":
         renderSearchWidget(msg.data);
@@ -423,6 +450,28 @@ window.addEventListener("DOMContentLoaded", () => {
   if (input) {
     input.addEventListener("keydown", (e) => {
       if (e.key === "Enter") sendChat();
+    });
+  }
+
+  const newsBtn = $("btn-news");
+  if (newsBtn) {
+    newsBtn.addEventListener("click", () => {
+      safeWSSend({ text: "news" });
+    });
+  }
+
+  const newsSummaryBtn = $("btn-news-summary");
+  if (newsSummaryBtn) {
+    newsSummaryBtn.addEventListener("click", () => {
+      injectUserText("Summarize the news headlines on the dashboard.", "text");
+    });
+  }
+
+  const newsExpandBtn = $("btn-news-expand");
+  if (newsExpandBtn) {
+    newsExpandBtn.addEventListener("click", () => {
+      newsExpanded = !newsExpanded;
+      renderNewsWidget(latestNewsItems, $("news-summary")?.textContent || "");
     });
   }
 

--- a/nova_backend/static/index.html
+++ b/nova_backend/static/index.html
@@ -54,6 +54,7 @@
       <div class="panel conversation">
         <div id="chat-log" class="chat-log"></div>
       </div>
+      <div id="search-widget" class="widget search-widget" aria-live="polite"></div>
     </main>
 
     <!-- ---------- NEWS PANEL ---------- -->

--- a/nova_backend/static/index.html
+++ b/nova_backend/static/index.html
@@ -62,11 +62,21 @@
         <h3>Top News</h3>
 
         <!-- SCROLL CONTAINER (CSS targets this) -->
+        <p id="news-summary" class="news-summary">Press “Summarize headlines” for a dashboard briefing.</p>
+
         <ul id="news-list"></ul>
 
-        <button id="btn-news" type="button">
-          Get headlines
-        </button>
+        <div class="news-actions">
+          <button id="btn-news" type="button">
+            Get headlines
+          </button>
+          <button id="btn-news-summary" type="button">
+            Summarize headlines
+          </button>
+          <button id="btn-news-expand" type="button" aria-pressed="false" style="display:none">
+            Expand details
+          </button>
+        </div>
       </div>
     </aside>
 

--- a/nova_backend/static/style.phase1.css
+++ b/nova_backend/static/style.phase1.css
@@ -363,6 +363,17 @@ html, body {
   opacity: 0.9;
 }
 
+.news-summary {
+  margin: 0 0 12px 0;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: rgba(230, 233, 240, 0.9);
+  font-size: 0.86rem;
+  line-height: 1.4;
+}
+
 /* FIX: Make the list scroll (matches your HTML) */
 #news-list {
   flex: 1;
@@ -454,6 +465,52 @@ html, body {
 #btn-news.updating::after {
   content: "…";
   margin-left: 4px;
+}
+
+.news-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+#btn-news-summary {
+  margin-top: 14px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(123, 109, 255, 0.35);
+  background: rgba(123, 109, 255, 0.12);
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: all 120ms ease;
+}
+
+#btn-news-summary:hover:not(:disabled) {
+  background: rgba(123, 109, 255, 0.18);
+}
+
+#btn-news-summary:active:not(:disabled) {
+  background: rgba(123, 109, 255, 0.24);
+}
+
+#btn-news-expand {
+  margin-top: 14px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: all 120ms ease;
+}
+
+#btn-news-expand:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.14);
+}
+
+#btn-news-expand:active:not(:disabled) {
+  background: rgba(255, 255, 255, 0.2);
 }
 
 /* -----------------------

--- a/nova_backend/static/style.phase1.css
+++ b/nova_backend/static/style.phase1.css
@@ -675,3 +675,44 @@ html, body {
   padding-left: 18px;
   font-size: 0.8rem;
 }
+
+.citation-index {
+  display: inline-block;
+  margin-right: 8px;
+  color: rgba(230, 233, 240, 0.65);
+  font-size: 0.82rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.domain-badge {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid rgba(123, 109, 255, 0.32);
+  background: rgba(123, 109, 255, 0.12);
+  font-size: 0.75rem;
+  color: rgba(230, 233, 240, 0.88);
+}
+
+.search-widget {
+  background: rgba(255, 255, 255, 0.035);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 12px;
+  padding: 12px;
+  display: grid;
+  gap: 8px;
+}
+
+.search-result {
+  line-height: 1.35;
+}
+
+.search-result a {
+  color: #7ba1ff;
+  text-decoration: none;
+}
+
+.search-result a:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
### Motivation
- Improve the dashboard user experience by adding readable news summaries, expand/collapse behavior, and an explicit "Summarize headlines" action. 
- Surface assistant reasoning to observers via a clickable thought indicator and small overlay. 
- Provide a search widget and richer, deterministic search/speech output formats from the backend for more useful, calm responses. 
- Refactor the TTS path to use a profile-driven renderer and add deterministic phrasing templates for governed search results.

### Description
- Frontend: added a thinking indicator (`#thinking-bar`), news summary block (`#news-summary`), buttons for `#btn-news-summary` and `#btn-news-expand`, and support for expand/collapse of news (JS: `renderNewsWidget`, `updateNewsSummary`, `setNewsExpandButton`).
- Frontend: added thought/reasoning UI (`.thought-indicator` button, `showThoughtOverlay`, `bindThoughtIndicator`) and message meta-tracking so assistant messages can request and display reasoning (`appendChatMessage` now stores `message_id` metadata).
- Frontend: implemented a `renderSearchWidget` that either renders to a `#search-widget` container or falls back to chat messages; added safe WS calls for news summary and expand interactions; updated static asset paths to `/static/*`.
- CSS: added styles for `.news-summary`, `.news-actions`, `.thinking-bar`, `.thought-overlay`, and related controls to match the new UI elements.
- Backend: `NewsSkill` now returns a short deterministic summary in the widget (`widget['summary']`) and the WebSocket send path includes that `summary` (`send_widget_message`); `brain_server` propagates `chat_done` events and handles a polite "thanks" phrase with a short reply.
- Backend: added `ResponseTemplates` used by `WebSearchExecutor` to create a calm, structured search briefing and included a `search` widget payload in action results; refactored TTS into `VoiceProfile`, `SpeechRenderer`, and used `SpeechFormatter` in `tts_engine.py`.

### Testing
- Manually started the dev server and verified the dashboard loads, the news fetch populates `#news-list` and `#news-summary`, the "Summarize headlines" button sends a WS message, and expand/collapse toggles list length successfully.
- Exercised chat flows to confirm assistant messages include thought indicators and that clicking the indicator requests and displays a reasoning overlay when the backend emits a `thought` message; `chat_done` toggles the thinking bar off.
- Ran backend smoke checks and executor flows to confirm `NewsSkill` and `WebSearchExecutor` return the expected widget payloads and the new TTS renderer (`nova_speak`) executes without throwing in the default environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a287d493208326a270755c92758d02)