### PR TITLE
Add runtime auditor, snapshot writer, and audit endpoints; update runtime docs

### DIFF
--- a/docs/CANONICAL/PHASE_4_RUNTIME_TRUTH.md
+++ b/docs/CANONICAL/PHASE_4_RUNTIME_TRUTH.md
@@ -1,6 +1,6 @@
 # PHASE-4 RUNTIME TRUTH SNAPSHOT
 
-**Last updated:** 2026-03-03  
+**Last updated:** 2026-03-04  
 **This document is the single, authoritative record of the current governed runtime state for NovaLIS.**
 
 ---
@@ -28,6 +28,15 @@
 | 22 | `open_file_folder` | disabled | confirm | false | Declared; disabled |
 | 32 | `os_diagnostics` | enabled | low | false | Wired; executor uses real shutil.disk_usage() for disk stats but hardcodes network_status — partial implementation |
 | 48 | `multi_source_reporting` | disabled | low | true | Declared; disabled |
+
+### Disabled-but-routable mediator surfaces
+
+`GovernorMediator` currently parses user phrases into invocations for capability IDs `22` and `48`:
+
+- `open documents|downloads|desktop|pictures` → ID `22`
+- `report <query>` / `summarize <query>` → ID `48`
+
+Both still fail closed at Governor admission because registry `enabled` is `false`.
 
 ---
 
