### PR TITLE
Add Nova Brain architecture package

### DIFF
--- a/.agent_context/brain_loop.md
+++ b/.agent_context/brain_loop.md
@@ -1,0 +1,24 @@
+# Brain Loop Context
+
+Nova's proposed Brain loop is:
+
+```text
+Task Intake
+→ Task Understanding
+→ Task Clarifier
+→ Working Memory
+→ Environment Reasoner
+→ Authority Question
+→ Plan Builder
+→ Dry Run / Preview
+→ Governor Gate
+→ Execution
+→ Proof
+→ Reflection
+```
+
+Current status: conceptual/design unless runtime implementation proves otherwise.
+
+Agents should not treat this as live routing.
+
+When implementing, prefer read-only schemas and tests before behavior changes.

--- a/.agent_context/current_priority.md
+++ b/.agent_context/current_priority.md
@@ -1,0 +1,18 @@
+# Current Priority
+
+Current priority remains:
+
+```text
+Cap 16 web-search answer quality + conversation coherence proof
+```
+
+Do not jump to Cap 64 P5, Shopify write work, OpenClaw browser automation, or broad advanced features until the conversation/search proof path is stable.
+
+Near-term focus:
+
+1. Cap 16 CPU-budget/search reliability
+2. conversation/search proof re-run
+3. public demo capture
+4. then Cap 64 P5 live signoff
+
+This file is a working agent context note. Exact runtime truth still comes from code and generated runtime docs.

--- a/.agent_context/environments.md
+++ b/.agent_context/environments.md
@@ -1,0 +1,21 @@
+# Environment Context
+
+Nova's Brain should reason about environments before execution.
+
+## Current Environment Categories
+
+- local internal: conversation, runtime truth, memory, project docs, ledger, dashboard
+- local machine: filesystem, screen, OS controls, mail client, audio/voice
+- network read: web search, website open, news, weather, calendar read, Shopify read-only
+- browser: OpenClaw isolated browser, test browser, personal browser session
+- external effect: email draft, future email send, future Shopify write, future calendar write, form submit, purchase, account change
+
+## Rule
+
+Naming an environment does not mean it is implemented or allowed.
+
+Agents must verify current capability/runtime truth before claiming support.
+
+## OpenClaw Rule
+
+Prefer isolated OpenClaw/browser environments over the user's personal signed-in browser. Personal browser sessions require explicit user approval and stronger proof.

--- a/.agent_context/governance.md
+++ b/.agent_context/governance.md
@@ -1,0 +1,31 @@
+# Governance Context
+
+Core rule:
+
+```text
+Intelligence is not authority.
+```
+
+The Brain may reason freely, clarify, plan, rank environment options, and prepare dry-run previews.
+
+Execution still requires the existing governed runtime path.
+
+## Current Boundaries
+
+- Cap 16 is governed web search and current active proof priority.
+- Cap 64 is local email draft only; no SMTP, no inbox, no autonomous send.
+- Cap 65 is Shopify read-only intelligence; no writes.
+- OpenClaw is an execution environment, not the brain.
+- Memory is context, not permission.
+- Receipts prove events; they do not authorize future actions.
+
+## Agent Rule
+
+When adding docs or code, distinguish clearly between:
+
+- implemented runtime behavior
+- design scaffold
+- future plan
+- proof requirement
+
+Do not overstate conceptual Brain docs as live features.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# AGENTS.md
+
+Guidance for AI agents working on NovaLIS.
+
+Start here before editing the repo.
+
+## Core Rule
+
+Intelligence is not authority.
+
+Nova's reasoning layers may clarify, plan, search, summarize, and propose. Runtime execution still goes through the Governor, capability registry, execution boundaries, and receipts.
+
+## Current Priority
+
+Read `.agent_context/current_priority.md`.
+
+As of this Brain package, the active priority remains Cap 16 search reliability and conversation/search proof. Cap 64 P5 remains paused until that proof path is stable.
+
+## Required Context Files
+
+Read these before making brain/governance changes:
+
+- `docs/brain.md`
+- `docs/brain/README.md`
+- `.agent_context/brain_loop.md`
+- `.agent_context/environments.md`
+- `.agent_context/governance.md`
+- `.agent_context/current_priority.md`
+
+## Do Not
+
+- add execution capabilities without explicit request
+- bypass GovernorMediator
+- treat memory as permission
+- claim conceptual docs are implemented runtime behavior
+- mark Cap 64 or Cap 65 complete without live proof
+- add Shopify writes or email sending under existing read/draft capabilities
+
+## Repo Truth Rule
+
+Generated runtime docs and implementation beat roadmap language.
+
+When exact current status matters, verify against code and generated runtime truth.

