### PR TITLE
feat: Phase 9 Token Awareness Layer + audit remediation

### DIFF
--- a/docs/design/NOVA_AGENT_NODE_ARCHITECTURE_2026-04-01.md
+++ b/docs/design/NOVA_AGENT_NODE_ARCHITECTURE_2026-04-01.md
@@ -1,0 +1,144 @@
+# Nova — Agent over Contained Intelligence: Honest Assessment & Path Forward
+Updated: 2026-04-01
+
+---
+
+## Is Nova Currently an "Agent over Contained Intelligence"?
+
+**Partially yes** — but it is currently structured more as a **governed tool executor** than a true agent.
+
+---
+
+## What Nova IS Right Now
+
+| Property | Status | Notes |
+|---|---|---|
+| Governed | ✅ | The Governor is a real constitutional authority layer — all execution passes through a single choke point |
+| Local-first | ✅ | All intelligence runs on your machine via Ollama |
+| Contained | ✅ | Hard capability boundaries, ledger-audited, budget-gated (Phase 9) |
+| Agent-like | ✅ | OpenClaw does multi-step planning: collect → summarize → deliver |
+| Node-ready foundation | ✅ | The WebSocket protocol, ledger, and executor architecture are designed for distribution |
+
+## What Nova is NOT Yet
+
+| Property | Status | Notes |
+|---|---|---|
+| True autonomous agent | ❌ | Nova cannot self-initiate goals or chain multi-step reasoning on its own without user prompt |
+| A node | ❌ | No peer-to-peer or inter-node communication layer yet |
+| Owned intelligence | ❌ | `gemma2:2b` via Ollama is a small model being called as a service — Nova routes through it but does not own or grow it |
+
+---
+
+## The Core Constraint: Local Model Intelligence Ceiling
+
+The local model is the binding constraint on agentic capability. Here is the honest picture:
+
+| What Nova runs | Model | VRAM needed | What you get |
+|---|---|---|---|
+| Default | `gemma2:2b` | ~2–3 GB | Fast, basic reasoning |
+| Fallback | `phi3:mini` | ~2–3 GB | Similar quality |
+| Real step up | `gemma2:9b` | ~6–8 GB | Much better reasoning |
+| Serious step up | `llama3.1:8b` | ~6–8 GB | Very capable |
+| Agent-grade | `llama3.1:70b` | ~40–48 GB | True agentic reasoning |
+| Node-viable | `mistral:7b` / `mixtral:8x7b` | 5–48 GB | Good for routing tasks |
+
+If your GPU cannot push past 2b or mini models without crawling, the intelligence ceiling is genuinely low — not because the code is broken, but because the foundation model is small.
+
+---
+
+## The Path Forward: Agent → Node
+
+### Phase NOW (current)
+```
+Nova = Governed Shell → calls gemma2:2b → returns result
+Problem: gemma2:2b is not capable enough for real agentic reasoning chains
+```
+
+### Phase NEXT (no GPU upgrade required)
+```
+Nova = Agent Shell → routes complex tasks to cloud model via API key
+                     (GPT-4o, Claude Sonnet, Gemini)
+
+The code already has this:
+  nova_backend/src/providers/openai_responses_lane.py
+
+Currently: used only as a fallback for OpenClaw briefing tasks
+Should be: promoted to PRIMARY reasoning engine for tasks that exceed
+           local model capability, governed by existing budget system
+
+Cost: ~$0.01–0.05 per complex conversation
+Result: Real intelligence without GPU upgrade
+```
+
+### Phase AFTER (node-ready)
+```
+Nova = Node → exposes a governed API endpoint
+              Other Nova instances or services call YOUR Nova as a specialist node
+
+Already in place:
+  - WebSocket ↔ REST bridge architecture (brain_server.py + session_handler.py)
+  - Ledger with full audit trail per action
+  - Capability registry is structured for distributed routing
+
+Still needed:
+  - WebSocket → REST bridge for external callers
+  - Node discovery protocol
+  - Trust protocol between nodes (governor-to-governor handshake)
+```
+
+---
+
+## The Immediate Recommendation
+
+**Promote `openai_responses_lane.py` to primary reasoning engine for complex tasks.**
+
+Nova already has the infrastructure — it just needs to be activated as the default for reasoning-heavy requests:
+
+```
+Small/fast things (gemma2:2b) → handled locally          ✅ already works
+Complex reasoning, agentic tasks → routed to GPT-4o/Claude via OpenAI lane  ✅ code exists, needs wiring
+Budgeted and logged just like everything else             ✅ Phase 9 budget gate already enforces this
+No GPU upgrade needed                                     ✅
+```
+
+**What this requires:**
+1. Set `OPENAI_API_KEY` in your `.env` (now documented in `.env.example`)
+2. Set `MODEL_PROVIDER=auto` to enable the routing logic
+3. The existing `provider_usage_store` and Phase 9 budget gate apply automatically — no new governance needed
+
+---
+
+## Architectural Reality Check
+
+Nova's codebase is already structured for the agent-node future:
+
+- **Governor**: Single authority choke point — suitable as the trust broker in a node network
+- **Capability registry**: JSON-driven, extensible — nodes can declare their own capability surfaces
+- **Ledger**: Append-only audit trail — provides accountability across node boundaries
+- **Budget gate**: Token-aware — prevents runaway costs in automated chains
+- **OpenClaw executor**: Already does multi-step template execution — the pattern for agent chains
+
+The missing pieces are soft (model quality, cloud routing config) not hard (architecture). The hard infrastructure is in place.
+
+---
+
+## What "Agent over Contained Intelligence" Means for Nova
+
+Nova is not an agent **yet** in the autonomous sense. It is a **governed intelligence surface** — a shell that can be upgraded to agentic reasoning by:
+
+1. Connecting better intelligence (larger local model or cloud API)
+2. Enabling multi-step planning chains (extend OpenClaw templates)
+3. Adding peer trust protocols (node-to-node governor handshake)
+
+The governance layer — the thing that makes this safe — is already mature. The intelligence layer is the current ceiling.
+
+---
+
+## Decision Point
+
+| Choice | Trade-off | Recommendation |
+|---|---|---|
+| Stay fully local (`gemma2:2b`) | Free, private, limited reasoning | Keep as default; acceptable for simple tasks |
+| Add cloud reasoning (`OPENAI_API_KEY` + `MODEL_PROVIDER=auto`) | ~$0.01–0.05/complex task, full intelligence | **Do this now** — infrastructure ready |
+| GPU upgrade to 8b+ model | One-time cost, fully private, real capability | Future option when budget allows |
+| Build node protocol | High effort, enables distributed Nova | Phase 10+ roadmap item |

