### PR TITLE
runtime_auditor: emit governance docs, fingerprinting, and bypass detections

### DIFF
--- a/docs/current_runtime/BYPASS_SURFACES.md
+++ b/docs/current_runtime/BYPASS_SURFACES.md
@@ -1,0 +1,25 @@
+# BYPASS_SURFACES
+
+Read-only truth report of detectable bypass indicators from allowlisted runtime sources.
+
+## Direct ollama.chat outside llm_manager
+
+- nova_backend/src/conversation/deepseek_bridge.py
+- nova_backend/src/skills/general_chat.py
+
+## requests/network usage outside NetworkMediator
+
+- None detected.
+
+## Executor callable paths outside governor
+
+- Architectural constraint: executors exist as importable callables, but governed runtime routes execution through Governor branches.
+- nova_backend/src/executors/brightness_executor.py
+- nova_backend/src/executors/media_executor.py
+- nova_backend/src/executors/multi_source_reporting_executor.py
+- nova_backend/src/executors/open_folder_executor.py
+- nova_backend/src/executors/os_diagnostics_executor.py
+- nova_backend/src/executors/tts_executor.py
+- nova_backend/src/executors/volume_executor.py
+- nova_backend/src/executors/web_search_executor.py
+- nova_backend/src/executors/webpage_launch_executor.py

--- a/docs/current_runtime/CURRENT_RUNTIME_STATE.md
+++ b/docs/current_runtime/CURRENT_RUNTIME_STATE.md
@@ -1,0 +1,85 @@
+# CURRENT_RUNTIME_STATE.md
+
+Auto-generated runtime snapshot. Do not edit manually.
+
+- Generated (UTC): 2026-03-04T05:42:00.148785+00:00
+- Audit status: **FAIL**
+- Execution gate enabled: True
+
+## Enabled capability IDs
+
+- [16, 17, 18, 19, 20, 21, 32]
+
+## Disabled capability IDs
+
+- [22, 48]
+
+## Capability table
+
+| id | name | enabled | status | risk_level | data_exfiltration |
+| --- | --- | --- | --- | --- | --- |
+| 16 | governed_web_search | True | active | low | True |
+| 17 | open_website | True | active | low | False |
+| 18 | speak_text | True | active | low | False |
+| 22 | open_file_folder | False | active | confirm | False |
+| 19 | volume_up_down | True | active | low | False |
+| 20 | media_play_pause | True | active | low | False |
+| 21 | brightness_control | True | active | low | False |
+| 32 | os_diagnostics | True | active | low | False |
+| 48 | multi_source_reporting | False | active | low | True |
+
+## Capability Governance Matrix
+
+| id | name | enabled | authority_class | confirmation_required | network_access | execution_layer |
+| --- | --- | --- | --- | --- | --- | --- |
+| 16 | governed_web_search | True | read_only | False | True | Governor → NetworkMediator |
+| 17 | open_website | True | system_action | False | False | Governor → Executor |
+| 18 | speak_text | True | speech_output | False | False | Governor → Speech |
+| 19 | volume_up_down | True | system_action | False | False | Governor → Executor |
+| 20 | media_play_pause | True | system_action | False | False | Governor → Executor |
+| 21 | brightness_control | True | system_action | False | False | Governor → Executor |
+| 22 | open_file_folder | False | confirm_required | True | False | Governor → Executor |
+| 32 | os_diagnostics | True | system_action | False | False | Governor → Executor |
+| 48 | multi_source_reporting | False | read_only | False | True | Governor → NetworkMediator |
+
+## Governor Enforcement Summary
+
+- single_action_queue_enforced: True
+- execution_timeout_guard_active: True
+- dns_rebinding_protection_active: True
+- ledger_logging_active: True
+- execution_gate_enabled: True
+
+## Network Surface Summary
+
+- Capabilities using NetworkMediator: [16, 48]
+- Direct LLM calls detected: deepseek_uses_ollama_chat_directly=True
+- Allowed_analysis_only surfaces: escalation_policy.ALLOW_ANALYSIS_ONLY=True
+
+## Skill → Capability Routing Map
+
+- brightness -> capability_id=21
+- diagnostics -> capability_id=32
+- media -> capability_id=20
+- open_folder -> capability_id=22
+- open_website -> capability_id=17
+- report -> capability_id=48
+- search -> capability_id=16
+- speak -> capability_id=18
+- volume -> capability_id=19
+
+## Runtime Fingerprint
+
+- git_commit_hash: 74e8f1bcd3fbbe5d99b88da4d4df76ca5e9c2ec6
+- generated_at_utc: 2026-03-04T05:42:00.177251+00:00
+- phase_marker: Phase-4 runtime active
+
+## Mediator mapped capability IDs
+
+- [16, 17, 18, 19, 20, 21, 22, 32, 48]
+
+## Runtime truth discrepancies
+
+- [hard_fail] ENABLED_ID_SET_MISMATCH: Enabled capability ID set differs between docs/current_runtime/CURRENT_RUNTIME_STATE.md and registry.json.
+- [warning] MEDIATOR_ROUTES_TO_DISABLED_CAPABILITY: Mediator routes include capabilities that are currently disabled in registry.
+- [warning] DIRECT_MODEL_CALL_BYPASS: DeepSeekBridge appears to call ollama.chat directly instead of a centralized LLM gateway.

