### PR TITLE
Auto-refresh runtime.md snapshot on startup

### DIFF
--- a/nova_backend/src/audit/runtime_auditor.py
+++ b/nova_backend/src/audit/runtime_auditor.py
@@ -14,6 +14,7 @@ from src.governor.governor_mediator import GovernorMediator, Invocation
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 REGISTRY_PATH = PROJECT_ROOT / "src" / "config" / "registry.json"
 RUNTIME_DOC_PATH = PROJECT_ROOT.parent / "docs" / "runtime" / "CURRENT_RUNTIME_STATE.md"
+RUNTIME_SNAPSHOT_PATH = PROJECT_ROOT.parent / "runtime.md"
 CANONICAL_RUNTIME_DOC_PATH = PROJECT_ROOT.parent / "docs" / "CANONICAL" / "PHASE_4_RUNTIME_TRUTH.md"
 DEEPSEEK_BRIDGE_PATH = PROJECT_ROOT / "src" / "conversation" / "deepseek_bridge.py"
 LLM_MANAGER_PATH = PROJECT_ROOT / "src" / "llm" / "llm_manager.py"
@@ -314,3 +315,80 @@ def render_runtime_truth_markdown(report: dict[str, Any]) -> str:
             )
 
     return "\n".join(lines).strip() + "\n"