--- a/docs/brain/AUTHORITY_PLANE.md
+++ b/docs/brain/AUTHORITY_PLANE.md
@@ -1,0 +1,70 @@
+# Authority Plane
+
+The Authority Plane is the conceptual map between Nova's brain and Nova's Governor.
+
+The brain may reason, clarify, rank environments, and prepare dry-run plans.
+
+The Governor remains the execution boundary.
+
+## Purpose
+
+The Authority Plane answers:
+
+- What authority does this task require?
+- Which capability grants that authority?
+- What setup is required?
+- Is confirmation required?
+- What proof must be produced?
+- What fallback should be offered if blocked?
+
+## Configurable Plane Concept
+
+Inspired by guardrail/config-map patterns, the Authority Plane should eventually be represented as data, not hidden prose.
+
+Example shape:
+
+```yaml
+environment: email_draft
+authority_tier: L4
+capability: cap64_send_email_draft
+requires_confirmation: true
+expected_receipts:
+  - EMAIL_DRAFT_CREATED
+  - EMAIL_DRAFT_FAILED
+blocked_actions:
+  - send_email
+  - smtp_send
+  - inbox_read
+fallbacks:
+  - show draft text in chat
+  - explain mailto setup
+  - user copy/paste manually
+```
+
+## Capability Contracts
+
+Capability Contracts are the per-capability source of what a capability can and cannot do.
+
+Contract fields:
+
+```text
+capability_id
+name
+environment
+authority_tier
+can
+cannot
+required_setup
+confirmation_required
+expected_receipts
+fallbacks
+known_failure_modes
+```
+
+## Governor-Safe Rule
+
+The brain may consult the Authority Plane.
+
+The brain may not execute because the Authority Plane says something is possible.
+
+The runtime Governor still decides.

--- a/docs/brain/BRAIN_TRACE_UI_SPEC.md
+++ b/docs/brain/BRAIN_TRACE_UI_SPEC.md
@@ -1,0 +1,73 @@
+# Brain Trace UI Spec
+
+The Brain Trace UI makes Nova's operational reasoning visible without exposing hidden chain-of-thought.
+
+It should show structured state, not private reasoning.
+
+## Pre-Execution View: Dry Run
+
+Before higher-authority or multi-step work, Nova can show a plan preview.
+
+Fields:
+
+- user task
+- clarification status
+- proposed steps
+- environments to enter
+- capability contracts involved
+- confirmation points
+- expected receipts
+- fallback ladder
+- what Nova will not do
+
+Example:
+
+```text
+Plan preview:
+1. Use Cap 16 governed web search.
+   Proof: source URLs.
+2. Summarize candidates.
+   Proof: cited summary.
+3. Prepare Cap 64 email draft.
+   Confirmation required before opening local mail client.
+   Proof: EMAIL_DRAFT_CREATED if opened.
+
+Nova will not send email.
+```
+
+## Execution View: Governor Dashboard
+
+Represent the brain loop as visible states:
+
+```text
+Task Intake → Clarifier → Environment Reasoner → Authority Question → Plan Preview → Governor Gate → Execution → Proof
+```
+
+If Nova pauses at authority, the UI should show `CONFIRMATION REQUIRED` instead of hiding the reason.
+
+If blocked, the UI should show the blocker and fallback ladder.
+
+## Post-Execution View: Proof Package
+
+After a governed action, show:
+
+- receipt ID/event
+- capability used
+- environment entered
+- confirmation state
+- source URLs or screenshots if applicable
+- state change summary
+- next safe step
+
+## Receipts As Journaling
+
+Receipts should also support learning and reflection.
+
+The trace can show:
+
+- what memory was used
+- what context was pruned or ignored
+- what proof was created
+- whether the user rejected or accepted the plan
+
+This should be operational metadata, not hidden chain-of-thought.