@@ -78,6 +87,7 @@ Modules under `src/conversation/` (heuristics, escalation, thought store, Deep T
 - **Advisory only** – their output is treated as user‑facing text or internal hints, never as execution authority.
 - **Execution‑isolated** – they operate strictly in the read‑only phase of the request lifecycle.
 - **Local model only** – `DeepSeekBridge` uses local Ollama/phi3:mini. Full DeepSeek cloud API integration is design-only; no external network calls are made from the conversation layer.
+- **Model-path note** – `DeepSeekBridge` currently calls `ollama.chat(...)` directly rather than routing through `src/llm/llm_manager.py`. This is a known architecture-drift item tracked by runtime auditor warnings.
 
 ---
 

--- a/docs/runtime/CURRENT_RUNTIME_STATE.md
+++ b/docs/runtime/CURRENT_RUNTIME_STATE.md
@@ -1,0 +1,42 @@
+# CURRENT RUNTIME STATE
+
+**Generated at (UTC):** 2026-03-04T03:20:31.266392+00:00
+**Scope:** Runtime-truth snapshot aligned to current code paths.
+
+## Enabled Capability IDs (registry truth)
+
+- 16: enabled
+- 17: enabled
+- 18: enabled
+- 19: enabled
+- 20: enabled
+- 21: enabled
+- 32: enabled
+
+## Disabled Capability IDs
+
+- 22: disabled
+- 48: disabled
+
+## Capability Table
+
+| ID | Name | Enabled | Status | Risk Level | Data Exfiltration |
+|---:|---|---|---|---|---|
+| 16 | governed_web_search | enabled | active | low | true |
+| 17 | open_website | enabled | active | low | false |
+| 18 | speak_text | enabled | active | low | false |
+| 19 | volume_up_down | enabled | active | low | false |
+| 20 | media_play_pause | enabled | active | low | false |
+| 21 | brightness_control | enabled | active | low | false |
+| 22 | open_file_folder | disabled | active | confirm | false |
+| 32 | os_diagnostics | enabled | active | low | false |
+| 48 | multi_source_reporting | disabled | active | low | true |
+
+## Mediator Route Notes (current code)
+
+- Mediator currently maps capability IDs: [16, 17, 18, 19, 20, 21, 22, 32, 48]
+- Routes to disabled capability IDs are expected to fail closed at Governor admission.
+
+## Execution Gate
+
+- `GOVERNED_ACTIONS_ENABLED`: true

--- a/nova_backend/src/audit/__init__.py
+++ b/nova_backend/src/audit/__init__.py
@@ -1,0 +1,1 @@
+"""Runtime audit utilities for NovaLIS."""

--- a/nova_backend/src/audit/runtime_auditor.py
+++ b/nova_backend/src/audit/runtime_auditor.py
@@ -1,0 +1,394 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from src.governor.execute_boundary.execute_boundary import GOVERNED_ACTIONS_ENABLED
+from src.governor.governor_mediator import GovernorMediator, Invocation
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+REGISTRY_PATH = PROJECT_ROOT / "src" / "config" / "registry.json"
+RUNTIME_DOC_PATH = PROJECT_ROOT.parent / "docs" / "runtime" / "CURRENT_RUNTIME_STATE.md"
+CANONICAL_RUNTIME_DOC_PATH = PROJECT_ROOT.parent / "docs" / "CANONICAL" / "PHASE_4_RUNTIME_TRUTH.md"
+DEEPSEEK_BRIDGE_PATH = PROJECT_ROOT / "src" / "conversation" / "deepseek_bridge.py"
+LLM_MANAGER_PATH = PROJECT_ROOT / "src" / "llm" / "llm_manager.py"
+
+# Read-only allowlist for v1 auditor scope.
+ALLOWED_READ_PATHS = (
+    REGISTRY_PATH,
+    RUNTIME_DOC_PATH,
+    CANONICAL_RUNTIME_DOC_PATH,
+    DEEPSEEK_BRIDGE_PATH,
+    LLM_MANAGER_PATH,
+)
+
+# Minimal explicit phrase probes used to map mediator surfaces.
+MEDIATOR_TRIGGER_PROBES: dict[str, str] = {
+    "search for weather in ann arbor": "search",
+    "look up nasa": "search",
+    "research battery technology": "search",
+    "open github": "open_website",
+    "open documents": "open_folder",
+    "speak that": "speak",
+    "read that": "speak",
+    "say it": "speak",
+    "volume up": "volume",
+    "volume down": "volume",
+    "set volume 45": "volume",
+    "play": "media",
+    "pause": "media",
+    "resume": "media",
+    "brightness up": "brightness",
+    "brightness down": "brightness",
+    "set brightness 50": "brightness",
+    "system check": "diagnostics",
+    "system status": "diagnostics",
+    "report market update": "report",
+    "summarize ai safety": "report",
+}
+
+
+@dataclass(frozen=True)
+class Discrepancy:
+    severity: str  # hard_fail | warning
+    code: str
+    message: str
+    details: dict[str, Any]
+
+
+def _safe_read(path: Path) -> str:
+    if path not in ALLOWED_READ_PATHS:
+        raise ValueError(f"Path not allowlisted for auditor: {path}")
+    if not path.exists():
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def _load_registry() -> dict[str, Any]:
+    raw = _safe_read(REGISTRY_PATH)
+    if not raw:
+        return {"schema_version": None, "phase": None, "capabilities": []}
+    return json.loads(raw)
+
+
+def _enabled_registry_ids(registry: dict[str, Any]) -> list[int]:
+    ids = [int(item["id"]) for item in registry.get("capabilities", []) if item.get("enabled") is True]
+    return sorted(ids)
+
+
+def _extract_enabled_ids_from_markdown(markdown_text: str) -> list[int]:
+    """Best-effort extraction for lines like: `- 16: enabled` or table rows with enabled in enabled-column."""
+    if not markdown_text:
+        return []
+
+    found: set[int] = set()
+
+    for line in markdown_text.splitlines():
+        lower = line.lower()
+
+        bullet_match = re.search(r"\b(\d+)\b\s*[:\-|]\s*.*\benabled\b", lower)
+        if bullet_match:
+            found.add(int(bullet_match.group(1)))
+            continue
+
+        # Keep the match strict to the "Enabled" column position in our table format.
+        table_match = re.search(r"^\|\s*(\d+)\s*\|\s*[^|]+\|\s*(enabled|true)\s*\|", lower)
+        if table_match:
+            found.add(int(table_match.group(1)))
+            continue
+
+    return sorted(found)
+
+
+def _mediator_surface_map() -> dict[str, Any]:
+    entries = []
+    capability_ids = set()
+
+    for phrase, group in MEDIATOR_TRIGGER_PROBES.items():
+        parsed = GovernorMediator.parse_governed_invocation(phrase, session_id="audit-runtime")
+        cap_id = parsed.capability_id if isinstance(parsed, Invocation) else None
+        if cap_id is not None:
+            capability_ids.add(cap_id)
+        entries.append(
+            {
+                "probe": phrase,
+                "group": group,
+                "capability_id": cap_id,
+                "matched": cap_id is not None,
+            }
+        )
+
+    return {
+        "probes": entries,
+        "mapped_capability_ids": sorted(capability_ids),
+    }
+
+
+def _detect_direct_model_call_bypass() -> dict[str, Any]:
+    deepseek_src = _safe_read(DEEPSEEK_BRIDGE_PATH)
+    llm_manager_src = _safe_read(LLM_MANAGER_PATH)
+
+    return {
+        "deepseek_uses_ollama_chat_directly": "ollama.chat(" in deepseek_src,
+        "llm_manager_generate_present": "def generate(" in llm_manager_src,
+    }
+
+
+def _derive_status(hard_fail_count: int, warning_count: int) -> str:
+    if hard_fail_count > 0:
+        return "fail"
+    if warning_count > 0:
+        return "warn"
+    return "pass"
+
+
+def _build_discrepancies(
+    runtime_doc_enabled_ids: list[int],
+    registry_enabled_ids: list[int],
+    mediator_mapped_ids: list[int],
+    model_path_signals: dict[str, Any],
+    execution_gate_enabled: bool,
+    runtime_doc_exists: bool,
+) -> list[Discrepancy]:
+    discrepancies: list[Discrepancy] = []
+
+    runtime_doc_set = set(runtime_doc_enabled_ids)
+    registry_enabled_set = set(registry_enabled_ids)
+    mediator_mapped_set = set(mediator_mapped_ids)
+
+    if runtime_doc_exists and runtime_doc_set != registry_enabled_set:
+        discrepancies.append(
+            Discrepancy(
+                severity="hard_fail",
+                code="ENABLED_ID_SET_MISMATCH",
+                message="Enabled capability ID set differs between docs/runtime/CURRENT_RUNTIME_STATE.md and registry.json.",
+                details={
+                    "registry_enabled_ids": sorted(registry_enabled_set),
+                    "doc_enabled_ids": sorted(runtime_doc_set),
+                    "missing_in_doc": sorted(registry_enabled_set - runtime_doc_set),
+                    "extra_in_doc": sorted(runtime_doc_set - registry_enabled_set),
+                },
+            )
+        )
+
+    missing_mediator_routes = sorted(registry_enabled_set - mediator_mapped_set)
+    if missing_mediator_routes:
+        discrepancies.append(
+            Discrepancy(
+                severity="hard_fail",
+                code="ENABLED_CAPABILITY_MISSING_MEDIATOR_ROUTE",
+                message="One or more enabled capabilities are not matched by known mediator routes.",
+                details={"missing_capability_ids": missing_mediator_routes},
+            )
+        )
+
+    disabled_but_routable = sorted(mediator_mapped_set - registry_enabled_set)
+    if disabled_but_routable:
+        discrepancies.append(
+            Discrepancy(
+                severity="warning",
+                code="MEDIATOR_ROUTES_TO_DISABLED_CAPABILITY",
+                message="Mediator routes include capabilities that are currently disabled in registry.",
+                details={"disabled_or_non_enabled_capability_ids": disabled_but_routable},
+            )
+        )
+
+    if not execution_gate_enabled:
+        discrepancies.append(
+            Discrepancy(
+                severity="warning",
+                code="EXECUTION_GATE_DISABLED",
+                message="Global execution gate is disabled (GOVERNED_ACTIONS_ENABLED=False).",
+                details={"governed_actions_enabled": execution_gate_enabled},
+            )
+        )
+
+    if not runtime_doc_exists:
+        discrepancies.append(
+            Discrepancy(
+                severity="warning",
+                code="RUNTIME_DOC_MISSING",
+                message="docs/runtime/CURRENT_RUNTIME_STATE.md is missing.",
+                details={"path": str(RUNTIME_DOC_PATH.relative_to(PROJECT_ROOT.parent))},
+            )
+        )
+
+    if model_path_signals.get("deepseek_uses_ollama_chat_directly"):
+        discrepancies.append(
+            Discrepancy(
+                severity="warning",
+                code="DIRECT_MODEL_CALL_BYPASS",
+                message="DeepSeekBridge appears to call ollama.chat directly instead of a centralized LLM gateway.",
+                details={"path": str(DEEPSEEK_BRIDGE_PATH.relative_to(PROJECT_ROOT))},
+            )
+        )
+
+    return discrepancies
+
+
+def run_runtime_truth_audit() -> dict[str, Any]:
+    registry = _load_registry()
+    registry_enabled_ids = _enabled_registry_ids(registry)
+
+    runtime_doc_exists = RUNTIME_DOC_PATH.exists()
+    runtime_doc_text = _safe_read(RUNTIME_DOC_PATH)
+    runtime_doc_enabled_ids = _extract_enabled_ids_from_markdown(runtime_doc_text)
+
+    mediator_map = _mediator_surface_map()
+    mediator_mapped_ids = mediator_map["mapped_capability_ids"]
+    model_signals = _detect_direct_model_call_bypass()
+    execution_gate_enabled = bool(GOVERNED_ACTIONS_ENABLED)
+
+    discrepancies = _build_discrepancies(
+        runtime_doc_enabled_ids=runtime_doc_enabled_ids,
+        registry_enabled_ids=registry_enabled_ids,
+        mediator_mapped_ids=mediator_mapped_ids,
+        model_path_signals=model_signals,
+        execution_gate_enabled=execution_gate_enabled,
+        runtime_doc_exists=runtime_doc_exists,
+    )
+
+    hard_fail_count = sum(1 for item in discrepancies if item.severity == "hard_fail")
+    warning_count = sum(1 for item in discrepancies if item.severity == "warning")
+
+    status = _derive_status(hard_fail_count=hard_fail_count, warning_count=warning_count)
+
+    return {
+        "auditor": "runtime_truth_v1",
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "status": status,
+        "summary": {
+            "hard_fail_count": hard_fail_count,
+            "warning_count": warning_count,
+            "registry_enabled_ids": registry_enabled_ids,
+            "runtime_doc_enabled_ids": runtime_doc_enabled_ids,
+            "mediator_mapped_capability_ids": mediator_mapped_ids,
+            "execution_gate_enabled": execution_gate_enabled,
+            "runtime_doc_exists": runtime_doc_exists,
+        },
+        "inputs": {
+            "allowlisted_paths": [str(path.relative_to(PROJECT_ROOT.parent)) for path in ALLOWED_READ_PATHS],
+            "registry_path": str(REGISTRY_PATH.relative_to(PROJECT_ROOT.parent)),
+            "runtime_doc_path": str(RUNTIME_DOC_PATH.relative_to(PROJECT_ROOT.parent)),
+            "canonical_runtime_doc_path": str(CANONICAL_RUNTIME_DOC_PATH.relative_to(PROJECT_ROOT.parent)),
+        },
+        "checks": {
+            "model_path_signals": model_signals,
+            "mediator_surface": mediator_map,
+        },
+        "discrepancies": [asdict(item) for item in discrepancies],
+    }
+
+
+
+
+def render_current_runtime_state_markdown(report: dict[str, Any], registry: dict[str, Any]) -> str:
+    generated_at = report.get("generated_at_utc", datetime.now(timezone.utc).isoformat())
+    execution_gate_enabled = bool((report.get("summary") or {}).get("execution_gate_enabled", False))
+    mediator_ids = (report.get("summary") or {}).get("mediator_mapped_capability_ids", [])
+
+    capabilities = sorted(registry.get("capabilities", []), key=lambda c: int(c.get("id", 0)))
+    enabled_ids = [int(c["id"]) for c in capabilities if c.get("enabled") is True]
+    disabled_ids = [int(c["id"]) for c in capabilities if c.get("enabled") is not True]
+
+    lines = [
+        "# CURRENT RUNTIME STATE",
+        "",
+        f"**Generated at (UTC):** {generated_at}",
+        "**Scope:** Runtime-truth snapshot aligned to current code paths.",
+        "",
+        "## Enabled Capability IDs (registry truth)",
+        "",
+    ]
+
+    for cap_id in enabled_ids:
+        lines.append(f"- {cap_id}: enabled")
+
+    lines.extend(["", "## Disabled Capability IDs", ""])
+    for cap_id in disabled_ids:
+        lines.append(f"- {cap_id}: disabled")
+
+    lines.extend([
+        "",
+        "## Capability Table",
+        "",
+        "| ID | Name | Enabled | Status | Risk Level | Data Exfiltration |",
+        "|---:|---|---|---|---|---|",
+    ])
+
+    for cap in capabilities:
+        lines.append(
+            "| {id} | {name} | {enabled} | {status} | {risk} | {exfil} |".format(
+                id=cap.get("id"),
+                name=cap.get("name", ""),
+                enabled="enabled" if cap.get("enabled") else "disabled",
+                status=cap.get("status", ""),
+                risk=cap.get("risk_level", ""),
+                exfil=str(bool(cap.get("data_exfiltration"))).lower(),
+            )
+        )
+
+    lines.extend([
+        "",
+        "## Mediator Route Notes (current code)",
+        "",
+        f"- Mediator currently maps capability IDs: {mediator_ids}",
+        "- Routes to disabled capability IDs are expected to fail closed at Governor admission.",
+        "",
+        "## Execution Gate",
+        "",
+        f"- `GOVERNED_ACTIONS_ENABLED`: {str(execution_gate_enabled).lower()}",
+        "",
+    ])
+
+    return "\n".join(lines).strip() + "\n"
+
+
+def write_current_runtime_state_snapshot(path: Path = RUNTIME_DOC_PATH) -> Path:
+    report = run_runtime_truth_audit()
+    registry = _load_registry()
+    markdown = render_current_runtime_state_markdown(report, registry)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(markdown, encoding="utf-8")
+    return path
+
+def render_runtime_truth_markdown(report: dict[str, Any]) -> str:
+    summary = report.get("summary", {})
+    lines = [
+        "# Runtime Truth Audit Report",
+        "",
+        f"- Generated (UTC): {report.get('generated_at_utc', '')}",
+        f"- Status: **{report.get('status', 'unknown').upper()}**",
+        f"- Hard failures: {summary.get('hard_fail_count', 0)}",
+        f"- Warnings: {summary.get('warning_count', 0)}",
+        f"- Execution gate enabled: {summary.get('execution_gate_enabled', False)}",
+        f"- Runtime doc exists: {summary.get('runtime_doc_exists', False)}",
+        "",
+        "## Enabled Capability Set Comparison",
+        "",
+        f"- Registry enabled IDs: {summary.get('registry_enabled_ids', [])}",
+        f"- Runtime doc enabled IDs: {summary.get('runtime_doc_enabled_ids', [])}",
+        "",
+        "## Mediator Surface",
+        "",
+        f"- Mediator mapped capability IDs from explicit probes: {summary.get('mediator_mapped_capability_ids', [])}",
+        "",
+        "## Discrepancies",
+        "",
+    ]
+
+    discrepancies = report.get("discrepancies", [])
+    if not discrepancies:
+        lines.append("- None.")
+    else:
+        for item in discrepancies:
+            lines.append(
+                f"- [{item.get('severity', 'unknown')}] {item.get('code', 'UNKNOWN')}: {item.get('message', '')}"
+            )
+
+    return "\n".join(lines).strip() + "\n"

--- a/nova_backend/src/brain_server.py
+++ b/nova_backend/src/brain_server.py
@@ -19,6 +19,7 @@ from datetime import datetime
 from typing import Optional
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.responses import PlainTextResponse
 
 from src.skill_registry import SkillRegistry
 from src.gates.confirmation_gate import confirmation_gate
@@ -30,6 +31,7 @@ from src.conversation.response_style_router import InputNormalizer
 from src.voice.stt_pipeline import STTAckConfig, build_ack_payload
 from src.voice.tts_engine import resolve_speakable_text, nova_speak, stop_speaking
 from src.conversation.clarify_prompts import CLARIFY_PROMPTS
+from src.audit.runtime_auditor import run_runtime_truth_audit, render_runtime_truth_markdown, write_current_runtime_state_snapshot
 
 # -------------------------------------------------
 # App + Logging
@@ -80,6 +82,16 @@ VOICE_ACK_CONFIG = STTAckConfig(enabled=VOICE_ACK_ENABLED, text=VOICE_ACK_TEXT)
 # -------------------------------------------------
 # Phase Status Endpoint
 # -------------------------------------------------
+
+
+@app.on_event("startup")
+async def refresh_runtime_snapshot_on_startup():
+    """Refresh docs/runtime/CURRENT_RUNTIME_STATE.md once on backend startup."""
+    try:
+        write_current_runtime_state_snapshot()
+    except Exception as error:
+        log.exception("Failed to refresh runtime snapshot on startup: %s", error)
+
 @app.get("/phase-status")
 async def phase_status():
     from src.governor.execute_boundary import GOVERNED_ACTIONS_ENABLED
@@ -89,6 +101,19 @@ async def phase_status():
         "execution_enabled": GOVERNED_ACTIONS_ENABLED,
         "note": "Phase‑4 runtime active – all actions mediated by Governor."
     }