--- a/nova_backend/.env.example
+++ b/nova_backend/.env.example
@@ -1,0 +1,106 @@
+# Nova Backend — Environment Variables
+# Copy this file to .env and fill in your values.
+# Never commit .env to version control.
+#
+# Required variables are marked [REQUIRED].
+# Optional variables show their default in the comment.
+
+# ---------------------------------------------------------------------------
+# Local Model (Ollama)
+# ---------------------------------------------------------------------------
+
+# URL of the local Ollama instance [default: http://localhost:11434]
+OLLAMA_URL=http://localhost:11434
+
+# Primary model to load in Ollama [default: gemma2:2b]
+# Upgrade path: gemma2:9b → llama3.1:8b → llama3.1:70b (more VRAM required)
+OLLAMA_MODEL=gemma2:2b
+
+# Fallback model if primary fails [default: phi3:mini]
+OLLAMA_FALLBACK_MODEL=phi3:mini
+
+# How long Ollama keeps the model in memory [default: 10m]
+OLLAMA_KEEP_ALIVE=10m
+
+# Request timeout in seconds [default: 60]
+OLLAMA_TIMEOUT=60
+
+# ---------------------------------------------------------------------------
+# Provider Routing
+# ---------------------------------------------------------------------------
+
+# Which provider Nova uses for reasoning: "local" | "openai" | "auto"
+# "auto" uses local for fast requests, routes complex reasoning to OpenAI if key is present
+# [default: local]
+MODEL_PROVIDER=local
+
+# Runtime profile override: "local-control" | "analyst" | "full"
+# [default: resolved from BUILD_PHASE in build_phase.py]
+# NOVA_RUNTIME_PROFILE=local-control
+
+# Default reasoning profile when multiple profiles are available
+# DEFAULT_PROFILE=local-control
+
+# ---------------------------------------------------------------------------
+# OpenAI / Cloud Reasoning (optional — required for full external reasoning)
+# ---------------------------------------------------------------------------
+
+# OpenAI API key — enables GPT-4o and the openai_responses_lane
+# Leave blank to stay fully local
+# OPENAI_API_KEY=sk-...
+
+# ---------------------------------------------------------------------------
+# Web Search (optional)
+# ---------------------------------------------------------------------------
+
+# Brave Search API key — enables governed web search (cap 16)
+# Without this, web search is disabled at runtime
+# BRAVE_API_KEY=BSA...
+
+# Enable web search globally: "true" | "false" [default: false]
+# WEB_SEARCH_ENABLED=false
+
+# ---------------------------------------------------------------------------
+# News (optional)
+# ---------------------------------------------------------------------------
+
+# NewsAPI.org API key — enables headline fetching (cap 48)
+# Without this, news capabilities return a graceful no-data response
+# NEWS_API_KEY=...
+
+# ---------------------------------------------------------------------------
+# Weather (optional)
+# ---------------------------------------------------------------------------
+
+# Visual Crossing API key — enables weather (cap 55)
+# Without this, weather returns a graceful no-data response
+# WEATHER_API_KEY=...
+
+# Temperature units: "metric" | "imperial" [default: metric]
+# WEATHER_UNITS=metric
+
+# ---------------------------------------------------------------------------
+# Calendar (optional)
+# ---------------------------------------------------------------------------
+
+# Path to a local .ics calendar file for offline calendar access (cap 56)
+# NOVA_CALENDAR_ICS_PATH=C:\Users\YourName\Documents\my-calendar.ics
+
+# ---------------------------------------------------------------------------
+# Voice / TTS (optional)
+# ---------------------------------------------------------------------------
+
+# Path to a local Piper TTS model (.onnx file) for high-quality TTS
+# Without this, Nova falls back to pyttsx3 (system TTS)
+# NOVA_PIPER_MODEL_PATH=C:\path\to\your\model.onnx
+
+# ---------------------------------------------------------------------------
+# OpenClaw Bridge (optional — remote access only)
+# ---------------------------------------------------------------------------
+
+# Secret token for the OpenClaw remote bridge
+# Only set this if you are enabling authenticated remote access to Nova
+# NOVA_OPENCLAW_BRIDGE_TOKEN=your-secret-token-here
+
+# Alias (older config key — same purpose, prefer NOVA_OPENCLAW_BRIDGE_TOKEN)
+# NOVA_BRIDGE_TOKEN=your-secret-token-here