--- a/docs/current_runtime/GOVERNANCE_MATRIX.md
+++ b/docs/current_runtime/GOVERNANCE_MATRIX.md
@@ -1,0 +1,22 @@
+# GOVERNANCE_MATRIX
+
+Deterministic capability governance matrix derived from allowlisted runtime sources.
+
+| id | name | enabled | status | phase_introduced | risk_level | data_exfiltration | authority_class | confirmation_required | network_access | execution_surface | execution_gate | single_action_queue | ledger_allowlist | dns_rebinding_guard | timeout_guard |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 16 | governed_web_search | True | active | 4 | low | True | read_only | False | True | Governor → NetworkMediator | True | True | True | True | True |
+| 17 | open_website | True | active | 4 | low | False | system_action | False | False | Governor → Executor | True | True | True | True | True |
+| 18 | speak_text | True | active | 4 | low | False | speech_output | False | False | Governor → Speech | True | True | True | True | True |
+| 19 | volume_up_down | True | active | 4 | low | False | system_action | False | False | Governor → Executor | True | True | True | True | True |
+| 20 | media_play_pause | True | active | 4 | low | False | system_action | False | False | Governor → Executor | True | True | True | True | True |
+| 21 | brightness_control | True | active | 4 | low | False | system_action | False | False | Governor → Executor | True | True | True | True | True |
+| 22 | open_file_folder | False | active | 4 | confirm | False | confirm_required | True | False | Governor → Executor | True | True | True | True | True |
+| 32 | os_diagnostics | True | active | 4 | low | False | system_action | False | False | Governor → Executor | True | True | True | True | True |
+| 48 | multi_source_reporting | False | active | 4 | low | True | read_only | False | True | Governor → NetworkMediator | True | True | True | True | True |
+
+## Derivation notes
+
+- authority_class derivation: `speech_output` for capability 18, `confirm_required` when risk_level is `confirm`, `read_only` for network-mediated/data-exfil surfaces, else `system_action`.
+- network_access is derived from Governor execution branches that pass `self.network` to an executor.
+- execution_gate/single_action_queue/dns_rebinding_guard/timeout_guard/ledger_allowlist are code-presence checks from allowlisted modules.
+- If a field cannot be proven from allowlisted runtime sources, value must be `unknown` (none currently unresolved under present code).

--- a/docs/current_runtime/RUNTIME_AUDIT_ANALYSIS.md
+++ b/docs/current_runtime/RUNTIME_AUDIT_ANALYSIS.md
@@ -1,0 +1,102 @@
+# Runtime Governance Audit Analysis (Phase 1)
+
+## Scope and method
+
+This Phase 1 audit is analysis-only and focuses on current runtime truth surfaces without changing execution behavior.
+
+Reviewed areas:
+- Capability registry and registry loader
+- Governor mediation and execution gate path
+- Network mediation enforcement
+- DeepSeek bridge and LLM invocation paths
+- Skill routing and skill registry behavior
+- Runtime auditor and runtime snapshot generation
+- Ledger writer and ledger call sites
+
+## A–J governance audit findings
+
+| Item | Finding | Evidence |
+| --- | --- | --- |
+| A) Capability definitions | Capabilities are defined in `nova_backend/src/config/registry.json` and validated/loaded by `CapabilityRegistry` (`src/governor/capability_registry.py`). Required fields currently include id, name, status, phase_introduced, risk_level, data_exfiltration, enabled. | `registry.json`, `capability_registry.py` |
+| B) Authority class representation | No explicit `authority_class` field exists in the runtime registry schema or `Capability` dataclass. Authority is implicit via risk level + invocation type. | `registry.json`, `capability_registry.py` |
+| C) Mediator route mapping | Natural-language route mapping is implemented in `GovernorMediator.parse_governed_invocation` with deterministic regex -> capability IDs (16/17/18/19/20/21/22/32/48). | `src/governor/governor_mediator.py` |
+| D) Execution gate enforcement | Global execution gate is `GOVERNED_ACTIONS_ENABLED` checked through `ExecuteBoundary.allow_execution()`, enforced in `Governor.handle_governed_invocation`. | `src/governor/execute_boundary/execute_boundary.py`, `src/governor/governor.py` |
+| E) NetworkMediator enforcement | Networked execution routes use governor-injected `NetworkMediator`; it enforces capability enabled check, rate limit, URL validation, DNS/private IP checks, timeout, and ledger logging. | `src/governor/network_mediator.py`, `src/governor/governor.py`, networked executors |
+| F) DeepSeekBridge LLM invocation | `DeepSeekBridge.analyze()` directly imports and calls `ollama.chat(...)` (model `phi3:mini`), not `LLMManager.generate()`. | `src/conversation/deepseek_bridge.py` |
+| G) Skills → capabilities mapping | No explicit runtime map currently exists. Governed capabilities are invoked by `GovernorMediator` path; non-governed skills in `SkillRegistry` use direct skill handlers. `GeneralChatSkill` can escalate to analysis-only DeepSeek path (non-capability). | `src/brain_server.py`, `src/skill_registry.py`, `src/skills/general_chat.py` |
+| H) Ledger logging locations | Ledger appends in `LedgerWriter.log_event`. Current runtime calls include governor action lifecycle events and network mediator success/failure events; model update events are in `LLMManager`. | `src/ledger/writer.py`, `src/governor/governor.py`, `src/governor/network_mediator.py`, `src/llm/llm_manager.py` |
+| I) Escalation policy runtime representation | Escalation policy exists in `EscalationPolicy` (thresholds + decisions `ALLOW_ANALYSIS_ONLY`/`DENY`/`ASK_USER`) and is used by `GeneralChatSkill`, but not surfaced in runtime snapshot markdown. | `src/conversation/escalation_policy.py`, `src/skills/general_chat.py`, `src/audit/runtime_auditor.py` |
+| J) Runtime fingerprint (commit hash) | No git commit hash is currently included in `CURRENT_RUNTIME_STATE.md`; snapshot currently includes generated timestamp + status fields only. | `src/audit/runtime_auditor.py` |
+
+## Existing runtime snapshot coverage
+
+Current snapshot generation (`write_current_runtime_state_snapshot`) includes:
+- generated timestamp
+- overall audit status
+- execution gate boolean
+- enabled/disabled capability ID lists
+- capability table (`id`, `name`, `enabled`, `status`, `risk_level`, `data_exfiltration`)
+- mediator mapped capability IDs
+- discrepancy list
+
+Current runtime-truth JSON audit includes:
+- registry/runtime-doc enabled set comparison
+- mediator mapped IDs from explicit probes
+- execution gate signal
+- model path signal (`deepseek_uses_ollama_chat_directly`)
+- discrepancies with warning/hard_fail levels
+
+## Missing governance visibility surfaces
+
+The following governance/introspection surfaces are currently missing from runtime snapshot output:
+- Capability Governance Matrix fields:
+  - explicit `authority_class`
+  - `confirmation_required`
+  - `network_access`
+  - explicit execution layer classification
+- Governor enforcement summary booleans (queue, timeout guard, DNS rebinding guard, ledger logging active, execution gate active)
+- Network surface summary:
+  - explicit capabilities that use `NetworkMediator`
+  - explicit direct LLM call detections in report body
+  - explicit `ALLOW_ANALYSIS_ONLY` surface listing
+- Deterministic skill/module → capability routing map
+- Runtime fingerprint:
+  - git commit hash
+  - phase marker
+
+## Current authority classification gaps
+
+- No first-class runtime `authority_class` metadata exists in registry schema or runtime markdown.
+- `risk_level` is not equivalent to authority class and does not encode speech-only vs execution vs analysis-only semantics.
+- Confirmation policy is partially implied (`risk_level == "confirm"`) but not emitted as a normalized runtime field.
+
+## Implicit bypass surfaces (observed)
+
+- `DeepSeekBridge` directly calls `ollama.chat` and bypasses centralized `LLMManager` path.
+- `GeneralChatSkill._run_local_model` also directly calls `ollama.chat` for local chat generation.
+- These are non-capability conversational paths and are not currently represented in runtime snapshot governance sections.
+
+## Nondeterministic path usage (observed)
+
+- Runtime snapshot generation uses real-time timestamps (`datetime.now(timezone.utc)`), expected but non-reproducible per run.
+- Network operations rely on live DNS resolution and outbound request outcomes in `NetworkMediator`.
+- Runtime audit route depends on presence/absence and content freshness of generated markdown file.
+
+## Confirmation: authority expansion status
+
+Audit conclusion: **no explicit authority expansion is detected** in current Phase-4 runtime implementation.
+
+Reasoning:
+- Governed action execution remains constrained to known capability IDs routed through `Governor.handle_governed_invocation` and registry-enabled checks.
+- No new capability IDs are introduced in current runtime code paths beyond those defined in registry.
+- Analysis-only escalation (`ALLOW_ANALYSIS_ONLY`) is conversational output and does not auto-execute governed capabilities.
+
+## Phase 2 implementation guidance (derived from audit)
+
+To satisfy required structural upgrade without behavior changes:
+1. Extend runtime snapshot rendering only, derived from current runtime truth.
+2. Add deterministic derived classification fields (authority/network/execution-layer) without editing capability logic.
+3. Add read-only runtime introspection helpers for governor/network/deepseek/skill routing surfaces.
+4. Add tests validating rendered sections and required detections.
+
+No runtime execution semantics should be changed for this upgrade.

