### PR TITLE
Phase 4.2 experience refinement for conversation and speech output

### DIFF
--- a/nova_backend/src/brain_server.py
+++ b/nova_backend/src/brain_server.py
@@ -31,6 +31,7 @@ from src.conversation.response_style_router import InputNormalizer
 from src.voice.stt_pipeline import STTAckConfig, build_ack_payload
 from src.voice.tts_engine import resolve_speakable_text, nova_speak, stop_speaking
 from src.conversation.clarify_prompts import CLARIFY_PROMPTS
+from src.conversation.response_formatter import ResponseFormatter
 from src.audit.runtime_auditor import (
     run_runtime_truth_audit,
     render_runtime_truth_markdown,
@@ -82,6 +83,7 @@ app.include_router(stt_router)
 # -------------------------------------------------
 thought_store = ThoughtStore(ttl=300)
 conversation_heuristics = ComplexityHeuristics()
+response_formatter = ResponseFormatter()
 
 # -------------------------------------------------
 # Security Constants
@@ -411,6 +413,15 @@ async def websocket_endpoint(ws: WebSocket):
                 message = getattr(skill_result, "message", "") or ""
                 widget_data = getattr(skill_result, "widget_data", None)
                 result_data = getattr(skill_result, "data", {}) or {}
+
+                payload = response_formatter.format_payload(
+                    message,
+                    speakable_text=(result_data.get("speakable_text") or ""),
+                    structured_data=(result_data.get("structured_data") or {}),
+                )
+                message = payload["user_message"]
+                result_data["speakable_text"] = payload["speakable_text"]
+                result_data["structured_data"] = payload["structured_data"]
 
                 speech_state.last_spoken_text = message
                 session_state["last_response"] = message

--- a/nova_backend/src/conversation/clarify_prompts.py
+++ b/nova_backend/src/conversation/clarify_prompts.py
@@ -1,14 +1,14 @@
 """Deterministic clarification prompt bank for conversational UX polish."""
 
 CLARIFY_PROMPTS = {
-    "brief_or_deep": "Would you like a brief answer or a deeper breakdown?",
-    "high_level_or_detail": "Do you want a high-level comparison or implementation detail?",
-    "concept_or_steps": "Should I stay conceptual, or break this into concrete steps?",
-    "broad_or_narrow": "Do you want broad ideas or a narrower direction?",
+    "brief_or_deep": "Would you like a brief answer or a deeper one?",
+    "high_level_or_detail": "Would you like the high-level view or the detailed version?",
+    "concept_or_steps": "Would you like the concept or the concrete steps?",
+    "broad_or_narrow": "Would you like broad options or a narrower direction?",
     "system_status_check": "Do you want a system status check?",
     "confirm_search_query": "Did you mean this as a web search?",
     "confirm_location_ann_arbor": "Did you mean food in Ann Arbor, Michigan?",
-    "search_target": "What would you like me to search for?",
+    "search_target": "Which website would you like?",
     "single_turn_yes_no": "Please answer yes or no.",
     "ready_prompt": "I'm here when you're ready.",
 }

--- a/nova_backend/src/conversation/deepseek_bridge.py
+++ b/nova_backend/src/conversation/deepseek_bridge.py
@@ -25,4 +25,4 @@ class DeepSeekBridge:
         if response:
             return response
         logger.error("Analysis call failed via centralized gateway.")
-        return "I can provide a structured analysis, but the analysis model is currently unavailable."
+        return "I can provide structured analysis, but it is currently unavailable."

--- a/nova_backend/src/conversation/response_formatter.py
+++ b/nova_backend/src/conversation/response_formatter.py
@@ -1,4 +1,5 @@
 import re
+from typing import Any
 
 from src.conversation.clarify_prompts import CLARIFY_PROMPTS
 
@@ -11,25 +12,66 @@ class ResponseFormatter:
         "brainstorming": CLARIFY_PROMPTS["broad_or_narrow"],
     }
 