+
+
+def render_current_runtime_state_markdown(report: dict[str, Any], registry: dict[str, Any]) -> str:
+    summary = report.get("summary", {})
+    generated_at = report.get("generated_at_utc", "")
+
+    capabilities = registry.get("capabilities", [])
+    enabled_ids = [int(item["id"]) for item in capabilities if item.get("enabled") is True]
+    disabled_ids = [int(item["id"]) for item in capabilities if item.get("enabled") is not True]
+
+    lines = [
+        "# runtime.md",
+        "",
+        "Auto-generated runtime snapshot. Do not edit manually.",
+        "",
+        f"- Generated (UTC): {generated_at}",
+        f"- Audit status: **{report.get('status', 'unknown').upper()}**",
+        f"- Execution gate enabled: {summary.get('execution_gate_enabled', False)}",
+        "",
+        "## Enabled capability IDs",
+        "",
+        f"- {sorted(enabled_ids)}",
+        "",
+        "## Disabled capability IDs",
+        "",
+        f"- {sorted(disabled_ids)}",
+        "",
+        "## Capability table",
+        "",
+        "| id | name | enabled | status | risk_level | data_exfiltration |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+
+    for capability in capabilities:
+        lines.append(
+            "| {id} | {name} | {enabled} | {status} | {risk_level} | {data_exfiltration} |".format(
+                id=capability.get("id", ""),
+                name=capability.get("name", ""),
+                enabled=bool(capability.get("enabled", False)),
+                status=capability.get("status", ""),
+                risk_level=capability.get("risk_level", ""),
+                data_exfiltration=bool(capability.get("data_exfiltration", False)),
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Mediator mapped capability IDs",
+            "",
+            f"- {summary.get('mediator_mapped_capability_ids', [])}",
+            "",
+            "## Runtime truth discrepancies",
+            "",
+        ]
+    )
+
+    discrepancies = report.get("discrepancies", [])
+    if not discrepancies:
+        lines.append("- None")
+    else:
+        for item in discrepancies:
+            lines.append(
+                f"- [{item.get('severity', 'unknown')}] {item.get('code', 'UNKNOWN')}: {item.get('message', '')}"
+            )
+
+    return "\n".join(lines).strip() + "\n"
+
+
+def write_current_runtime_state_snapshot() -> Path:
+    report = run_runtime_truth_audit()
+    registry = _load_registry()
+    markdown = render_current_runtime_state_markdown(report, registry)
+
+    RUNTIME_SNAPSHOT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    RUNTIME_SNAPSHOT_PATH.write_text(markdown, encoding="utf-8")
+    return RUNTIME_SNAPSHOT_PATH

--- a/nova_backend/src/brain_server.py
+++ b/nova_backend/src/brain_server.py
@@ -31,13 +31,26 @@ from src.conversation.response_style_router import InputNormalizer
 from src.voice.stt_pipeline import STTAckConfig, build_ack_payload
 from src.voice.tts_engine import resolve_speakable_text, nova_speak, stop_speaking
 from src.conversation.clarify_prompts import CLARIFY_PROMPTS
-from src.audit.runtime_auditor import run_runtime_truth_audit, render_runtime_truth_markdown
+from src.audit.runtime_auditor import (
+    run_runtime_truth_audit,
+    render_runtime_truth_markdown,
+    write_current_runtime_state_snapshot,
+)
 
 # -------------------------------------------------
 # App + Logging
 # -------------------------------------------------
 log = logging.getLogger("nova")
 app = FastAPI()
+
+
+@app.on_event("startup")
+async def refresh_runtime_snapshot_on_startup():
+    try:
+        output_path = write_current_runtime_state_snapshot()
+        log.info("Runtime snapshot refreshed at startup: %s", output_path)
+    except Exception:
+        log.exception("Failed to refresh runtime.md snapshot on startup")
 
 # -------------------------------------------------
 # Static Files

--- a/nova_backend/tests/governance/test_runtime_snapshot.py
+++ b/nova_backend/tests/governance/test_runtime_snapshot.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+from src.audit import runtime_auditor
+
+
+def test_render_current_runtime_state_markdown_contains_core_sections():
+    report = {
+        "generated_at_utc": "2026-01-01T00:00:00+00:00",
+        "status": "pass",
+        "summary": {
+            "execution_gate_enabled": True,
+            "mediator_mapped_capability_ids": [16, 17],
+        },
+        "discrepancies": [],
+    }
+    registry = {
+        "capabilities": [
+            {"id": 16, "name": "governed_web_search", "enabled": True, "status": "active", "risk_level": "low", "data_exfiltration": True},
+            {"id": 22, "name": "open_file_folder", "enabled": False, "status": "active", "risk_level": "confirm", "data_exfiltration": False},
+        ]
+    }
+
+    markdown = runtime_auditor.render_current_runtime_state_markdown(report, registry)
+
+    assert "# runtime.md" in markdown
+    assert "## Enabled capability IDs" in markdown
+    assert "- [16]" in markdown
+    assert "## Disabled capability IDs" in markdown
+    assert "- [22]" in markdown
+    assert "| 16 | governed_web_search | True |" in markdown
+
+
+def test_write_current_runtime_state_snapshot_writes_runtime_md(monkeypatch, tmp_path: Path):
+    output_path = tmp_path / "runtime.md"
+
+    monkeypatch.setattr(runtime_auditor, "RUNTIME_SNAPSHOT_PATH", output_path)
+    monkeypatch.setattr(
+        runtime_auditor,
+        "run_runtime_truth_audit",
+        lambda: {
+            "generated_at_utc": "2026-01-01T00:00:00+00:00",
+            "status": "warn",
+            "summary": {"execution_gate_enabled": True, "mediator_mapped_capability_ids": [16]},
+            "discrepancies": [{"severity": "warning", "code": "TEST", "message": "test message"}],
+        },
+    )
+    monkeypatch.setattr(
+        runtime_auditor,
+        "_load_registry",
+        lambda: {
+            "capabilities": [
+                {
+                    "id": 16,
+                    "name": "governed_web_search",
+                    "enabled": True,
+                    "status": "active",
+                    "risk_level": "low",
+                    "data_exfiltration": True,
+                }
+            ]
+        },
+    )
+
+    returned_path = runtime_auditor.write_current_runtime_state_snapshot()
+
+    assert returned_path == output_path
+    assert output_path.exists()
+    content = output_path.read_text(encoding="utf-8")
+    assert "# runtime.md" in content
+    assert "TEST" in content


### PR DESCRIPTION
### Motivation
- Ensure runtime documentation is always derived from the current runtime state to eliminate documentation drift by generating a machine-authored snapshot at program startup.
- Provide a single, auditable runtime snapshot file (`runtime.md`) that reflects the registry, mediator mapping, execution gate and audit discrepancies.

### Description
- Added `RUNTIME_SNAPSHOT_PATH` and two new auditor functions: `render_current_runtime_state_markdown(report, registry)` and `write_current_runtime_state_snapshot()` to `src/audit/runtime_auditor.py` to build and write an auto-generated `runtime.md` snapshot.
- Reused existing audit logic by calling `run_runtime_truth_audit()` and `_load_registry()` in `write_current_runtime_state_snapshot()` to ensure consistency between audit and snapshot outputs.
- Wired a FastAPI startup hook in `src/brain_server.py` which calls `write_current_runtime_state_snapshot()` once on app startup and logs any non-fatal errors.
- Added unit tests `nova_backend/tests/governance/test_runtime_snapshot.py` that validate the markdown renderer and that the snapshot writer creates the expected file and content.

### Testing
- Ran `pytest` for the new governance tests with `PYTHONPATH=.` which resulted in `2 passed` for `tests/governance/test_runtime_snapshot.py`.
- A plain test run without `PYTHONPATH` initially showed an import error (no `src` package on sys.path), corrected by running tests with `PYTHONPATH=.`, after which both tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7a6a63f6083269fd4d71909f27dc3)