--- a/docs/brain/ENVIRONMENT_CATALOG.md
+++ b/docs/brain/ENVIRONMENT_CATALOG.md
@@ -1,0 +1,73 @@
+# Environment Catalog
+
+This catalog defines the worlds Nova may reason about entering.
+
+An environment is not automatically available just because the brain names it.
+
+The Governor, capability registry, setup state, confirmation requirements, and proof rules still decide whether the environment can be entered.
+
+## Trust / Authority Tiers
+
+| Tier | Meaning | Examples |
+|---|---|---|
+| L0 | Local internal reasoning/read | local conversation, runtime truth, local docs |
+| L1 | Network read-only | web search, open public website, news/weather |
+| L2 | Account read | calendar read, Shopify read-only if configured |
+| L3 | Local/device effect | brightness, volume, screen capture, file/folder open |
+| L4 | External-effect draft | email draft, calendar draft, browser form preview |
+| L5 | Account write / external submission | send email, submit form, Shopify write, purchase |
+
+## Local Internal Environments
+
+- `local_conversation`
+- `local_runtime_truth`
+- `local_memory`
+- `local_project_docs`
+- `local_ledger`
+- `local_dashboard`
+
+## Local Machine Environments
+
+- `local_filesystem`
+- `local_screen`
+- `local_os_controls`
+- `local_mail_client`
+- `local_audio_voice`
+
+## Network Read Environments
+
+- `web_search`
+- `website_open`
+- `news_api`
+- `weather_api`
+- `calendar_read`
+- `shopify_read_only`
+
+## Browser Environments
+
+- `openclaw_isolated_browser`
+- `browser_use_test_browser`
+- `personal_browser_session`
+- `remote_browser`
+
+## External Effect Environments
+
+- `email_draft`
+- `email_send_future`
+- `shopify_write_future`
+- `calendar_write_future`
+- `form_submit`
+- `purchase_payment`
+- `account_change`
+
+## Granular Browser Rule
+
+`openclaw_isolated_browser` and `personal_browser_session` must stay separate.
+
+The isolated browser is the preferred governed automation lane.
+
+The personal browser session is higher risk because it may include logged-in accounts, cookies, private data, and account permissions.
+
+## Current Truth Note
+
+Naming an environment here does not mean Nova currently implements it.

--- a/docs/brain/IMPLEMENTATION_ROADMAP.md
+++ b/docs/brain/IMPLEMENTATION_ROADMAP.md
@@ -1,0 +1,92 @@
+# Brain Implementation Roadmap
+
+No fake deadlines.
+
+This roadmap phases the Brain from design to runtime scaffolding without widening execution authority.
+
+## Phase 0 — Governor Spine Proof
+
+Prove the brain can ask for permission and be denied.
+
+Deliverable:
+
+- dry-run examples that reach Governor Gate but do not execute
+- blocked examples with fallback ladders
+
+## Phase 1 — Task Clarifier
+
+Prove Nova can detect ambiguity and ask the minimum useful question before planning.
+
+Deliverable:
+
+- clarification examples
+- tests for missing city, missing recipient, missing product, ambiguous browser request
+
+## Phase 2 — Environment Catalog Validation
+
+Prove task plans validate against known environments and authority tiers.
+
+Deliverable:
+
+- schema/data file for environments
+- tests for valid/invalid environment requests
+
+## Phase 3 — Capability Contracts
+
+Create static contracts for the highest-priority capabilities:
+
+- Cap 16 governed web search
+- Cap 64 send email draft
+- Cap 65 Shopify intelligence report
+- Cap 63 OpenClaw execute
+
+Deliverable:
+
+- docs or data contracts
+- tests that blocked actions are represented correctly
+
+## Phase 4 — Dry Run / Plan Preview
+
+Generate non-executing plan previews for multi-step tasks.
+
+Deliverable:
+
+- structured dry-run payloads
+- UI or API preview later
+
+## Phase 5 — Brain Trace UI
+
+Render operational trace metadata:
+
+- task
+- clarification status
+- environments
+- authority
+- capability
+- confirmation
+- proof
+- fallback
+
+## Phase 6 — Cap 16 Reliability Integration
+
+Tie current-information requests to the EnvironmentRequest model and Cap 16 proof harness.
+
+Current active priority remains Cap 16 search reliability.
+
+## Phase 7 — OpenClaw Environment Planning
+
+Add plan-time OpenClaw environment requests before any browser execution work.
+
+## Phase 8 — Project Contexts and Suggestion Buffer
+
+Add project-specific context, rejected-plan memory, and governed suggestions.
+
+## Runtime Constraint
+
+Each phase must preserve:
+
+- Governor authority
+- capability registry boundaries
+- receipt/proof discipline
+- no hidden execution
+- no conceptual docs treated as implemented runtime truth