+
+
+@app.get("/system/audit/runtime-truth")
+async def audit_runtime_truth():
+    """Read-only runtime-truth audit report (JSON)."""
+    return run_runtime_truth_audit()
+
+
+@app.get("/system/audit/runtime-truth.md", response_class=PlainTextResponse)
+async def audit_runtime_truth_markdown():
+    """Read-only runtime-truth audit report (Markdown)."""
+    report = run_runtime_truth_audit()
+    return render_runtime_truth_markdown(report)
 
 # -------------------------------------------------
 # WebSocket Utilities

--- a/nova_backend/tests/test_runtime_auditor.py
+++ b/nova_backend/tests/test_runtime_auditor.py
@@ -1,0 +1,66 @@
+from src.audit.runtime_auditor import _build_discrepancies, _derive_status, write_current_runtime_state_snapshot
+
+
+def test_status_warn_tier_when_only_warnings():
+    assert _derive_status(hard_fail_count=0, warning_count=2) == "warn"
+
+
+def test_status_fail_overrides_warnings():
+    assert _derive_status(hard_fail_count=1, warning_count=3) == "fail"
+
+
+def test_mediator_vs_enabled_mismatch_detection_and_execution_gate_warning():
+    discrepancies = _build_discrepancies(
+        runtime_doc_enabled_ids=[16, 17],
+        registry_enabled_ids=[16, 17],
+        mediator_mapped_ids=[16, 17, 22],
+        model_path_signals={"deepseek_uses_ollama_chat_directly": False},
+        execution_gate_enabled=False,
+        runtime_doc_exists=True,
+    )
+
+    codes = {item.code for item in discrepancies}
+    assert "MEDIATOR_ROUTES_TO_DISABLED_CAPABILITY" in codes
+    assert "EXECUTION_GATE_DISABLED" in codes
+
+
+def test_missing_enabled_mediator_route_is_hard_fail():
+    discrepancies = _build_discrepancies(
+        runtime_doc_enabled_ids=[16, 17],
+        registry_enabled_ids=[16, 17, 18],
+        mediator_mapped_ids=[16, 17],
+        model_path_signals={"deepseek_uses_ollama_chat_directly": False},
+        execution_gate_enabled=True,
+        runtime_doc_exists=True,
+    )
+
+    missing = [d for d in discrepancies if d.code == "ENABLED_CAPABILITY_MISSING_MEDIATOR_ROUTE"]
+    assert missing
+    assert missing[0].severity == "hard_fail"
+
+
+def test_runtime_doc_missing_does_not_emit_enabled_id_hard_fail():
+    discrepancies = _build_discrepancies(
+        runtime_doc_enabled_ids=[],
+        registry_enabled_ids=[16, 17],
+        mediator_mapped_ids=[16, 17],
+        model_path_signals={"deepseek_uses_ollama_chat_directly": False},
+        execution_gate_enabled=True,
+        runtime_doc_exists=False,
+    )
+
+    codes = {item.code for item in discrepancies}
+    assert "RUNTIME_DOC_MISSING" in codes
+    assert "ENABLED_ID_SET_MISMATCH" not in codes
+
+
+def test_write_current_runtime_state_snapshot_writes_enabled_ids(tmp_path):
+    output = tmp_path / "CURRENT_RUNTIME_STATE.md"
+    written = write_current_runtime_state_snapshot(path=output)
+
+    assert written == output
+    text = output.read_text(encoding="utf-8")
+    assert "# CURRENT RUNTIME STATE" in text
+    assert "- 16: enabled" in text
+    assert "- 32: enabled" in text
+    assert "- 22: disabled" in text