--- a/docs/current_runtime/RUNTIME_FINGERPRINT.md
+++ b/docs/current_runtime/RUNTIME_FINGERPRINT.md
@@ -1,0 +1,9 @@
+# RUNTIME_FINGERPRINT
+
+- git_commit_hash: 74e8f1bcd3fbbe5d99b88da4d4df76ca5e9c2ec6
+- git_dirty: true
+- python_version: 3.10.19
+- platform: Linux-6.12.47-x86_64-with-glibc2.39
+- generated_at_utc: 2026-03-04T05:42:00.201780+00:00
+- enabled_capability_ids_hash: 6ecb1abda24a13189f4fec48ebd24d498463265690aeac3ed00600077ae3ddbc
+- phase_marker: Phase-4 runtime active

--- a/docs/current_runtime/SKILL_SURFACE_MAP.md
+++ b/docs/current_runtime/SKILL_SURFACE_MAP.md
@@ -1,0 +1,27 @@
+# SKILL_SURFACE_MAP
+
+Deterministic surface map for skills, conversation modules, and governor capability routes.
+
+| skill_or_surface | module | surface_type | network_usage | model_usage | capability_id |
+| --- | --- | --- | --- | --- | --- |
+| deepseek_bridge | src/conversation/deepseek_bridge.py | conversation | unknown | ollama_direct |  |
+| brightness | src/governor/governor_mediator.py | governor_capability | unknown | none | 21 |
+| diagnostics | src/governor/governor_mediator.py | governor_capability | unknown | none | 32 |
+| media | src/governor/governor_mediator.py | governor_capability | unknown | none | 20 |
+| open_folder | src/governor/governor_mediator.py | governor_capability | unknown | none | 22 |
+| open_website | src/governor/governor_mediator.py | governor_capability | unknown | none | 17 |
+| report | src/governor/governor_mediator.py | governor_capability | unknown | none | 48 |
+| search | src/governor/governor_mediator.py | governor_capability | unknown | none | 16 |
+| speak | src/governor/governor_mediator.py | governor_capability | unknown | none | 18 |
+| volume | src/governor/governor_mediator.py | governor_capability | unknown | none | 19 |
+| general_chat | src/skills/general_chat.py | skill | yes | ollama_direct |  |
+| news | src/skills/news.py | skill | yes | none |  |
+| news | src/skills/web_search.py | skill | no | none |  |
+| system | src/skills/system.py | skill | no | none |  |
+| weather | src/skills/weather.py | skill | yes | none |  |
+| web_search | src/skills/web_search_skill.py | skill | no | none |  |
+
+## Escalation vs governed execution
+
+- `ALLOW_ANALYSIS_ONLY` is represented in `src/conversation/escalation_policy.py` and used by `GeneralChatSkill` as analysis-only output path.
+- Governed capabilities are routed by `GovernorMediator.parse_governed_invocation(...)` and executed via `Governor.handle_governed_invocation(...)`.

--- a/nova_backend/src/audit/runtime_auditor.py
+++ b/nova_backend/src/audit/runtime_auditor.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import hashlib
 import json
+import platform
 import re
+import subprocess
+import sys
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -12,20 +16,52 @@ from src.governor.governor_mediator import GovernorMediator, Invocation
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
+RUNTIME_DOC_DIR = PROJECT_ROOT / "docs" / "current_runtime"
 REGISTRY_PATH = PROJECT_ROOT / "nova_backend" / "src" / "config" / "registry.json"