--- a/docs/brain/MEMORY_LAYERS.md
+++ b/docs/brain/MEMORY_LAYERS.md
@@ -1,0 +1,63 @@
+# Memory Layers
+
+Nova memory is context, not authority.
+
+Memory can help Nova understand a task, but it cannot authorize execution.
+
+## Layers
+
+- Session context
+- Working memory
+- Core user memory
+- Project memory
+- Topic/story memory
+- Archival memory
+- Conversation search
+- Suggestion buffer
+- Receipts / ledger
+- Runtime truth
+- Future docs
+
+## Working Memory
+
+Working Memory tracks the active task:
+
+- current goal
+- known facts
+- unknowns
+- active project
+- current environment
+- blocker
+- next decision
+
+## Suggestion Buffer
+
+The Suggestion Buffer stores candidate suggestions, not actions.
+
+Example:
+
+```text
+Pattern noticed: user often asks for Shopify summary, then an email draft.
+Suggestion: offer to prepare the summary and hold an email draft plan for review.
+```
+
+Rules:
+
+- suggestions do not execute
+- suggestions do not authorize actions
+- suggestions are dismissible
+- suggestions should be inspectable and deletable
+
+## Active Garbage Collection
+
+Long tasks need resource control.
+
+The brain should eventually be able to move stale Working Memory into Archival Memory to avoid context collapse.
+
+This should be visible and reversible where practical.
+
+## Receipts Are Separate
+
+Receipts and ledger events are proof, not personal memory.
+
+They may inform reflection, but they must not become hidden permission.

--- a/docs/brain/NOVA_BRAIN_MODEL.md
+++ b/docs/brain/NOVA_BRAIN_MODEL.md
@@ -1,0 +1,82 @@
+# Nova Brain Model
+
+The Nova Brain is a governed cognitive loop.
+
+It is not a new executor. It is the reasoning layer that prepares structured, Governor-safe plans.
+
+## Loop
+
+```text
+Task Intake
+→ Task Understanding
+→ Task Clarifier
+→ Working Memory
+→ Environment Reasoner
+→ Authority Question
+→ Plan Builder
+→ Dry Run / Preview
+→ Governor Gate
+→ Execution
+→ Proof
+→ Reflection
+```
+
+## Layers
+
+### 1. Task Intake
+
+Identify what the user is trying to accomplish.
+
+### 2. Task Understanding
+
+Classify task type, ambiguity, evidence need, risk, and whether the task is single-step or multi-step.
+
+### 3. Task Clarifier
+
+If the goal is underspecified, ask the smallest useful question before planning.
+
+Examples:
+
+- `Find contractors` → ask for city/service area.
+- `Update Shopify product` → ask which product/field, and note current Shopify support is read-only.
+- `Use browser` → ask whether isolated OpenClaw browser or personal signed-in browser is meant.
+
+### 4. Working Memory
+
+Track current goal, known facts, unknowns, active project, current environment, blocker, and next decision.
+
+### 5. Environment Reasoner
+
+Decide what environment the task requires: local conversation, memory, runtime docs, web search, isolated browser, personal browser, local OS, email draft, Shopify, OpenClaw, or future connector lane.
+
+### 6. Authority Question
+
+Ask what boundary is crossed, which capability grants access, whether confirmation is required, whether setup is missing, and what proof should exist.
+
+### 7. Plan Builder
+
+Create steps with environment, capability, confirmation points, fallbacks, and expected receipts.
+
+### 8. Dry Run / Preview
+
+Generate a non-executing plan preview so the user can inspect the intended route before execution.
+
+### 9. Governor Gate
+
+The existing Nova governance spine decides whether execution is allowed.
+
+### 10. Execution
+
+Only the existing governed runtime path executes actions.
+
+### 11. Proof
+
+Receipts, source URLs, screenshots, state change, and run timeline evidence are collected where applicable.
+
+### 12. Reflection
+
+Determine whether the task was satisfied, what remains blocked, what should be remembered, what should be asked next, and what proof package should be updated.
+
+## Current Status
+
+This model is conceptual until runtime implementation proves otherwise.

