### PR TITLE
Update runtime snapshot path and startup log message

### DIFF
--- a/nova_backend/src/audit/runtime_auditor.py
+++ b/nova_backend/src/audit/runtime_auditor.py
@@ -14,7 +14,7 @@ from src.governor.governor_mediator import GovernorMediator, Invocation
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 REGISTRY_PATH = PROJECT_ROOT / "src" / "config" / "registry.json"
 RUNTIME_DOC_PATH = PROJECT_ROOT.parent / "docs" / "runtime" / "CURRENT_RUNTIME_STATE.md"
-RUNTIME_SNAPSHOT_PATH = PROJECT_ROOT.parent / "runtime.md"
+RUNTIME_SNAPSHOT_PATH = PROJECT_ROOT.parent / "docs" / "current_runtime" / "runtime.md"
 CANONICAL_RUNTIME_DOC_PATH = PROJECT_ROOT.parent / "docs" / "CANONICAL" / "PHASE_4_RUNTIME_TRUTH.md"
 DEEPSEEK_BRIDGE_PATH = PROJECT_ROOT / "src" / "conversation" / "deepseek_bridge.py"
 LLM_MANAGER_PATH = PROJECT_ROOT / "src" / "llm" / "llm_manager.py"

--- a/nova_backend/src/brain_server.py
+++ b/nova_backend/src/brain_server.py
@@ -50,7 +50,7 @@ async def refresh_runtime_snapshot_on_startup():
         output_path = write_current_runtime_state_snapshot()
         log.info("Runtime snapshot refreshed at startup: %s", output_path)
     except Exception:
-        log.exception("Failed to refresh runtime.md snapshot on startup")
+        log.exception("Failed to refresh runtime snapshot on startup")
 
 # -------------------------------------------------
 # Static Files


### PR DESCRIPTION
### Motivation
- Reorganize where the runtime snapshot is stored and make the startup log message less file-specific for clarity and consistent docs layout.

### Description
- Change `RUNTIME_SNAPSHOT_PATH` from `PROJECT_ROOT.parent / "runtime.md"` to `PROJECT_ROOT.parent / "docs" / "current_runtime" / "runtime.md"` to move snapshots under the docs tree.
- Simplify the startup error log message from "Failed to refresh runtime.md snapshot on startup" to "Failed to refresh runtime snapshot on startup".

### Testing
- Ran the project unit test suite with `pytest` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7ae4d80608326aaf3ec90e3d2ef41)