### PR DESCRIPTION
### Motivation

- Provide an automated runtime-truth auditor to validate registry vs. mediator vs. docs and surface discrepancies for Phase‑4 runtime governance. 
- Persist a machine-readable and human-readable snapshot of the current runtime state for operational visibility. 
- Expose read-only audit endpoints and refresh the snapshot at backend startup so runtime state is discoverable without manual steps.

### Description

- Add a new audit package with `src/audit/runtime_auditor.py` implementing `run_runtime_truth_audit`, `render_runtime_truth_markdown`, `write_current_runtime_state_snapshot`, and supporting helpers to compare `registry.json`, mediator parsing, and canonical docs; add `__init__.py`.
- Create a generated runtime snapshot `docs/runtime/CURRENT_RUNTIME_STATE.md` and update the canonical runtime doc `docs/CANONICAL/PHASE_4_RUNTIME_TRUTH.md` (bump date and add "Disabled-but-routable mediator surfaces" note).
- Wire the brain server to refresh the runtime snapshot on startup via `write_current_runtime_state_snapshot()` and add read-only endpoints `GET /system/audit/runtime-truth` (JSON) and `GET /system/audit/runtime-truth.md` (Markdown), and import `PlainTextResponse` to serve Markdown.
- Add unit tests `nova_backend/tests/test_runtime_auditor.py` that exercise `_derive_status`, `_build_discrepancies`, and `write_current_runtime_state_snapshot` behaviors.

### Testing

- Ran the new unit tests in `nova_backend/tests/test_runtime_auditor.py` with `pytest` and they passed locally (all assertions succeeded). 
- Exercised `write_current_runtime_state_snapshot()` in a temporary directory as part of tests to confirm `CURRENT_RUNTIME_STATE.md` is created and contains expected enabled/disabled capability lines.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a722dc47888326b9ced9e300947986)