--- a/docs/brain/OPENCLAW_ENVIRONMENT_MODEL.md
+++ b/docs/brain/OPENCLAW_ENVIRONMENT_MODEL.md
@@ -1,0 +1,54 @@
+# OpenClaw Environment Model
+
+OpenClaw is an environment, not the brain.
+
+Nova's brain may decide that a task requires an OpenClaw environment, but execution still requires the governed OpenClaw capability path.
+
+## Preferred Default
+
+Prefer an isolated OpenClaw-managed browser profile over the user's personal signed-in browser.
+
+## Environment Types
+
+- `openclaw_isolated_browser`
+- `personal_browser_session`
+- `browser_use_test_browser`
+- `remote_browser`
+
+## Provision Request Concept
+
+OpenClaw sessions should be treated like temporary sandboxes.
+
+Conceptual schema:
+
+```json
+{
+  "task_id": "task_123",
+  "environment": "openclaw_isolated_browser",
+  "required_screenshots": ["before", "after"],
+  "max_runtime_seconds": 300,
+  "allowed_domains": [],
+  "blocked_actions": ["purchase", "send", "delete", "submit_without_confirmation"]
+}
+```
+
+## Proof Requirements
+
+- session started receipt
+- screenshot before meaningful action
+- proposed action preview
+- confirmation where required
+- screenshot after action
+- session closed receipt
+
+## Personal Browser Rule
+
+A personal browser session may contain logged-in accounts, cookies, private data, and account authority.
+
+It should require explicit user approval and strong proof.
+
+## No Persistent Drift
+
+After a governed browser task, the environment should close or be explicitly preserved by user choice.
+
+The default should avoid silent persistent state drift.

--- a/docs/brain/PROJECT_CONTEXTS.md
+++ b/docs/brain/PROJECT_CONTEXTS.md
@@ -1,0 +1,62 @@
+# Project Contexts
+
+Project Contexts let Nova reason inside the correct workspace.
+
+They are not permission by themselves.
+
+A project context can shape memory, allowed environments, proof expectations, and suggestions, but execution still goes through the Governor.
+
+## Example Contexts
+
+- NovaLIS
+- Pour Social
+- Website Business
+- Shopify / E-commerce
+- Personal Admin
+- Career / Learning
+
+## Context Fields
+
+Each project context can eventually define:
+
+```text
+goals
+memory
+docs
+active tasks
+allowed environments
+blocked environments
+proof logs
+capability profile
+suggestion patterns
+trust/reputation notes
+```
+
+## Rejected Plans / Reputation
+
+If a user rejects a plan, that rejection should become proof for future planning.
+
+Example:
+
+```text
+Rejected plan: browser task used personal browser instead of isolated browser.
+Future behavior: prefer isolated browser and explicitly ask before personal browser.
+```
+
+This is not a social score.
+
+It is a project-local trust and preference record that helps Nova avoid repeating bad plans.
+
+## Project Examples
+
+### NovaLIS
+
+Nova may inspect repo docs/code and suggest patches.
+
+### Shopify / E-commerce
+
+Current truth: Nova may produce read-only Shopify intelligence if configured. It may not write products, orders, refunds, or customer messages unless future governed write capabilities are implemented.
+
+### Pour Social
+
+Nova may draft contracts, menus, pricing calculators, and operating docs. Sending client communications should remain user-reviewed and governed.

--- a/docs/brain/README.md
+++ b/docs/brain/README.md
@@ -1,0 +1,43 @@
+# Nova Brain Architecture
+
+This folder expands the canonical `docs/brain.md` note into a more detailed architecture package.
+
+Nova's brain is not the authority.
+
+The Governor remains the authority boundary for execution.
+
+Reasoning may explore, clarify, plan, rank environments, prepare dry runs, and propose fallback paths. Execution still requires the existing governed runtime path.
+
+Core rule:
+
+```text
+Let intelligence reason.
+Let the Governor authorize.
+Let receipts prove.
+```
+
+## What This Package Defines
+
+- The Nova Brain model
+- Task clarification before planning
+- Task Environment Router behavior
+- environment catalog and trust tiers
+- Authority Plane concepts
+- capability contracts
+- fallback ladders
+- dry-run / plan-preview behavior
+- Brain Trace UI concepts
+- memory layers and project contexts
+- OpenClaw as an environment, not the brain
+- implementation roadmap
+
+## What This Package Does Not Do
+
+This package does not implement runtime autonomy.
+
+It does not add new execution paths.
+It does not bypass the Governor.
+It does not change Cap 64, Cap 65, OpenClaw, Shopify, or email behavior.
+It does not mark conceptual plans as implemented runtime features.
+
+Current runtime truth still comes from generated runtime docs and code.