-    DEPTH_PROMPTS = {
-        "casual": "If useful, I can break that into clear steps.",
-        "analytical": "If useful, I can go deeper on tradeoffs and assumptions.",
-        "implementation": "If useful, I can map this into an implementation sequence.",
-        "brainstorming": "If useful, I can branch this into neutral options.",
+    ACK_REPLACEMENTS = {
+        "operation completed": "That's done.",
+        "task executed": "Completed.",
+        "execution successful": "Completed.",
+        "volume increased": "Volume up.",
+        "volume decreased": "Volume down.",
+        "media paused successfully": "Paused.",
+        "the brightness has been adjusted": "Brightness adjusted.",
+        "current weather retrieved": "Here's the current weather.",
+        "here are the results": "Here's what I found.",
     }
+
+    URL_PATTERN = re.compile(r"https?://\S+", re.IGNORECASE)
+    PATH_PATTERN = re.compile(r"(?:\b[A-Za-z]:\\[^\s]+|/(?:[^\s/]+/)+[^\s]*)")
 
     @staticmethod
     def format(text: str, mode: str = "casual") -> str:
-        clean = (text or "").strip()
-        clean = re.sub(r"\s+", " ", clean)
+        clean = (text or "").strip().replace("\r\n", "\n")
+        clean = re.sub(r"[ \t]+", " ", clean)
+        clean = re.sub(r"\n{3,}", "\n\n", clean)
         clean = re.sub(r"!+", ".", clean)
         clean = re.sub(r"([.!?])([A-Z])", r"\1 \2", clean)
 
         for filler in [r"\bwell\b", r"\bso\b", r"\byou see\b", r"\blet me think\b"]:
             clean = re.sub(filler, "", clean, flags=re.IGNORECASE)
 
+        clean = ResponseFormatter._apply_ack_replacements(clean)
         clean = ResponseFormatter._tone_shape(clean, mode)
-        return re.sub(r"\s{2,}", " ", clean).strip()
+        clean = re.sub(r"[ \t]{2,}", " ", clean).strip()
+        return clean.strip()
+
+    @classmethod
+    def format_payload(
+        cls,
+        message: str,
+        *,
+        mode: str = "casual",
+        speakable_text: str = "",
+        structured_data: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        user_message = cls.format(message, mode=mode)
+        data = dict(structured_data or {})
+        data.setdefault("structured_data", structured_data or {})
+
+        if cls._needs_executive_summary(user_message):
+            executive = cls._build_executive_summary(user_message)
+            if executive:
+                user_message = f"{executive}\n\n{user_message}" if executive.lower() not in user_message.lower() else user_message
+
+        raw_speakable = (speakable_text or user_message).strip()
+        data["speakable_text"] = cls.to_speakable_text(raw_speakable)
+        return {"user_message": user_message, "speakable_text": data["speakable_text"], "structured_data": data.get("structured_data", {}), "data": data}
+
+    @staticmethod
+    def to_speakable_text(text: str) -> str:
+        clean = ResponseFormatter.format(text)
+        clean = ResponseFormatter.URL_PATTERN.sub("I have opened the link", clean)
+        clean = ResponseFormatter.PATH_PATTERN.sub("the selected file", clean)
+        clean = re.sub(r"\s+", " ", clean).strip()
+        return clean
 
     @staticmethod
     def with_conversational_initiative(
@@ -45,11 +87,8 @@ class ResponseFormatter:
         if allow_clarification:
             add_ons.append(ResponseFormatter.CLARIFICATION_TEMPLATES.get(mode, ResponseFormatter.CLARIFICATION_TEMPLATES["casual"]))
 
-        if allow_depth_prompt:
-            add_ons.append(ResponseFormatter.DEPTH_PROMPTS.get(mode, ResponseFormatter.DEPTH_PROMPTS["casual"]))
-
-        if allow_branch_suggestion and mode in {"brainstorming", "analytical"}:
-            add_ons.append("I can present this as options or a direct recommendation.")
+        _ = allow_depth_prompt
+        _ = allow_branch_suggestion
 
         if add_ons:
             text = f"{text}\n\n" + "\n".join(add_ons[:1])
@@ -63,3 +102,28 @@ class ResponseFormatter:
         if mode == "implementation" and "\n" not in text and ". " in text:
             return text.replace(". ", ".\n")
         return text
+
+    @classmethod
+    def _apply_ack_replacements(cls, text: str) -> str:
+        out = text
+        for old, new in cls.ACK_REPLACEMENTS.items():
+            out = re.sub(rf"\b{re.escape(old)}\b", new, out, flags=re.IGNORECASE)
+        return out
+
+    @staticmethod
+    def _needs_executive_summary(text: str) -> bool:
+        if "\n" in text:
+            return True
+        sentence_count = len([s for s in re.split(r"(?<=[.!?])\s+", text) if s.strip()])
+        return sentence_count >= 4
+
+    @staticmethod
+    def _build_executive_summary(text: str) -> str:
+        lines = [line.strip(" -•") for line in text.splitlines() if line.strip()]
+        if not lines:
+            return ""
+        first = lines[0]
+        first = re.sub(r"\s+", " ", first).strip()
+        if len(first) > 120:
+            first = first[:117].rstrip() + "..."
+        return f"Summary: {first}"

--- a/nova_backend/src/rendering/speech_formatter.py
+++ b/nova_backend/src/rendering/speech_formatter.py
@@ -16,10 +16,14 @@ class SpeechFormatter:
         if not clean:
             return ""
 
+        clean = re.sub(r"https?://\S+", "the link", clean, flags=re.IGNORECASE)
+        clean = re.sub(r"(?:\b[A-Za-z]:\\[^\s]+|/(?:[^\s/]+/)+[^\s]*)", "the file", clean)
+
         # Gentle cadence shaping: pause after labels and list markers.
         clean = re.sub(r":\s+", ": … ", clean)
         clean = re.sub(r"\n\s*[-•]\s+", " … ", clean)
         clean = re.sub(r"\n\s*\d+[.)]\s+", " … ", clean)
+        clean = re.sub(r"\b(Weather|System|News|Summary)\b", r"… \1", clean)
 
         sentences = self.split_sentences(clean)
         if not sentences:

--- a/nova_backend/src/skills/general_chat.py
+++ b/nova_backend/src/skills/general_chat.py
@@ -188,10 +188,15 @@ class GeneralChatSkill(BaseSkill):
         initiative = self.policy.conversational_flags(heuristic_result, normalized_query, session_state)
 
         if decision == "ASK_USER":
+            payload = self.formatter.format_payload(
+                "Would you like a deeper analysis?",
+                mode=mode,
+            )
             return SkillResult(
                 success=True,
-                message="Would you like a deeper analysis of that?",
+                message=payload["user_message"],
                 data={
+                    "speakable_text": payload["speakable_text"],
                     "escalation": {
                         "ask_user": True,
                         "original_query": normalized_query,
@@ -218,11 +223,15 @@ class GeneralChatSkill(BaseSkill):
             )
             safe = self.safety.filter(raw)
             safe = self.analysis_safety.sanitize(safe)
-            formatted = self.formatter.format(safe)
+            payload = self.formatter.format_payload(safe, mode=mode)
             return SkillResult(
                 success=True,
-                message=formatted,
-                data={"escalation": {"escalated": True, "thought_data": thought_data}},
+                message=payload["user_message"],
+                data={
+                    "speakable_text": payload["speakable_text"],
+                    "structured_data": payload["structured_data"],
+                    "escalation": {"escalated": True, "thought_data": thought_data},
+                },
                 widget_data=None,
                 skill=self.name,
             )
@@ -231,14 +240,20 @@ class GeneralChatSkill(BaseSkill):
         if local is None:
             return None
 
-        local.message = self.formatter.with_conversational_initiative(
+        local_message = self.formatter.with_conversational_initiative(
             local.message,
             mode=mode,
             allow_clarification=initiative.get("allow_clarification", False),
             allow_branch_suggestion=initiative.get("allow_branch_suggestion", False),
             allow_depth_prompt=initiative.get("allow_depth_prompt", False),
         )
+        payload = self.formatter.format_payload(local_message, mode=mode)
+        local.message = payload["user_message"]
         if initiative.get("allow_clarification"):
             session_state["last_clarification_turn"] = session_state.get("turn_count", 0)
-        local.data = {"escalation": {"escalated": False}}
+        local.data = {
+            "speakable_text": payload["speakable_text"],
+            "structured_data": payload["structured_data"],
+            "escalation": {"escalated": False},
+        }
         return local

--- a/nova_backend/src/voice/tts_engine.py
+++ b/nova_backend/src/voice/tts_engine.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, Optional
 from uuid import uuid4
 
 from src.audio.audio_task_runner import run_speech_task
+from src.conversation.response_formatter import ResponseFormatter
 from src.rendering.speech_formatter import SpeechFormatter
 
 logger = logging.getLogger(__name__)
@@ -208,7 +209,7 @@ def resolve_speakable_text(action_result: Any) -> str:
     data: Dict[str, Any] = getattr(action_result, "data", {}) or {}
     speakable = (data.get("speakable_text") or "").strip()
     if speakable:
-        return speakable
+        return ResponseFormatter.to_speakable_text(speakable)
 
     message = getattr(action_result, "user_message", "") or getattr(action_result, "message", "")
-    return (message or "").strip()
+    return ResponseFormatter.to_speakable_text((message or "").strip())

--- a/nova_backend/tests/conversation/test_clarify_prompts.py
+++ b/nova_backend/tests/conversation/test_clarify_prompts.py
@@ -1,0 +1,10 @@
+from src.conversation.clarify_prompts import CLARIFY_PROMPTS
+
+
+def test_clarify_prompts_are_single_question_and_deterministic():
+    for key, prompt in CLARIFY_PROMPTS.items():
+        assert "\n" not in prompt, key
+        if key in {"single_turn_yes_no", "ready_prompt"}:
+            continue
+        assert prompt.count("?") == 1, key
+        assert prompt.endswith("?"), key

--- a/nova_backend/tests/conversation/test_response_formatter.py
+++ b/nova_backend/tests/conversation/test_response_formatter.py
@@ -9,3 +9,21 @@ def test_formatter_normalizes_punctuation_and_spacing():
     assert "!" not in out
     assert "  " not in out
     assert "This" in out
+
+
+def test_format_payload_builds_speakable_and_summary_for_structured_text():
+    from src.conversation.response_formatter import ResponseFormatter
+
+    payload = ResponseFormatter.format_payload("Item one.\n- Item two")
+
+    assert payload["user_message"].startswith("Summary:")
+    assert "speakable_text" in payload
+
+
+def test_speakable_text_strips_urls_and_paths():
+    from src.conversation.response_formatter import ResponseFormatter
+
+    out = ResponseFormatter.to_speakable_text("Open https://example.com and /tmp/file.txt")
+
+    assert "http" not in out.lower()
+    assert "/tmp" not in out

--- a/nova_backend/tests/rendering/test_speech_formatter.py
+++ b/nova_backend/tests/rendering/test_speech_formatter.py
@@ -5,3 +5,10 @@ def test_speech_formatter_adds_pause_markers_between_sentences():
     fmt = SpeechFormatter()
     out = fmt.format_for_tts("First sentence. Second sentence!")
     assert " … " in out
+
+
+def test_speech_formatter_masks_urls_and_paths_for_tts():
+    fmt = SpeechFormatter()
+    out = fmt.format_for_tts("Open https://example.com from /tmp/demo.txt")
+    assert "http" not in out.lower()
+    assert "/tmp" not in out


### PR DESCRIPTION
### Motivation

- Improve the user-facing conversational and TTS experience (tone, brevity, speakable text) while preserving all Phase‑4 governance, authority surfaces, and execution pathways. 
- Consolidate formatting so skills emit a consistent payload (`user_message`, `speakable_text`, `structured_data`) for cleaner UI/TTS integration. 

### Description

- Added a centralized `ResponseFormatter` with `format_payload()` to produce standardized `user_message`, sanitized `speakable_text`, and `structured_data`, plus deterministic one-line executive summaries for multi-line or longer outputs; also added concise micro-acknowledgment replacements and URL/path masking. (modified `src/conversation/response_formatter.py`)
- Updated `general_chat` to route ask-user prompts, analysis-only results, and local LLM responses through the centralized formatter so conversation outputs are polished and audio-safe without altering policy/authority logic. (modified `src/skills/general_chat.py`)
- Applied centralized formatting in the websocket response path so all skill outputs are normalized before delivery and before the auto‑speak flow. (modified `src/brain_server.py`)
- Refined TTS pipeline behavior by masking raw URLs and file paths and adding cadence markers in `SpeechFormatter`, and ensured TTS resolution uses `ResponseFormatter.to_speakable_text()` so spoken text is sanitized. (modified `src/rendering/speech_formatter.py`, `src/voice/tts_engine.py`)
- Polished a DeepSeek fallback sentence and updated clarification prompts to be more natural while preserving deterministic, single-question behavior. (modified `src/conversation/deepseek_bridge.py`, `src/conversation/clarify_prompts.py`)
- Added/updated unit tests validating formatter behavior, speakable-text sanitization, and clarification prompt shape. (added/modified tests under `nova_backend/tests/conversation` and `nova_backend/tests/rendering`)
- No changes were made to Governor, ExecuteBoundary, NetworkMediator authority, registry semantics, single action queue, decision token logic, or any execution pathways; this is strictly an experience-layer refinement.

### Testing

- Ran targeted unit tests with: `PYTHONPATH=. pytest -q tests/conversation/test_response_formatter.py tests/conversation/test_clarify_prompts.py tests/rendering/test_speech_formatter.py tests/governance/test_no_direct_ollama_usage.py tests/governance/test_no_skill_executes_capabilities.py tests/adversarial/test_conversation_non_authorizing.py`.
- Result: all listed tests passed (`10 passed`).
- Initial collection failed in this environment due to missing `PYTHONPATH` (fixed by running with `PYTHONPATH=.`), no functional regressions detected in the executed test subset.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a7d27a5ae08326a23c0bf8e8f21bd7)