### PR DESCRIPTION
## Summary

- **Phase 9 Token Awareness Layer**: daily token budget gate in the Governor, `token_budget_update` WebSocket event, `GET /api/token/budget` REST endpoint, and frontend budget bar (amber warning / red limit)
- **Audit remediation**: `.env.example` documenting all 17 environment variables, email connector interface stub (`src/connectors/email_connector.py`), cap 63 dual-surface design reconciled in audit TODO
- **Strategic docs**: agent-node architecture honest assessment with GPU ceiling analysis, three-phase roadmap, and recommendation to promote `openai_responses_lane.py` for complex reasoning

## Changes

- `nova_backend/src/governor/governor.py` — budget gate pre-dispatch + budget snapshot in result.data
- `nova_backend/src/api/settings_api.py` — `GET /api/token/budget` endpoint
- `nova_backend/src/brain_server.py` — `send_token_budget_update()` helper
- `nova_backend/src/websocket/session_handler.py` — emits `token_budget_update` after budget-gated caps
- `nova_backend/static/dashboard.js` — `renderTokenBudgetBar()` + WebSocket handler
- `nova_backend/static/index.html` — token-budget-bar element
- `nova_backend/static/style.phase1.css` — budget bar CSS (warning/limit states)
- `nova_backend/src/connectors/email_connector.py` — Phase 10 inbox connector stub
- `nova_backend/tests/phase9/test_token_awareness.py` — 10-test suite
- `nova_backend/.env.example` — all environment variables documented
- `docs/design/NOVA_AGENT_NODE_ARCHITECTURE_2026-04-01.md` — strategic architecture assessment
- `docs/design/NOVA_AUDIT_TODO_2026-03-28.md` — Phase 9 deferred items + cap 63 dual-surface docs

## Test plan

- [ ] `pytest nova_backend/tests/phase9/` — all 10 token awareness tests pass
- [ ] Budget gate blocks network caps when `budget_state == "limit"`
- [ ] `GET /api/token/budget` returns snapshot with `budget_state`, `budget_remaining_tokens`
- [ ] Frontend budget bar hidden at normal, amber at warning, red at limit
- [ ] `token_budget_update` WebSocket event fires after network cap invocations

🤖 Generated with [Claude Code](https://claude.com/claude-code)