-RUNTIME_DOC_PATH = PROJECT_ROOT / "docs" / "current_runtime" / "CURRENT_RUNTIME_STATE.md"
+RUNTIME_DOC_PATH = RUNTIME_DOC_DIR / "CURRENT_RUNTIME_STATE.md"
 CANONICAL_RUNTIME_DOC_PATH = PROJECT_ROOT / "docs" / "CANONICAL" / "PHASE_4_RUNTIME_TRUTH.md"
 DEEPSEEK_BRIDGE_PATH = PROJECT_ROOT / "nova_backend" / "src" / "conversation" / "deepseek_bridge.py"
 LLM_MANAGER_PATH = PROJECT_ROOT / "nova_backend" / "src" / "llm" / "llm_manager.py"
+GOVERNOR_PATH = PROJECT_ROOT / "nova_backend" / "src" / "governor" / "governor.py"
+GOVERNOR_MEDIATOR_PATH = PROJECT_ROOT / "nova_backend" / "src" / "governor" / "governor_mediator.py"
+NETWORK_MEDIATOR_PATH = PROJECT_ROOT / "nova_backend" / "src" / "governor" / "network_mediator.py"
+SKILL_REGISTRY_PATH = PROJECT_ROOT / "nova_backend" / "src" / "skill_registry.py"
+LEDGER_WRITER_PATH = PROJECT_ROOT / "nova_backend" / "src" / "ledger" / "writer.py"
+LEDGER_EVENT_TYPES_PATH = PROJECT_ROOT / "nova_backend" / "src" / "ledger" / "event_types.py"
+ESCALATION_POLICY_PATH = PROJECT_ROOT / "nova_backend" / "src" / "conversation" / "escalation_policy.py"
 