--- a/docs/brain/TASK_ENVIRONMENT_ROUTER.md
+++ b/docs/brain/TASK_ENVIRONMENT_ROUTER.md
@@ -1,0 +1,106 @@
+# Task Environment Router
+
+The Task Environment Router is the missing middle layer between conversation and execution.
+
+It answers:
+
+```text
+For this task, what environment does Nova need to enter?
+What authority is required?
+Which capability would grant access?
+What confirmation is needed?
+What proof should exist afterward?
+```
+
+## Required Questions
+
+- Can Nova solve this locally?
+- Does it need current evidence?
+- Does it need memory or project context?
+- Does it need a browser?
+- Does it need a signed-in account?
+- Does it need to write, change, submit, send, or purchase?
+- Is the capability available?
+- Is the environment configured?
+- Is confirmation needed?
+- What happens if blocked?
+- What proof will satisfy the user?
+
+## Output Shape
+
+```text
+task_type
+required_environments
+environment_options
+authority_required
+capability_needed
+confirmation_required
+setup_required
+proof_required
+allowed_status
+confidence
+risk_level
+blocker
+recovery_path
+fallback_ladder
+next_safe_step
+```
+
+## Capability Contract Check
+
+Before selecting a capability, the router should consult the capability contract.
+
+The contract should say:
+
+- what the capability can do
+- what it cannot do
+- required setup
+- authority tier
+- confirmation rules
+- expected receipts
+- fallback behaviors
+- known failure modes
+
+If a user requests an action outside the contract, the router should mark the request as blocked or future-only and offer a recovery path.
+
+## Example
+
+```json
+{
+  "task": "Find a contractor near me and draft an email",
+  "task_type": "multi_step",
+  "required_environments": ["web_search", "email_draft"],
+  "environment_options": [
+    {
+      "environment": "web_search",
+      "confidence": 0.94,
+      "risk_level": "network_read",
+      "capability_needed": "cap16_governed_web_search"
+    },
+    {
+      "environment": "email_draft",
+      "confidence": 0.88,
+      "risk_level": "external_effect_draft",
+      "capability_needed": "cap64_send_email_draft"
+    }
+  ],
+  "confirmation_points": ["before_opening_email_draft"],
+  "proof_expected": ["source_urls", "EMAIL_DRAFT_CREATED"],
+  "recovery_path": []
+}
+```
+
+## Recovery Path
+
+If blocked, the router should not simply stop.
+
+It should produce a recovery path such as:
+
+- ask a clarifying question
+- run a lower-authority read-only step
+- produce a manual guide
+- offer setup instructions
+- show a dry-run plan only
+- ask the user to perform a manual step and report back
+
+Recovery paths are suggestions, not execution authority.


### PR DESCRIPTION
## Summary

Adds a dedicated `docs/brain/` architecture package and repo-native agent context files for Nova's Brain concept.

This expands the existing canonical `docs/brain.md` note into reviewable architecture documents covering:

- Nova Brain loop
- Task Environment Router
- Task Clarifier
- environment catalog and authority tiers
- Authority Plane / capability contracts
- Brain Trace UI
- memory layers
- project contexts
- OpenClaw environment model
- implementation roadmap
- agent guidance via `AGENTS.md` and `.agent_context/`

## Important boundary

This PR is documentation/scaffold only.

It does **not**:

- add execution capabilities
- widen autonomy
- change Governor behavior
- change Cap 16, Cap 64, Cap 65, Shopify, email, or OpenClaw runtime behavior
- mark conceptual Brain plans as implemented runtime truth

## Current truth preserved

- Cap 16 search reliability remains current active priority.
- Cap 64 P5 remains paused until conversation/search proof is stable.
- Cap 64 remains local mailto draft only; no send.
- Cap 65 remains read-only.
- Memory remains context, not authority.
- Governor remains the execution boundary.

## Tests

Docs-only package. No runtime tests run through the GitHub tool.