### PR TITLE
Fix dashboard JS parse regression from merge conflict markers

### DIFF
--- a/nova_backend/static/dashboard.js
+++ b/nova_backend/static/dashboard.js
@@ -341,10 +341,7 @@ function injectUserText(text, channel = "text") {
   appendChatMessage("user", clean);
   waitingForAssistant = true;
  
-  setLoadingHint(clean.toLowerCase().includes("search") ? "Checking latest sources" : "Processing");
-=======
   setLoadingHint(loadingHintForInput(clean));
- inspect/codex-phase4
   setThinkingBar(true);
   
   // Phase-3 calm: if WS fails, just log, don't spam chat


### PR DESCRIPTION
### Motivation
- A leftover Git merge conflict inside `injectUserText()` introduced a JavaScript parse error that prevented `DOMContentLoaded` handlers (including `connectWebSocket()`) from running, breaking weather/news population and WebSocket startup.

### Description
- Replaced the conflicted block with the single canonical call `setLoadingHint(loadingHintForInput(clean));` and ensured only one `setLoadingHint()` call exists in `injectUserText()`.
- Removed all stray merge conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) and accidental artifact lines while preserving all other logic in the function.
- Kept the exact Phase-4 canonical pattern in `injectUserText()`: `appendChatMessage("user", clean);`, `waitingForAssistant = true;`, `setLoadingHint(loadingHintForInput(clean));`, `setThinkingBar(true);`, and the `safeWSSend(...)` call.

### Testing
- Verified no remaining conflict markers with `rg` (pattern for `<<<<<<<|=======|>>>>>>>`) and the check succeeded.
- Verified `injectUserText()` contains exactly one `setLoadingHint()` call via a small Python-based block parse and the check succeeded.
- Verified the file parses with `node --check` with no syntax errors and the check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a50fb7665c8326b9c7f720056c22b5)