-# Read-only allowlist for v1 auditor scope.
-ALLOWED_READ_PATHS = (
-    REGISTRY_PATH,
-    RUNTIME_DOC_PATH,
-    CANONICAL_RUNTIME_DOC_PATH,
-    DEEPSEEK_BRIDGE_PATH,
-    LLM_MANAGER_PATH,
-)
+GOVERNANCE_MATRIX_PATH = RUNTIME_DOC_DIR / "GOVERNANCE_MATRIX.md"
+SKILL_SURFACE_MAP_PATH = RUNTIME_DOC_DIR / "SKILL_SURFACE_MAP.md"
+BYPASS_SURFACES_PATH = RUNTIME_DOC_DIR / "BYPASS_SURFACES.md"
+RUNTIME_FINGERPRINT_PATH = RUNTIME_DOC_DIR / "RUNTIME_FINGERPRINT.md"
+
+SKILLS_DIR = PROJECT_ROOT / "nova_backend" / "src" / "skills"
+EXECUTORS_DIR = PROJECT_ROOT / "nova_backend" / "src" / "executors"
+CONVERSATION_DIR = PROJECT_ROOT / "nova_backend" / "src" / "conversation"
+
+
+def _build_allowlisted_paths() -> frozenset[Path]:
+    paths = {
+        REGISTRY_PATH,
+        RUNTIME_DOC_PATH,
+        CANONICAL_RUNTIME_DOC_PATH,
+        DEEPSEEK_BRIDGE_PATH,
+        LLM_MANAGER_PATH,
+        GOVERNOR_PATH,
+        GOVERNOR_MEDIATOR_PATH,
+        NETWORK_MEDIATOR_PATH,
+        SKILL_REGISTRY_PATH,
+        LEDGER_WRITER_PATH,
+        LEDGER_EVENT_TYPES_PATH,
+        ESCALATION_POLICY_PATH,
+    }
+    paths.update(SKILLS_DIR.glob("*.py"))
+    paths.update(EXECUTORS_DIR.glob("*.py"))
+    paths.update(CONVERSATION_DIR.glob("*.py"))
+    return frozenset(paths)
+
+
+ALLOWED_READ_PATHS = _build_allowlisted_paths()
 
 # Minimal explicit phrase probes used to map mediator surfaces.
 MEDIATOR_TRIGGER_PROBES: dict[str, str] = {
@@ -133,7 +169,7 @@ def _detect_direct_model_call_bypass() -> dict[str, Any]:
     llm_manager_src = _safe_read(LLM_MANAGER_PATH)
 
     return {
-        "deepseek_uses_ollama_chat_directly": "ollama.chat(" in deepseek_src,
+        "deepseek_uses_ollama_chat_directly": "ollama.chat" in deepseek_src,
         "llm_manager_generate_present": "def generate(" in llm_manager_src,
     }
 
@@ -144,6 +180,229 @@ def _derive_status(hard_fail_count: int, warning_count: int) -> str:
     if warning_count > 0:
         return "warn"
     return "pass"
+
+
+def _governor_enforcement_summary() -> dict[str, bool]:
+    governor_src = _safe_read(GOVERNOR_PATH)
+    network_src = _safe_read(NETWORK_MEDIATOR_PATH)
+    ledger_src = _safe_read(LEDGER_WRITER_PATH)
+
+    return {
+        "single_action_queue_enforced": "SingleActionQueue" in governor_src and "has_pending" in governor_src,
+        "execution_timeout_guard_active": "MAX_EXECUTION_TIME" in governor_src,
+        "dns_rebinding_protection_active": "socket.getaddrinfo" in network_src,
+        "ledger_logging_active": "log_event(" in governor_src or "log_event(" in network_src,
+        "execution_gate_enabled": bool(GOVERNED_ACTIONS_ENABLED),
+    }
+
+
+def _network_mediated_capability_ids(governor_source: str) -> list[int]:
+    mediated: set[int] = set()
+    current_cap: int | None = None
+    for line in governor_source.splitlines():
+        cap_match = re.search(r"req\.capability_id\s*==\s*(\d+)", line)
+        if cap_match:
+            current_cap = int(cap_match.group(1))
+            continue
+        if current_cap is not None and "self.network" in line:
+            mediated.add(current_cap)
+    return sorted(mediated)
+
+
+def _derive_capability_governance_rows(registry: dict[str, Any]) -> list[dict[str, Any]]:
+    governor_src = _safe_read(GOVERNOR_PATH)
+    mediated_ids = set(_network_mediated_capability_ids(governor_src))
+    enforce = _governor_enforcement_summary()
+
+    rows: list[dict[str, Any]] = []
+    for capability in registry.get("capabilities", []):
+        cid = int(capability.get("id", -1))
+        risk_level = str(capability.get("risk_level", ""))
+        confirmation_required = risk_level == "confirm"
+        network_access = cid in mediated_ids
+
+        if cid == 18:
+            authority_class = "speech_output"
+            execution_surface = "Governor → Speech"
+        elif confirmation_required:
+            authority_class = "confirm_required"
+            execution_surface = "Governor → Executor"
+        elif network_access:
+            authority_class = "read_only"
+            execution_surface = "Governor → NetworkMediator"
+        elif capability.get("data_exfiltration") is True:
+            authority_class = "read_only"
+            execution_surface = "Governor → Executor"
+        else:
+            authority_class = "system_action"
+            execution_surface = "Governor → Executor"
+
+        rows.append(
+            {
+                "id": cid,
+                "name": capability.get("name", ""),
+                "enabled": bool(capability.get("enabled", False)),
+                "status": capability.get("status", ""),
+                "phase_introduced": capability.get("phase_introduced", ""),
+                "risk_level": risk_level,
+                "data_exfiltration": bool(capability.get("data_exfiltration", False)),
+                "authority_class": authority_class,
+                "confirmation_required": confirmation_required,
+                "network_access": network_access,
+                "execution_surface": execution_surface,
+                "execution_gate": enforce["execution_gate_enabled"],
+                "single_action_queue": enforce["single_action_queue_enforced"],
+                "ledger_allowlist": "event_type not in EVENT_TYPES" in _safe_read(LEDGER_WRITER_PATH),
+                "dns_rebinding_guard": enforce["dns_rebinding_protection_active"],
+                "timeout_guard": enforce["execution_timeout_guard_active"],
+            }
+        )
+
+    return sorted(rows, key=lambda r: r["id"])
+
+
+def _skill_surface_rows() -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+
+    for path in sorted(SKILLS_DIR.glob("*.py")):
+        src = _safe_read(path)
+        if not src.strip() or path.name == "__init__.py":
+            continue
+        name_match = re.search(r'^\s*name\s*=\s*"([^"]+)"', src, re.MULTILINE)
+        skill_name = name_match.group(1) if name_match else path.stem
+        network_usage = "yes" if ("NetworkMediator" in src or "self.network" in src) else "no"
+        if "ollama.chat" in src:
+            model_usage = "ollama_direct"
+        elif "LLMManager" in src or "llm_manager" in src:
+            model_usage = "manager"
+        else:
+            model_usage = "none"
+        rows.append(
+            {
+                "name": skill_name,
+                "module": f"src/skills/{path.name}",
+                "surface_type": "skill",
+                "network_usage": network_usage,
+                "model_usage": model_usage,
+            }
+        )
+
+    deepseek_src = _safe_read(DEEPSEEK_BRIDGE_PATH)
+    rows.append(
+        {
+            "name": "deepseek_bridge",
+            "module": "src/conversation/deepseek_bridge.py",
+            "surface_type": "conversation",
+            "network_usage": "unknown",
+            "model_usage": "ollama_direct" if "ollama.chat" in deepseek_src else "none",
+        }
+    )
+
+    mediator_map = _mediator_surface_map()
+    for probe in mediator_map["probes"]:
+        if probe["capability_id"] is None:
+            continue
+        rows.append(
+            {
+                "name": probe["group"],
+                "module": "src/governor/governor_mediator.py",
+                "surface_type": "governor_capability",
+                "network_usage": "unknown",
+                "model_usage": "none",
+                "capability_id": str(probe["capability_id"]),
+            }
+        )
+
+    dedup = {(r.get("name"), r.get("module"), r.get("surface_type")): r for r in rows}
+    return sorted(dedup.values(), key=lambda r: (r.get("surface_type", ""), r.get("name", "")))
+
+
+def _find_direct_ollama_calls_outside_manager() -> list[str]:
+    offenders: list[str] = []
+    for path in sorted(ALLOWED_READ_PATHS):
+        if path.suffix != ".py":
+            continue
+        rel = path.relative_to(PROJECT_ROOT)
+        if rel.as_posix() in {"nova_backend/src/llm/llm_manager.py", "nova_backend/src/llm/llm_manager_vlock.py"}:
+            continue
+        src = _safe_read(path)
+        if "ollama.chat" in src:
+            offenders.append(rel.as_posix())
+    return offenders
+
+
+def _find_requests_usage_outside_network_mediator() -> list[str]:
+    offenders: list[str] = []
+    allowed_requests_users = {
+        "nova_backend/src/governor/network_mediator.py",
+        "nova_backend/src/llm/llm_manager.py",
+        "nova_backend/src/llm/llm_manager_vlock.py",
+    }
+    for path in sorted(ALLOWED_READ_PATHS):
+        if path.suffix != ".py":
+            continue
+        rel = path.relative_to(PROJECT_ROOT).as_posix()
+        src = _safe_read(path)
+        if "import requests" in src or "requests." in src:
+            if rel not in allowed_requests_users:
+                offenders.append(rel)
+    return offenders
+
+
+def _executor_paths_outside_governor() -> list[str]:
+    paths: list[str] = []
+    for path in sorted(EXECUTORS_DIR.glob("*.py")):
+        if path.name == "__init__.py":
+            continue
+        paths.append(path.relative_to(PROJECT_ROOT).as_posix())
+    return paths
+
+
+def _runtime_fingerprint(registry_enabled_ids: list[int]) -> dict[str, str]:
+    commit_hash = "unknown"
+    dirty = "unknown"
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        commit_hash = result.stdout.strip() or "unknown"
+    except Exception:
+        commit_hash = "unknown"
+
+    try:
+        status = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        dirty = "true" if status.stdout.strip() else "false"
+    except Exception:
+        dirty = "unknown"
+
+    enabled_hash = hashlib.sha256(json.dumps(registry_enabled_ids, sort_keys=True).encode("utf-8")).hexdigest()
+
+    return {
+        "git_commit_hash": commit_hash,
+        "git_dirty": dirty,
+        "python_version": sys.version.split()[0],
+        "platform": platform.platform(),
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "enabled_capability_ids_hash": enabled_hash,
+        "phase_marker": "Phase-4 runtime active",
+    }
+
+
+def _path_for_report(path: Path) -> str:
+    try:
+        return str(path.relative_to(PROJECT_ROOT))
+    except Exception:
+        return str(path)
 
 
 def _build_discrepancies(
@@ -212,7 +471,7 @@ def _build_discrepancies(
                 severity="warning",
                 code="RUNTIME_DOC_MISSING",
                 message="docs/current_runtime/CURRENT_RUNTIME_STATE.md is missing.",
-                details={"path": str(RUNTIME_DOC_PATH.relative_to(PROJECT_ROOT))},
+                details={"path": _path_for_report(RUNTIME_DOC_PATH)},
             )
         )
 
@@ -222,7 +481,7 @@ def _build_discrepancies(
                 severity="warning",
                 code="DIRECT_MODEL_CALL_BYPASS",
                 message="DeepSeekBridge appears to call ollama.chat directly instead of a centralized LLM gateway.",
-                details={"path": str(DEEPSEEK_BRIDGE_PATH.relative_to(PROJECT_ROOT))},
+                details={"path": _path_for_report(DEEPSEEK_BRIDGE_PATH)},
             )
         )
 
