### PR TITLE
Use deterministic docs/current_runtime/CURRENT_RUNTIME_STATE.md for runtime snapshot

### DIFF
--- a/nova_backend/src/audit/runtime_auditor.py
+++ b/nova_backend/src/audit/runtime_auditor.py
@@ -11,13 +11,12 @@ from src.governor.execute_boundary.execute_boundary import GOVERNED_ACTIONS_ENAB
 from src.governor.governor_mediator import GovernorMediator, Invocation
 
 
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
-REGISTRY_PATH = PROJECT_ROOT / "src" / "config" / "registry.json"
-RUNTIME_DOC_PATH = PROJECT_ROOT.parent / "docs" / "runtime" / "CURRENT_RUNTIME_STATE.md"
-RUNTIME_SNAPSHOT_PATH = PROJECT_ROOT.parent / "docs" / "current_runtime" / "runtime.md"
-CANONICAL_RUNTIME_DOC_PATH = PROJECT_ROOT.parent / "docs" / "CANONICAL" / "PHASE_4_RUNTIME_TRUTH.md"
-DEEPSEEK_BRIDGE_PATH = PROJECT_ROOT / "src" / "conversation" / "deepseek_bridge.py"
-LLM_MANAGER_PATH = PROJECT_ROOT / "src" / "llm" / "llm_manager.py"
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+REGISTRY_PATH = PROJECT_ROOT / "nova_backend" / "src" / "config" / "registry.json"
+RUNTIME_DOC_PATH = PROJECT_ROOT / "docs" / "current_runtime" / "CURRENT_RUNTIME_STATE.md"
+CANONICAL_RUNTIME_DOC_PATH = PROJECT_ROOT / "docs" / "CANONICAL" / "PHASE_4_RUNTIME_TRUTH.md"
+DEEPSEEK_BRIDGE_PATH = PROJECT_ROOT / "nova_backend" / "src" / "conversation" / "deepseek_bridge.py"
+LLM_MANAGER_PATH = PROJECT_ROOT / "nova_backend" / "src" / "llm" / "llm_manager.py"
 
 # Read-only allowlist for v1 auditor scope.
 ALLOWED_READ_PATHS = (
@@ -165,7 +164,7 @@ def _build_discrepancies(
             Discrepancy(
                 severity="hard_fail",
                 code="ENABLED_ID_SET_MISMATCH",
-                message="Enabled capability ID set differs between docs/runtime/CURRENT_RUNTIME_STATE.md and registry.json.",
+                message="Enabled capability ID set differs between docs/current_runtime/CURRENT_RUNTIME_STATE.md and registry.json.",
                 details={
                     "registry_enabled_ids": sorted(registry_enabled_set),
                     "doc_enabled_ids": sorted(runtime_doc_set),
@@ -212,8 +211,8 @@ def _build_discrepancies(
             Discrepancy(
                 severity="warning",
                 code="RUNTIME_DOC_MISSING",
-                message="docs/runtime/CURRENT_RUNTIME_STATE.md is missing.",
-                details={"path": str(RUNTIME_DOC_PATH.relative_to(PROJECT_ROOT.parent))},
+                message="docs/current_runtime/CURRENT_RUNTIME_STATE.md is missing.",
+                details={"path": str(RUNTIME_DOC_PATH.relative_to(PROJECT_ROOT))},
             )
         )
 
@@ -268,10 +267,10 @@ def run_runtime_truth_audit() -> dict[str, Any]:
             "execution_gate_enabled": execution_gate_enabled,
         },
         "inputs": {
-            "allowlisted_paths": [str(path.relative_to(PROJECT_ROOT.parent)) for path in ALLOWED_READ_PATHS],
-            "registry_path": str(REGISTRY_PATH.relative_to(PROJECT_ROOT.parent)),
-            "runtime_doc_path": str(RUNTIME_DOC_PATH.relative_to(PROJECT_ROOT.parent)),
-            "canonical_runtime_doc_path": str(CANONICAL_RUNTIME_DOC_PATH.relative_to(PROJECT_ROOT.parent)),
+            "allowlisted_paths": [str(path.relative_to(PROJECT_ROOT)) for path in ALLOWED_READ_PATHS],
+            "registry_path": str(REGISTRY_PATH.relative_to(PROJECT_ROOT)),
+            "runtime_doc_path": str(RUNTIME_DOC_PATH.relative_to(PROJECT_ROOT)),
+            "canonical_runtime_doc_path": str(CANONICAL_RUNTIME_DOC_PATH.relative_to(PROJECT_ROOT)),
         },
         "checks": {
             "model_path_signals": model_signals,
@@ -326,7 +325,7 @@ def render_current_runtime_state_markdown(report: dict[str, Any], registry: dict
     disabled_ids = [int(item["id"]) for item in capabilities if item.get("enabled") is not True]
 
     lines = [
-        "# runtime.md",
+        "# CURRENT_RUNTIME_STATE.md",
         "",
         "Auto-generated runtime snapshot. Do not edit manually.",
         "",
@@ -384,11 +383,11 @@ def render_current_runtime_state_markdown(report: dict[str, Any], registry: dict
     return "\n".join(lines).strip() + "\n"
 
 
-def write_current_runtime_state_snapshot() -> Path:
+def write_current_runtime_state_snapshot(path: Path = RUNTIME_DOC_PATH) -> Path:
     report = run_runtime_truth_audit()
     registry = _load_registry()
     markdown = render_current_runtime_state_markdown(report, registry)
 
-    RUNTIME_SNAPSHOT_PATH.parent.mkdir(parents=True, exist_ok=True)
-    RUNTIME_SNAPSHOT_PATH.write_text(markdown, encoding="utf-8")
-    return RUNTIME_SNAPSHOT_PATH
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(markdown, encoding="utf-8")
+    return path.resolve()

--- a/nova_backend/tests/governance/test_runtime_snapshot.py
+++ b/nova_backend/tests/governance/test_runtime_snapshot.py
@@ -3,44 +3,49 @@ from pathlib import Path
 from src.audit import runtime_auditor
 
 
+def test_runtime_doc_path_points_to_current_runtime_state_md():
+    expected = (Path(__file__).resolve().parents[3] / "docs" / "current_runtime" / "CURRENT_RUNTIME_STATE.md").resolve()
+    assert runtime_auditor.RUNTIME_DOC_PATH.resolve() == expected
+
+
 def test_render_current_runtime_state_markdown_contains_core_sections():
     report = {
         "generated_at_utc": "2026-01-01T00:00:00+00:00",
         "status": "pass",
         "summary": {
             "execution_gate_enabled": True,
-            "mediator_mapped_capability_ids": [16, 17],
+            "mediator_mapped_capability_ids": [16, 32],
         },
         "discrepancies": [],
     }
     registry = {
         "capabilities": [
             {"id": 16, "name": "governed_web_search", "enabled": True, "status": "active", "risk_level": "low", "data_exfiltration": True},
+            {"id": 32, "name": "governed_file_ops", "enabled": True, "status": "active", "risk_level": "confirm", "data_exfiltration": False},
             {"id": 22, "name": "open_file_folder", "enabled": False, "status": "active", "risk_level": "confirm", "data_exfiltration": False},
         ]
     }
 
     markdown = runtime_auditor.render_current_runtime_state_markdown(report, registry)
 
-    assert "# runtime.md" in markdown
+    assert "# CURRENT_RUNTIME_STATE.md" in markdown
     assert "## Enabled capability IDs" in markdown
-    assert "- [16]" in markdown
+    assert "- [16, 32]" in markdown
     assert "## Disabled capability IDs" in markdown
     assert "- [22]" in markdown
     assert "| 16 | governed_web_search | True |" in markdown
 
 
-def test_write_current_runtime_state_snapshot_writes_runtime_md(monkeypatch, tmp_path: Path):
-    output_path = tmp_path / "runtime.md"
+def test_write_current_runtime_state_snapshot_writes_current_runtime_state_and_creates_dir(monkeypatch, tmp_path: Path):
+    output_path = tmp_path / "docs" / "current_runtime" / "CURRENT_RUNTIME_STATE.md"
 
-    monkeypatch.setattr(runtime_auditor, "RUNTIME_SNAPSHOT_PATH", output_path)
     monkeypatch.setattr(
         runtime_auditor,
         "run_runtime_truth_audit",
         lambda: {
             "generated_at_utc": "2026-01-01T00:00:00+00:00",
             "status": "warn",
-            "summary": {"execution_gate_enabled": True, "mediator_mapped_capability_ids": [16]},
+            "summary": {"execution_gate_enabled": True, "mediator_mapped_capability_ids": [16, 32]},
             "discrepancies": [{"severity": "warning", "code": "TEST", "message": "test message"}],
         },
     )
@@ -56,15 +61,24 @@ def test_write_current_runtime_state_snapshot_writes_runtime_md(monkeypatch, tmp
                     "status": "active",
                     "risk_level": "low",
                     "data_exfiltration": True,
-                }
+                },
+                {
+                    "id": 32,
+                    "name": "governed_file_ops",
+                    "enabled": True,
+                    "status": "active",
+                    "risk_level": "confirm",
+                    "data_exfiltration": False,
+                },
             ]
         },
     )
 
-    returned_path = runtime_auditor.write_current_runtime_state_snapshot()
+    returned_path = runtime_auditor.write_current_runtime_state_snapshot(path=output_path)
 
-    assert returned_path == output_path
+    assert returned_path == output_path.resolve()
     assert output_path.exists()
     content = output_path.read_text(encoding="utf-8")
-    assert "# runtime.md" in content
+    assert "# CURRENT_RUNTIME_STATE.md" in content
+    assert "- [16, 32]" in content
     assert "TEST" in content


### PR DESCRIPTION
### Motivation

- Remove relative-path drift by deriving the project root from the auditor file location and standardizing the runtime snapshot location. 

### Description

- Derive `PROJECT_ROOT` deterministically with `Path(__file__).resolve().parents[3]` and set `REGISTRY_PATH`, `DEEPSEEK_BRIDGE_PATH`, and `LLM_MANAGER_PATH` relative to that root. 
- Standardize the runtime document to `RUNTIME_DOC_PATH = PROJECT_ROOT / "docs" / "current_runtime" / "CURRENT_RUNTIME_STATE.md"` and update allowlisted paths and human-readable messages to reference `docs/current_runtime`. 
- Replace the legacy snapshot writer to `def write_current_runtime_state_snapshot(path: Path = RUNTIME_DOC_PATH) -> Path`, ensure `path.parent.mkdir(parents=True, exist_ok=True)`, write the markdown to `path`, and return `path.resolve()`. 
- Update rendered snapshot header to `# CURRENT_RUNTIME_STATE.md` and adjust tests to assert the new path, ensure directory creation, and validate enabled IDs (including `16` and `32`), while leaving governance/discrepancy logic unchanged. 

### Testing

- Ran the full test suite with `python -m pytest` and all tests passed. 
- Updated unit tests under `nova_backend/tests/governance/test_runtime_snapshot.py` were executed as part of the suite and succeeded. 
- Verified `write_current_runtime_state_snapshot()` creates `docs/current_runtime/CURRENT_RUNTIME_STATE.md` when invoked (checked programmatically during test runs).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7b4e590888326b8b27eabd03e5775)