@@ -267,10 +526,10 @@ def run_runtime_truth_audit() -> dict[str, Any]:
             "execution_gate_enabled": execution_gate_enabled,
         },
         "inputs": {
-            "allowlisted_paths": [str(path.relative_to(PROJECT_ROOT)) for path in ALLOWED_READ_PATHS],
-            "registry_path": str(REGISTRY_PATH.relative_to(PROJECT_ROOT)),
-            "runtime_doc_path": str(RUNTIME_DOC_PATH.relative_to(PROJECT_ROOT)),
-            "canonical_runtime_doc_path": str(CANONICAL_RUNTIME_DOC_PATH.relative_to(PROJECT_ROOT)),
+            "allowlisted_paths": [_path_for_report(path) for path in sorted(ALLOWED_READ_PATHS)],
+            "registry_path": _path_for_report(REGISTRY_PATH),
+            "runtime_doc_path": _path_for_report(RUNTIME_DOC_PATH),
+            "canonical_runtime_doc_path": _path_for_report(CANONICAL_RUNTIME_DOC_PATH),
         },
         "checks": {
             "model_path_signals": model_signals,
@@ -316,6 +575,115 @@ def render_runtime_truth_markdown(report: dict[str, Any]) -> str:
     return "\n".join(lines).strip() + "\n"
 
 
+def render_governance_matrix_markdown(registry: dict[str, Any]) -> str:
+    rows = _derive_capability_governance_rows(registry)
+    lines = [
+        "# GOVERNANCE_MATRIX",
+        "",
+        "Deterministic capability governance matrix derived from allowlisted runtime sources.",
+        "",
+        "| id | name | enabled | status | phase_introduced | risk_level | data_exfiltration | authority_class | confirmation_required | network_access | execution_surface | execution_gate | single_action_queue | ledger_allowlist | dns_rebinding_guard | timeout_guard |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for row in rows:
+        lines.append(
+            "| {id} | {name} | {enabled} | {status} | {phase_introduced} | {risk_level} | {data_exfiltration} | {authority_class} | {confirmation_required} | {network_access} | {execution_surface} | {execution_gate} | {single_action_queue} | {ledger_allowlist} | {dns_rebinding_guard} | {timeout_guard} |".format(
+                **row
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Derivation notes",
+            "",
+            "- authority_class derivation: `speech_output` for capability 18, `confirm_required` when risk_level is `confirm`, `read_only` for network-mediated/data-exfil surfaces, else `system_action`.",
+            "- network_access is derived from Governor execution branches that pass `self.network` to an executor.",
+            "- execution_gate/single_action_queue/dns_rebinding_guard/timeout_guard/ledger_allowlist are code-presence checks from allowlisted modules.",
+            "- If a field cannot be proven from allowlisted runtime sources, value must be `unknown` (none currently unresolved under present code).",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def render_skill_surface_map_markdown() -> str:
+    rows = _skill_surface_rows()
+    lines = [
+        "# SKILL_SURFACE_MAP",
+        "",
+        "Deterministic surface map for skills, conversation modules, and governor capability routes.",
+        "",
+        "| skill_or_surface | module | surface_type | network_usage | model_usage | capability_id |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    for row in rows:
+        lines.append(
+            f"| {row.get('name', '')} | {row.get('module', '')} | {row.get('surface_type', '')} | {row.get('network_usage', 'unknown')} | {row.get('model_usage', 'unknown')} | {row.get('capability_id', '')} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Escalation vs governed execution",
+            "",
+            "- `ALLOW_ANALYSIS_ONLY` is represented in `src/conversation/escalation_policy.py` and used by `GeneralChatSkill` as analysis-only output path.",
+            "- Governed capabilities are routed by `GovernorMediator.parse_governed_invocation(...)` and executed via `Governor.handle_governed_invocation(...)`.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def render_bypass_surfaces_markdown() -> str:
+    ollama_offenders = _find_direct_ollama_calls_outside_manager()
+    requests_offenders = _find_requests_usage_outside_network_mediator()
+    executor_surfaces = _executor_paths_outside_governor()
+
+    lines = [
+        "# BYPASS_SURFACES",
+        "",
+        "Read-only truth report of detectable bypass indicators from allowlisted runtime sources.",
+        "",
+        "## Direct ollama.chat outside llm_manager",
+        "",
+    ]
+
+    if ollama_offenders:
+        lines.extend(f"- {path}" for path in ollama_offenders)
+    else:
+        lines.append("- None detected.")
+
+    lines.extend(["", "## requests/network usage outside NetworkMediator", ""])
+    if requests_offenders:
+        lines.extend(f"- {path}" for path in requests_offenders)
+    else:
+        lines.append("- None detected.")
+
+    lines.extend(["", "## Executor callable paths outside governor", ""])
+    lines.append("- Architectural constraint: executors exist as importable callables, but governed runtime routes execution through Governor branches.")
+    lines.extend(f"- {path}" for path in executor_surfaces)
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_runtime_fingerprint_markdown(registry_enabled_ids: list[int]) -> str:
+    fp = _runtime_fingerprint(registry_enabled_ids)
+    lines = [
+        "# RUNTIME_FINGERPRINT",
+        "",
+        f"- git_commit_hash: {fp['git_commit_hash']}",
+        f"- git_dirty: {fp['git_dirty']}",
+        f"- python_version: {fp['python_version']}",
+        f"- platform: {fp['platform']}",
+        f"- generated_at_utc: {fp['generated_at_utc']}",
+        f"- enabled_capability_ids_hash: {fp['enabled_capability_ids_hash']}",
+        f"- phase_marker: {fp['phase_marker']}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
 def render_current_runtime_state_markdown(report: dict[str, Any], registry: dict[str, Any]) -> str:
     summary = report.get("summary", {})
     generated_at = report.get("generated_at_utc", "")
@@ -323,6 +691,13 @@ def render_current_runtime_state_markdown(report: dict[str, Any], registry: dict
     capabilities = registry.get("capabilities", [])
     enabled_ids = [int(item["id"]) for item in capabilities if item.get("enabled") is True]
     disabled_ids = [int(item["id"]) for item in capabilities if item.get("enabled") is not True]
+
+    governance_rows = _derive_capability_governance_rows(registry)
+    enforcement = _governor_enforcement_summary()
+    model_signals = report.get("checks", {}).get("model_path_signals", {})
+    network_caps = sorted({row["id"] for row in governance_rows if row["network_access"] is True})
+    skill_rows = [r for r in _skill_surface_rows() if r.get("surface_type") == "governor_capability" and r.get("capability_id")]
+    fingerprint = _runtime_fingerprint(sorted(enabled_ids))
 
     lines = [
         "# CURRENT_RUNTIME_STATE.md",
@@ -362,6 +737,51 @@ def render_current_runtime_state_markdown(report: dict[str, Any], registry: dict
     lines.extend(
         [
             "",
+            "## Capability Governance Matrix",
+            "",
+            "| id | name | enabled | authority_class | confirmation_required | network_access | execution_layer |",
+            "| --- | --- | --- | --- | --- | --- | --- |",
+        ]
+    )
+    for row in governance_rows:
+        lines.append(
+            f"| {row['id']} | {row['name']} | {row['enabled']} | {row['authority_class']} | {row['confirmation_required']} | {row['network_access']} | {row['execution_surface']} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Governor Enforcement Summary",
+            "",
+            f"- single_action_queue_enforced: {enforcement['single_action_queue_enforced']}",
+            f"- execution_timeout_guard_active: {enforcement['execution_timeout_guard_active']}",
+            f"- dns_rebinding_protection_active: {enforcement['dns_rebinding_protection_active']}",
+            f"- ledger_logging_active: {enforcement['ledger_logging_active']}",
+            f"- execution_gate_enabled: {enforcement['execution_gate_enabled']}",
+            "",
+            "## Network Surface Summary",
+            "",
+            f"- Capabilities using NetworkMediator: {network_caps}",
+            f"- Direct LLM calls detected: deepseek_uses_ollama_chat_directly={model_signals.get('deepseek_uses_ollama_chat_directly', False)}",
+            f"- Allowed_analysis_only surfaces: escalation_policy.ALLOW_ANALYSIS_ONLY={('ALLOW_ANALYSIS_ONLY' in _safe_read(ESCALATION_POLICY_PATH))}",
+            "",
+            "## Skill → Capability Routing Map",
+            "",
+        ]
+    )
+
+    for row in skill_rows:
+        lines.append(f"- {row['name']} -> capability_id={row['capability_id']}")
+
+    lines.extend(
+        [
+            "",
+            "## Runtime Fingerprint",
+            "",
+            f"- git_commit_hash: {fingerprint['git_commit_hash']}",
+            f"- generated_at_utc: {fingerprint['generated_at_utc']}",
+            f"- phase_marker: {fingerprint['phase_marker']}",
+            "",
             "## Mediator mapped capability IDs",
             "",
             f"- {summary.get('mediator_mapped_capability_ids', [])}",
@@ -383,6 +803,25 @@ def render_current_runtime_state_markdown(report: dict[str, Any], registry: dict
     return "\n".join(lines).strip() + "\n"
 
 
+def write_runtime_governance_docs() -> dict[str, Path]:
+    registry = _load_registry()
+    enabled_ids = _enabled_registry_ids(registry)
+
+    RUNTIME_DOC_DIR.mkdir(parents=True, exist_ok=True)
+
+    GOVERNANCE_MATRIX_PATH.write_text(render_governance_matrix_markdown(registry), encoding="utf-8")
+    SKILL_SURFACE_MAP_PATH.write_text(render_skill_surface_map_markdown(), encoding="utf-8")
+    BYPASS_SURFACES_PATH.write_text(render_bypass_surfaces_markdown(), encoding="utf-8")
+    RUNTIME_FINGERPRINT_PATH.write_text(render_runtime_fingerprint_markdown(enabled_ids), encoding="utf-8")
+
+    return {
+        "governance_matrix": GOVERNANCE_MATRIX_PATH.resolve(),
+        "skill_surface_map": SKILL_SURFACE_MAP_PATH.resolve(),
+        "bypass_surfaces": BYPASS_SURFACES_PATH.resolve(),
+        "runtime_fingerprint": RUNTIME_FINGERPRINT_PATH.resolve(),
+    }
+
+
 def write_current_runtime_state_snapshot(path: Path = RUNTIME_DOC_PATH) -> Path:
     report = run_runtime_truth_audit()
     registry = _load_registry()
@@ -390,4 +829,8 @@ def write_current_runtime_state_snapshot(path: Path = RUNTIME_DOC_PATH) -> Path:
 
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(markdown, encoding="utf-8")
+
+    # Companion governance docs for read-only introspection.
+    write_runtime_governance_docs()
+
     return path.resolve()

--- a/nova_backend/tests/test_runtime_governance_docs.py
+++ b/nova_backend/tests/test_runtime_governance_docs.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+
+from src.audit import runtime_auditor as ra
+
+
+def test_current_runtime_state_path_is_docs_current_runtime():
+    assert ra.RUNTIME_DOC_PATH.as_posix().endswith("docs/current_runtime/CURRENT_RUNTIME_STATE.md")
+
+
+def test_governance_docs_generation(tmp_path, monkeypatch):
+    runtime_dir = tmp_path / "docs" / "current_runtime"
+    monkeypatch.setattr(ra, "RUNTIME_DOC_DIR", runtime_dir)
+    monkeypatch.setattr(ra, "RUNTIME_DOC_PATH", runtime_dir / "CURRENT_RUNTIME_STATE.md")
+    monkeypatch.setattr(ra, "GOVERNANCE_MATRIX_PATH", runtime_dir / "GOVERNANCE_MATRIX.md")
+    monkeypatch.setattr(ra, "SKILL_SURFACE_MAP_PATH", runtime_dir / "SKILL_SURFACE_MAP.md")
+    monkeypatch.setattr(ra, "BYPASS_SURFACES_PATH", runtime_dir / "BYPASS_SURFACES.md")
+    monkeypatch.setattr(ra, "RUNTIME_FINGERPRINT_PATH", runtime_dir / "RUNTIME_FINGERPRINT.md")
+    monkeypatch.setattr(ra, "ALLOWED_READ_PATHS", set(ra.ALLOWED_READ_PATHS) | {ra.RUNTIME_DOC_PATH})
+
+    out = ra.write_current_runtime_state_snapshot(path=ra.RUNTIME_DOC_PATH)
+
+    assert out == ra.RUNTIME_DOC_PATH.resolve()
+    assert runtime_dir.exists()
+
+    files = {
+        "CURRENT_RUNTIME_STATE.md": "# CURRENT_RUNTIME_STATE.md",
+        "GOVERNANCE_MATRIX.md": "# GOVERNANCE_MATRIX",
+        "SKILL_SURFACE_MAP.md": "# SKILL_SURFACE_MAP",
+        "BYPASS_SURFACES.md": "# BYPASS_SURFACES",
+        "RUNTIME_FINGERPRINT.md": "# RUNTIME_FINGERPRINT",
+    }
+
+    for name, anchor in files.items():
+        content = (runtime_dir / name).read_text(encoding="utf-8")
+        assert anchor in content
+
+
+def test_current_runtime_state_includes_required_sections():
+    report = ra.run_runtime_truth_audit()
+    registry = ra._load_registry()
+    md = ra.render_current_runtime_state_markdown(report, registry)
+
+    assert "## Capability Governance Matrix" in md
+    assert "## Governor Enforcement Summary" in md
+    assert "## Network Surface Summary" in md
+    assert "## Skill → Capability Routing Map" in md
+    assert "## Runtime Fingerprint" in md
+
+    # Required checks
+    assert "Capabilities using NetworkMediator: [16" in md
+    assert "deepseek_uses_ollama_chat_directly=True" in md
+
+    # authority_class appears for each capability row
+    row_count = md.count("| ")
+    assert "authority_class" in md
+    assert len(registry.get("capabilities", [])) >= 1
+
+
+def test_derived_fields_do_not_crash_with_missing_optional_reads(monkeypatch):
+    registry = {"capabilities": [{"id": 999, "name": "x", "enabled": True, "status": "active", "phase_introduced": "4", "risk_level": "low", "data_exfiltration": False}]}
+
+    real_safe_read = ra._safe_read
+
+    def fake_safe_read(path: Path) -> str:
+        if path in {ra.GOVERNOR_PATH, ra.NETWORK_MEDIATOR_PATH, ra.LEDGER_WRITER_PATH}:
+            return ""
+        return real_safe_read(path)
+
+    monkeypatch.setattr(ra, "_safe_read", fake_safe_read)
+    rows = ra._derive_capability_governance_rows(registry)
+
+    assert len(rows) == 1
+    assert "authority_class" in rows[0]
+    assert rows[0]["execution_surface"] in {"Governor → Executor", "Governor → Speech", "Governor → NetworkMediator"}


### PR DESCRIPTION
### Motivation

- Provide richer, read-only runtime governance introspection without changing execution behavior by extending the runtime auditor to emit deterministic governance artifacts and detectable bypass signals.
- Surface derived classifications (authority/network/execution-layer), governor enforcement booleans, skill→capability routing, direct model-call and network bypass indicators, and a reproducible runtime fingerprint for auditing and drift detection.

### Description

- Extended `src/audit/runtime_auditor.py` to build an allowlisted path set, derive capability governance rows, detect direct `ollama.chat` and `requests` usage outside central mediators, compute a runtime fingerprint, and render multiple governance markdown artifacts. 
- Added renderers and writers for companion docs: `GOVERNANCE_MATRIX.md`, `SKILL_SURFACE_MAP.md`, `BYPASS_SURFACES.md`, and `RUNTIME_FINGERPRINT.md` under `docs/current_runtime`, and wired `write_runtime_governance_docs()` into `write_current_runtime_state_snapshot()` to emit them alongside `CURRENT_RUNTIME_STATE.md`.
- Improved discrepancy reporting and path formatting, added helper probes that map mediator triggers to capability IDs, and derived enforcement summary booleans from allowlisted source checks.
- Added generated example docs (in `docs/current_runtime/`) and a new unit test file `nova_backend/tests/test_runtime_governance_docs.py` that validates doc generation, required sections, and derived-field behavior when optional reads are missing.

### Testing

- Added unit tests in `nova_backend/tests/test_runtime_governance_docs.py` and ran them with `pytest`; the new tests executed and passed.
- Generated the governance docs via `write_current_runtime_state_snapshot()` in tests to validate that `GOVERNANCE_MATRIX.md`, `SKILL_SURFACE_MAP.md`, `BYPASS_SURFACES.md`, and `RUNTIME_FINGERPRINT.md` are created and contain expected anchors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7c20730708326bb0d8d4040a6657a)