### PR TITLE
Brain planning preview scaffold

### DIFF
--- a/docs/brain.md
+++ b/docs/brain.md
@@ -43,6 +43,10 @@ The Brain is designed to make Nova more helpful and adaptive without turning int
 Current live Brain behavior:
 
 - Task Clarifier is implemented for tested ambiguous/high-boundary prompts.
+- Task Understanding / Simple Task Mode / Task Envelope exist as planning-only scaffolds.
+- General-chat fallback can carry a planning-only Task Understanding preview for task-like requests.
+- RunManager exists as an in-memory planning-only scaffold for run continuity state.
+- General-chat fallback can create a session-local planning Run Preview for task-like requests.
 - EnvironmentRequest schema exists as read-only scaffold.
 - Static Capability Contract catalog exists for Cap 16, Cap 64, Cap 65, and Cap 63.
 - Brain live-test proof exists under `docs/demo_proof/brain_live_test/`.
@@ -53,6 +57,10 @@ Still future / not fully live:
 - live Capability Contract lookup in runtime routing/Governor
 - Dry Run / Plan Preview API
 - Brain Trace UI
+- Co-Work page
+- persistent RunManager storage
+- RunManager execution integration
+- persistent Run Preview history
 - project context engine
 - suggestion buffer runtime
 - full OpenClaw environment planning

--- a/docs/brain.md
+++ b/docs/brain.md
@@ -66,6 +66,23 @@ Still future / not fully live:
 - full OpenClaw environment planning
 - full small-model runtime stack: Context Assembler, Model Router, Intention Parser, Search Synthesis, Sandbox Boundary Enforcer, and Persona Filter
 
+## Scope Guard For This Preview
+
+This Brain preview is documentation and planning refinement only.
+
+It does not unpause any paused product scope. It does not expand Shopify, OpenClaw, browser, email, calendar, file, account, or social publishing authority.
+
+In particular:
+
+- Cap 65 remains read-only Shopify reporting/intelligence.
+- Shopify P5 live signoff remains paused until the owner explicitly unpauses it.
+- Shopify write/operator capabilities remain future-only.
+- The Brain planning preview may describe a possible future environment or task envelope, but that description is not permission to execute.
+- A Run Preview is continuity state, not authorization state.
+- Any future execution still requires the existing governed capability path, confirmation where required, and receipts.
+
+Use this document to clarify what Nova can safely understand before action, not to widen what Nova may do.
+
 ## Brain Loop
 
 ```text

--- a/docs/brain/IMPLEMENTATION_ROADMAP.md
+++ b/docs/brain/IMPLEMENTATION_ROADMAP.md
@@ -12,6 +12,10 @@ Done:
 - Brain runtime architecture doc exists.
 - Read-only `EnvironmentRequest` schema scaffold exists.
 - Task Clarifier is implemented for tested ambiguity/boundary prompts.
+- Task Understanding / Simple Task Mode / Task Envelope planning-only scaffolds exist.
+- General-chat fallback can attach a planning-only Task Understanding preview for task-like requests.
+- In-memory planning-only RunManager scaffold exists.
+- General-chat fallback can create a session-local planning Run Preview for task-like requests.
 - Static Capability Contract catalog exists for Cap 16, Cap 64, Cap 65, and Cap 63.
 - Brain live-test proof exists under `docs/demo_proof/brain_live_test/`.
 
@@ -20,8 +24,14 @@ Still not done:
 - full Task Environment Router
 - live Capability Contract lookup
 - Capability Contract use by runtime routing/Governor
+- Task Understanding MVP integration beyond conversation fallback preview helper
+- Simple Task Mode integration beyond conversation fallback preview helper
+- Task Envelope MVP integration beyond conversation fallback preview helper
+- RunManager persistence, UI integration, or execution integration
+- Run Preview integration beyond session-local conversation fallback metadata
 - Dry Run / Plan Preview API
 - Brain Trace UI
+- Co-Work page
 - project context engine
 - suggestion buffer runtime
 - full OpenClaw environment planning
@@ -205,10 +215,12 @@ Mapping to existing roadmap phases:
 | 2 — Environment Catalog | ✅ | `EnvironmentType` / `AuthorityTier` enums | `test_environment_request.py` | none |
 | 3 — Capability Contracts | ✅ | `CapabilityContract` dataclass | `test_environment_request.py` | none |
 | 4 — Dry Run / Plan Preview | ⚠️ partial | `BrainDryRun`, `task_to_environment_request()` | `test_environment_request.py` | none (builder exists, no routing wired) |
-| 5 — Brain Trace UI | ⚠️ schema only | `BrainTraceEvent` dataclass | `test_environment_request.py` | none |
-| 6 — Cap 16 Reliability Integration | ❌ | — | — | — |
-| 7 — OpenClaw Environment Planning | ❌ | planning docs only | — | none |
-| 8 — Project Contexts / Suggestion Buffer | ❌ | — | — | — |
+| 5 — Task Understanding / Simple Task Mode | ✅ scaffold | `TaskUnderstanding`, `TaskEnvelope`, `SimpleTaskPlan` | `test_task_understanding.py` | conversation fallback preview helper only |
+| 6 — Planning-only RunManager / Run Preview | ✅ scaffold | `RunManager`, `Run`, `RunStep`, planning preview helper | `test_run_manager.py`, conversation preview tests | session-local conversation metadata only |
+| 7 — Brain Trace UI | ⚠️ schema only | `BrainTraceEvent` dataclass | `test_environment_request.py` | none |
+| 8 — Cap 16 Reliability Integration | ❌ | — | — | — |
+| 9 — OpenClaw Environment Planning | ❌ | planning docs only | — | none |
+| 10 — Project Contexts / Suggestion Buffer | ❌ | — | — | — |
 
 Capability Contracts status note: the shared `CapabilityContract` dataclass exists, and a static catalog now exists in `src/brain/capability_contracts.py` for Cap 16, Cap 64, Cap 65, and Cap 63. Runtime contract lookup is not wired into the full Task Environment Router or Governor path yet.
 

--- a/docs/brain/README.md
+++ b/docs/brain/README.md
@@ -41,6 +41,10 @@ Let receipts prove.
 Implemented today:
 
 - Task Clarifier for tested ambiguity/boundary prompt classes
+- Task Understanding / Simple Task Mode / Task Envelope planning-only scaffold
+- conversation fallback helper can attach a planning-only Task Understanding preview for task-like requests
+- planning-only in-memory RunManager scaffold for run creation, listing, pause/cancel, and focus tracking
+- conversation fallback helper can create a session-local planning Run Preview for task-like requests
 - read-only EnvironmentRequest schema scaffold
 - static Capability Contract catalog for Cap 16, Cap 64, Cap 65, and Cap 63
 - Brain live proof package under `docs/demo_proof/brain_live_test/`
@@ -50,7 +54,12 @@ Not fully implemented yet:
 - full Task Environment Router
 - runtime/live Capability Contract lookup
 - Dry Run / Plan Preview API
+- full runtime routing for Task Understanding / Simple Task Mode / Task Envelope
+- persistent RunManager storage
+- RunManager integration with dashboard / Co-Work page
+- persistent Run Preview history
 - Brain Trace UI
+- Co-Work page
 - project context engine
 - suggestion buffer runtime
 - full OpenClaw environment planning

--- a/nova_backend/src/brain/run_manager.py
+++ b/nova_backend/src/brain/run_manager.py
@@ -1,0 +1,191 @@
+"""Planning-only Brain run manager.
+
+This module tracks non-executing planning runs in memory. It does not call the
+Governor, capabilities, OpenClaw, browser tools, file tools, email, calendar, or
+account systems. A run is continuity state, not permission.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field, replace
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Callable
+from uuid import uuid4
+
+from src.brain.task_understanding import SimpleTaskPlan, TaskEnvelope, TaskUnderstanding
+
+
+class _StringEnum(str, Enum):
+    def __str__(self) -> str:
+        return str(self.value)
+
+
+class RunStatus(_StringEnum):
+    PLANNING = "planning"
+    PAUSED = "paused"
+    CANCELLED = "cancelled"
+
+
+@dataclass(frozen=True)
+class RunStep:
+    step_id: str
+    description: str
+    status: str = "planned"
+    authority_effect: str = "none"
+    execution_performed: bool = False
+    authorization_granted: bool = False
+
+    def __post_init__(self) -> None:
+        if self.authority_effect != "none":
+            raise ValueError("RunStep is non-authorizing: authority_effect must be 'none'.")
+        if self.execution_performed:
+            raise ValueError("RunStep must not record executed actions.")
+        if self.authorization_granted:
+            raise ValueError("RunStep must not grant authorization.")
+
+
+@dataclass(frozen=True)
+class Run:
+    run_id: str
+    goal: str
+    status: RunStatus
+    created_at: str
+    updated_at: str
+    understanding: TaskUnderstanding
+    envelope: TaskEnvelope
+    steps: tuple[RunStep, ...] = field(default_factory=tuple)
+    planning_only: bool = True
+    authority_effect: str = "none"
+    execution_performed: bool = False
+    authorization_granted: bool = False
+    pause_reason: str = ""
+    cancel_reason: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.planning_only:
+            raise ValueError("Run must remain planning-only.")
+        if self.authority_effect != "none":
+            raise ValueError("Run is non-authorizing: authority_effect must be 'none'.")
+        if self.execution_performed:
+            raise ValueError("Run must not record executed actions.")
+        if self.authorization_granted:
+            raise ValueError("Run must not grant authorization.")
+
+    def to_dict(self) -> dict[str, Any]:
+        return _to_primitive(self)
+
+
+class RunManager:
+    """In-memory manager for planning-only Brain runs."""
+
+    def __init__(
+        self,
+        *,
+        id_factory: Callable[[], str] | None = None,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._runs: dict[str, Run] = {}
+        self._last_interacted_run_id: str | None = None
+        self._id_factory = id_factory or (lambda: f"run_{uuid4().hex}")
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+
+    @property
+    def last_interacted_run_id(self) -> str | None:
+        return self._last_interacted_run_id
+
+    def create_run(self, plan: SimpleTaskPlan) -> Run:
+        if not plan.planning_only or plan.execution_performed or plan.authorization_granted:
+            raise ValueError("RunManager only accepts planning-only, non-authorizing plans.")
+
+        now = self._now()
+        run = Run(
+            run_id=self._id_factory(),
+            goal=plan.understanding.goal,
+            status=RunStatus.PLANNING,
+            created_at=now,
+            updated_at=now,
+            understanding=plan.understanding,
+            envelope=plan.envelope,
+            steps=tuple(
+                RunStep(step_id=f"step_{index}", description=description)
+                for index, description in enumerate(plan.plan_steps, start=1)
+            ),
+        )
+        self._runs[run.run_id] = run
+        self._last_interacted_run_id = run.run_id
+        return run
+
+    def get_run(self, run_id: str) -> Run | None:
+        return self._runs.get(str(run_id or "").strip())
+
+    def list_runs(self) -> tuple[Run, ...]:
+        return tuple(self._runs.values())
+
+    def pause_run(self, run_id: str, reason: str = "") -> Run | None:
+        run = self.get_run(run_id)
+        if run is None:
+            return None
+        updated = replace(
+            run,
+            status=RunStatus.PAUSED,
+            updated_at=self._now(),
+            pause_reason=str(reason or "").strip(),
+        )
+        self._runs[run.run_id] = updated
+        self._last_interacted_run_id = run.run_id
+        return updated
+
+    def cancel_run(self, run_id: str, reason: str = "") -> Run | None:
+        run = self.get_run(run_id)
+        if run is None:
+            return None
+        updated = replace(
+            run,
+            status=RunStatus.CANCELLED,
+            updated_at=self._now(),
+            cancel_reason=str(reason or "").strip(),
+        )
+        self._runs[run.run_id] = updated
+        self._last_interacted_run_id = run.run_id
+        return updated
+
+    def update_focus(self, run_id: str) -> Run | None:
+        run = self.get_run(run_id)
+        if run is None:
+            return None
+        self._last_interacted_run_id = run.run_id
+        return run
+
+    def last_interacted_run(self) -> Run | None:
+        if self._last_interacted_run_id is None:
+            return None
+        return self.get_run(self._last_interacted_run_id)
+
+    def _now(self) -> str:
+        value = self._clock()
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc).isoformat()
+
+
+def _to_primitive(value: Any) -> Any:
+    if isinstance(value, Enum):
+        return value.value
+    if hasattr(value, "__dataclass_fields__"):
+        return {key: _to_primitive(item) for key, item in asdict(value).items()}
+    if isinstance(value, tuple):
+        return [_to_primitive(item) for item in value]
+    if isinstance(value, list):
+        return [_to_primitive(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _to_primitive(item) for key, item in value.items()}
+    return value
+
+
+__all__ = [
+    "Run",
+    "RunManager",
+    "RunStatus",
+    "RunStep",
+]

--- a/nova_backend/src/brain/task_understanding.py
+++ b/nova_backend/src/brain/task_understanding.py
@@ -1,0 +1,331 @@
+"""Planning-only Brain task understanding scaffold.
+
+This module turns a user request plus optional local context into structured
+planning metadata. It does not execute, authorize, route capabilities, call
+OpenClaw, write files, or bypass the Governor.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any, Iterable
+
+
+class _StringEnum(str, Enum):
+    def __str__(self) -> str:
+        return str(self.value)
+
+
+class ContextSource(_StringEnum):
+    STABLE_MEMORY = "stable_memory"
+    SESSION_CONTEXT = "session_context"
+    INFERRED_ASSUMPTION = "inferred_assumption"
+    SYSTEM_LIMITATION = "system_limitation"
+
+
+class ApprovalLevel(_StringEnum):
+    NONE = "none"
+    USER_REVIEW_ONLY = "user_review_only"
+
+
+@dataclass(frozen=True)
+class ContextUsed:
+    source: ContextSource
+    label: str
+    value: str
+
+
+@dataclass(frozen=True)
+class TaskUnderstanding:
+    goal: str
+    context_used: tuple[ContextUsed, ...] = ()
+    constraints: tuple[str, ...] = ()
+    assumptions: tuple[str, ...] = ()
+    confidence: float = 0.0
+    clarification_needed: bool = False
+    suggested_next_step: str = ""
+    authority_effect: str = "none"
+    execution_performed: bool = False
+    authorization_granted: bool = False
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError(f"confidence must be 0.0-1.0, got {self.confidence}")
+        if self.authority_effect != "none":
+            raise ValueError("TaskUnderstanding is non-authorizing: authority_effect must be 'none'.")
+        if self.execution_performed:
+            raise ValueError("TaskUnderstanding must not record executed actions.")
+        if self.authorization_granted:
+            raise ValueError("TaskUnderstanding must not grant authorization.")
+
+    def to_dict(self) -> dict[str, Any]:
+        return _to_primitive(self)
+
+
+@dataclass(frozen=True)
+class TaskEnvelope:
+    allowed_actions: tuple[str, ...]
+    blocked_actions: tuple[str, ...]
+    environment_scope: tuple[str, ...]
+    step_limit: int
+    approval_level: ApprovalLevel
+    stop_condition: str
+    failure_behavior: str
+    authority_effect: str = "none"
+
+    def __post_init__(self) -> None:
+        if self.step_limit < 1:
+            raise ValueError("step_limit must be at least 1")
+        if self.authority_effect != "none":
+            raise ValueError("TaskEnvelope is non-authorizing: authority_effect must be 'none'.")
+
+    def to_dict(self) -> dict[str, Any]:
+        return _to_primitive(self)
+
+
+@dataclass(frozen=True)
+class SimpleTaskPlan:
+    mode: str
+    planning_only: bool
+    understanding: TaskUnderstanding
+    envelope: TaskEnvelope
+    plan_steps: tuple[str, ...] = field(default_factory=tuple)
+    execution_performed: bool = False
+    authorization_granted: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.planning_only:
+            raise ValueError("SimpleTaskPlan must remain planning-only.")
+        if self.execution_performed:
+            raise ValueError("SimpleTaskPlan must not execute actions.")
+        if self.authorization_granted:
+            raise ValueError("SimpleTaskPlan must not grant authorization.")
+
+    def to_dict(self) -> dict[str, Any]:
+        return _to_primitive(self)
+
+
+_SCRIPT_PLAN_RE = re.compile(r"\b(?:turn|convert|make)\b.{0,80}\b(?:script)\b.{0,80}\b(?:scene plan|scenes?)\b", re.I)
+_SUMMARY_RE = re.compile(r"\b(?:summari[sz]e|summary)\b.{0,80}\b(?:task|request|this)\b", re.I)
+_CLARIFICATION_RE = re.compile(r"\b(?:clarification|clarify|missing|ambiguous|unclear)\b", re.I)
+_ENVELOPE_RE = re.compile(r"\b(?:bounded task envelope|task envelope|envelope)\b", re.I)
+_AMBIGUOUS_REFERENCE_RE = re.compile(r"\b(?:this|that|it|them|the above|previous)\b", re.I)
+_HIGH_EFFECT_RE = re.compile(
+    r"\b(?:open browser|openclaw|send email|schedule|book|purchase|buy|post|publish|delete|write files?|update account|shopify)\b",
+    re.I,
+)
+
+
+def understand_task(
+    message: str,
+    *,
+    session_context: dict[str, str] | None = None,
+    stable_memory: Iterable[str] | None = None,
+) -> TaskUnderstanding:
+    """Return conservative, non-authorizing task understanding.
+
+    `stable_memory` is caller-provided only. This module intentionally does not
+    read runtime memory stores; when no memory is provided, it records that
+    limitation instead of pretending memory was consulted.
+    """
+
+    text = (message or "").strip()
+    session = {str(k): str(v) for k, v in (session_context or {}).items() if str(v).strip()}
+    memories = tuple(str(item).strip() for item in (stable_memory or ()) if str(item).strip())
+    context_used = _context_used(session, memories)
+    goal = _goal_from_message(text)
+    assumptions: list[str] = []
+    constraints = [
+        "planning-only",
+        "does not execute tools or capabilities",
+        "does not authorize actions",
+        "does not bypass GovernorMediator",
+    ]
+
+    if _HIGH_EFFECT_RE.search(text):
+        constraints.extend(
+            [
+                "no browser tabs opened",
+                "no OpenClaw execution",
+                "no email sending",
+                "no scheduling or account actions",
+                "no file writes",
+            ]
+        )
+
+    needs_context = bool(_AMBIGUOUS_REFERENCE_RE.search(text)) or not text
+    has_context = bool(session)
+    clarification_needed = needs_context and not has_context
+
+    if _SCRIPT_PLAN_RE.search(text) and not _has_context_key(session, "script"):
+        clarification_needed = True
+        assumptions.append("No script text was available in session context.")
+    elif _SCRIPT_PLAN_RE.search(text):
+        assumptions.append("The provided session script is the source material to plan from.")
+
+    if _SUMMARY_RE.search(text) and needs_context and not has_context:
+        clarification_needed = True
+        assumptions.append("The task to summarize was referenced but not provided.")
+
+    if not memories:
+        context_used = context_used + (
+            ContextUsed(
+                source=ContextSource.SYSTEM_LIMITATION,
+                label="stable_memory",
+                value="No runtime memory integration was read by this planning scaffold.",
+            ),
+        )
+
+    if not text:
+        suggested = "Ask the user what task they want planned."
+        confidence = 0.0
+    elif clarification_needed:
+        suggested = "Ask one focused clarification before making a plan."
+        confidence = 0.42
+    else:
+        suggested = "Prepare a planning-only summary and bounded task envelope."
+        confidence = 0.78 if has_context or memories else 0.62
+
+    return TaskUnderstanding(
+        goal=goal,
+        context_used=context_used,
+        constraints=tuple(dict.fromkeys(constraints)),
+        assumptions=tuple(assumptions),
+        confidence=confidence,
+        clarification_needed=clarification_needed,
+        suggested_next_step=suggested,
+    )
+
+
+def build_task_envelope(*, step_limit: int = 4) -> TaskEnvelope:
+    """Return the default planning-only envelope for Simple Task Mode."""
+
+    return TaskEnvelope(
+        allowed_actions=(
+            "summarize provided task/context",
+            "identify missing clarification",
+            "draft a bounded plan",
+            "create a non-executing task envelope",
+        ),
+        blocked_actions=(
+            "open browser tabs",
+            "write or modify files",
+            "use OpenClaw",
+            "send email",
+            "schedule calendar events",
+            "perform account actions",
+            "publish, trade, purchase, or submit forms",
+            "authorize capabilities",
+        ),
+        environment_scope=("local_conversation", "provided_session_context", "caller_provided_stable_memory"),
+        step_limit=step_limit,
+        approval_level=ApprovalLevel.USER_REVIEW_ONLY,
+        stop_condition="Stop after producing the planning artifact or when required context is missing.",
+        failure_behavior="Ask for clarification; do not guess, execute, or escalate to tools.",
+    )
+
+
+def build_simple_task_plan(
+    message: str,
+    *,
+    session_context: dict[str, str] | None = None,
+    stable_memory: Iterable[str] | None = None,
+    step_limit: int = 4,
+) -> SimpleTaskPlan:
+    """Build a planning-only Simple Task Mode result."""
+
+    understanding = understand_task(message, session_context=session_context, stable_memory=stable_memory)
+    envelope = build_task_envelope(step_limit=step_limit)
+    steps = _plan_steps(message, understanding)
+    return SimpleTaskPlan(
+        mode="simple_task_mode",
+        planning_only=True,
+        understanding=understanding,
+        envelope=envelope,
+        plan_steps=steps,
+    )
+
+
+def _context_used(session: dict[str, str], memories: tuple[str, ...]) -> tuple[ContextUsed, ...]:
+    used: list[ContextUsed] = []
+    for key in sorted(session):
+        used.append(ContextUsed(source=ContextSource.SESSION_CONTEXT, label=key, value=session[key]))
+    for index, memory in enumerate(memories, start=1):
+        used.append(ContextUsed(source=ContextSource.STABLE_MEMORY, label=f"memory_{index}", value=memory))
+    return tuple(used)
+
+
+def _goal_from_message(text: str) -> str:
+    if not text:
+        return "No task goal provided."
+    clean = " ".join(text.split())
+    return clean[:180]
+
+
+def _has_context_key(session: dict[str, str], needle: str) -> bool:
+    lowered = needle.lower()
+    return any(lowered in key.lower() for key in session)
+
+
+def _plan_steps(message: str, understanding: TaskUnderstanding) -> tuple[str, ...]:
+    text = (message or "").strip()
+    if understanding.clarification_needed:
+        return ("Ask for the missing source material or target.",)
+    if _SCRIPT_PLAN_RE.search(text):
+        return (
+            "Identify the core beats in the provided script.",
+            "Group beats into concise scenes.",
+            "Return the scene plan for user review.",
+        )
+    if _CLARIFICATION_RE.search(text):
+        return (
+            "List what is known.",
+            "List what is missing or ambiguous.",
+            "Ask the smallest useful clarification.",
+        )
+    if _ENVELOPE_RE.search(text):
+        return (
+            "State the planning-only scope.",
+            "List allowed and blocked actions.",
+            "Name the stop condition and failure behavior.",
+        )
+    if _SUMMARY_RE.search(text):
+        return (
+            "Read only the provided task/context.",
+            "Summarize the goal and constraints.",
+            "Suggest the next safe planning step.",
+        )
+    return (
+        "Summarize the understood goal.",
+        "State constraints and assumptions.",
+        "Suggest the next safe planning step.",
+    )
+
+
+def _to_primitive(value: Any) -> Any:
+    if isinstance(value, Enum):
+        return value.value
+    if hasattr(value, "__dataclass_fields__"):
+        return {key: _to_primitive(item) for key, item in asdict(value).items()}
+    if isinstance(value, tuple):
+        return [_to_primitive(item) for item in value]
+    if isinstance(value, list):
+        return [_to_primitive(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _to_primitive(item) for key, item in value.items()}
+    return value
+
+
+__all__ = [
+    "ApprovalLevel",
+    "ContextSource",
+    "ContextUsed",
+    "SimpleTaskPlan",
+    "TaskEnvelope",
+    "TaskUnderstanding",
+    "build_simple_task_plan",
+    "build_task_envelope",
+    "understand_task",
+]

--- a/nova_backend/src/conversation/general_chat_runtime.py
+++ b/nova_backend/src/conversation/general_chat_runtime.py
@@ -61,6 +61,14 @@ async def run_general_chat_fallback(
 
     chat_context = list(session_state.get("general_chat_context") or session_context)
     skill_state = dict(session_state)
+    skill_state.pop("_planning_run_manager", None)
+    for transient_key in (
+        "task_understanding_preview",
+        "task_understanding_prompt_block",
+        "task_understanding_envelope",
+        "planning_run_preview",
+    ):
+        skill_state.pop(transient_key, None)
     skill_state["relevant_memory_context"] = relevant_memory_context
 
     understanding = build_request_understanding(normalized_query)

--- a/nova_backend/src/conversation/general_chat_runtime.py
+++ b/nova_backend/src/conversation/general_chat_runtime.py
@@ -12,9 +12,11 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Optional
 
 from src.base_skill import SkillResult
+from src.conversation.planning_run_preview import create_planning_run_preview
 from src.conversation.request_understanding import build_request_understanding
 from src.conversation.request_understanding_formatter import format_request_understanding_block
 from src.conversation.session_router import SessionRouter
+from src.conversation.task_understanding_preview import build_task_understanding_preview
 from src.governor.network_mediator import NetworkMediator
 from src.personality.tone_profile_store import ToneProfileStore
 from src.skills.general_chat import GeneralChatSkill
@@ -63,9 +65,71 @@ async def run_general_chat_fallback(
 
     understanding = build_request_understanding(normalized_query)
     skill_state["request_understanding"] = understanding
-    skill_state["request_understanding_prompt_block"] = format_request_understanding_block(understanding)
+    request_block = format_request_understanding_block(understanding)
+
+    task_preview = build_task_understanding_preview(
+        normalized_query,
+        session_context=_task_preview_session_context(skill_state, chat_context),
+        stable_memory=_task_preview_memory_context(relevant_memory_context),
+    )
+    skill_state["task_understanding_preview"] = task_preview.plan
+    skill_state["task_understanding_prompt_block"] = task_preview.prompt_block
+    if task_preview.plan is not None:
+        skill_state["task_understanding_envelope"] = task_preview.plan.envelope
+        run_preview = create_planning_run_preview(
+            task_preview.plan,
+            session_state=session_state,
+            focused_run_id=str(session_state.get("focused_run_id") or ""),
+        )
+        if run_preview is not None:
+            skill_state["planning_run_preview"] = run_preview.to_dict()
+            skill_state["last_interacted_run_id"] = run_preview.last_interacted_run_id
+            skill_state["focused_run_id"] = run_preview.focused_run_id
+
+    skill_state["request_understanding_prompt_block"] = "\n\n".join(
+        block for block in (request_block, task_preview.prompt_block) if block
+    )
 
     return await general_chat_skill.handle(normalized_query, chat_context, skill_state)
+
+
+def _task_preview_session_context(
+    session_state: dict[str, Any],
+    chat_context: list[dict[str, Any]],
+) -> dict[str, str]:
+    context: dict[str, str] = {}
+    conversation_context = dict(session_state.get("conversation_context") or {})
+    for key in ("topic", "user_goal", "open_question", "latest_recommendation"):
+        value = str(conversation_context.get(key) or "").strip()
+        if value:
+            context[key] = value
+
+    for entry in reversed(chat_context[-4:]):
+        if not isinstance(entry, dict):
+            continue
+        role = str(entry.get("role") or "").strip().lower()
+        content = str(entry.get("content") or "").strip()
+        if role in {"user", "assistant"} and content:
+            context[f"recent_{role}"] = content[:240]
+            break
+    return context
+
+
+def _task_preview_memory_context(memory_context: list[dict[str, Any]]) -> tuple[str, ...]:
+    memories: list[str] = []
+    for entry in memory_context[:3]:
+        if not isinstance(entry, dict):
+            continue
+        text = str(
+            entry.get("content")
+            or entry.get("text")
+            or entry.get("summary")
+            or entry.get("value")
+            or ""
+        ).strip()
+        if text:
+            memories.append(text[:240])
+    return tuple(memories)
 
 
 async def resolve_pending_escalation_reply(

--- a/nova_backend/src/conversation/planning_run_preview.py
+++ b/nova_backend/src/conversation/planning_run_preview.py
@@ -33,6 +33,16 @@ class PlanningRunPreview:
     execution_performed: bool = False
     authorization_granted: bool = False
 
+    def __post_init__(self) -> None:
+        if not self.planning_only:
+            raise ValueError("PlanningRunPreview must remain planning-only.")
+        if self.authority_effect != "none":
+            raise ValueError("PlanningRunPreview is non-authorizing: authority_effect must be 'none'.")
+        if self.execution_performed:
+            raise ValueError("PlanningRunPreview must not record executed actions.")
+        if self.authorization_granted:
+            raise ValueError("PlanningRunPreview must not grant authorization.")
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "run_id": self.run_id,
@@ -64,11 +74,9 @@ def create_planning_run_preview(
         raise ValueError("Planning run previews require non-executing, non-authorizing plans.")
 
     manager = planning_run_manager(session_state)
-    run = manager.create_run(plan)
-    if focused_run_id:
-        focused = manager.update_focus(focused_run_id)
-        if focused is not None:
-            run = focused
+    run = manager.update_focus(focused_run_id) if focused_run_id else None
+    if run is None:
+        run = manager.create_run(plan)
     preview = format_planning_run_preview(run, manager=manager, focused_run_id=run.run_id)
     session_state["planning_run_preview"] = preview.to_dict()
     session_state["last_interacted_run_id"] = manager.last_interacted_run_id

--- a/nova_backend/src/conversation/planning_run_preview.py
+++ b/nova_backend/src/conversation/planning_run_preview.py
@@ -1,0 +1,122 @@
+"""Conversation-facing planning run preview helpers.
+
+This module adapts Brain RunManager state for session/UI use. It creates
+planning-only runs from Task Understanding plans and returns small preview
+payloads. It does not execute, authorize, call capabilities, call the Governor,
+or persist runs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from src.brain.run_manager import Run, RunManager
+from src.brain.task_understanding import SimpleTaskPlan
+
+
+_RUN_MANAGER_KEY = "_planning_run_manager"
+
+
+@dataclass(frozen=True)
+class PlanningRunPreview:
+    run_id: str
+    title: str
+    goal: str
+    status: str
+    current_step: str
+    next_step: str
+    last_interacted_run_id: str
+    focused_run_id: str
+    planning_only: bool = True
+    authority_effect: str = "none"
+    execution_performed: bool = False
+    authorization_granted: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "title": self.title,
+            "goal": self.goal,
+            "status": self.status,
+            "current_step": self.current_step,
+            "next_step": self.next_step,
+            "last_interacted_run_id": self.last_interacted_run_id,
+            "focused_run_id": self.focused_run_id,
+            "planning_only": self.planning_only,
+            "authority_effect": self.authority_effect,
+            "execution_performed": self.execution_performed,
+            "authorization_granted": self.authorization_granted,
+        }
+
+
+def create_planning_run_preview(
+    plan: SimpleTaskPlan | None,
+    *,
+    session_state: dict[str, Any],
+    focused_run_id: str = "",
+) -> PlanningRunPreview | None:
+    """Create a planning-only run preview when a plan exists."""
+
+    if plan is None:
+        return None
+    if not plan.planning_only or plan.execution_performed or plan.authorization_granted:
+        raise ValueError("Planning run previews require non-executing, non-authorizing plans.")
+
+    manager = planning_run_manager(session_state)
+    run = manager.create_run(plan)
+    if focused_run_id:
+        focused = manager.update_focus(focused_run_id)
+        if focused is not None:
+            run = focused
+    preview = format_planning_run_preview(run, manager=manager, focused_run_id=run.run_id)
+    session_state["planning_run_preview"] = preview.to_dict()
+    session_state["last_interacted_run_id"] = manager.last_interacted_run_id
+    session_state["focused_run_id"] = preview.focused_run_id
+    return preview
+
+
+def format_planning_run_preview(
+    run: Run,
+    *,
+    manager: RunManager | None = None,
+    focused_run_id: str = "",
+) -> PlanningRunPreview:
+    """Return serializable preview metadata for a planning run."""
+
+    current_step = run.steps[0].description if run.steps else "understand request"
+    if len(run.steps) > 1:
+        next_step = run.steps[1].description
+    else:
+        next_step = run.understanding.suggested_next_step or "build task envelope"
+    last_interacted = manager.last_interacted_run_id if manager is not None else run.run_id
+    focused = focused_run_id or last_interacted or run.run_id
+    return PlanningRunPreview(
+        run_id=run.run_id,
+        title=run.goal,
+        goal=run.goal,
+        status=run.status.value,
+        current_step=current_step,
+        next_step=next_step,
+        last_interacted_run_id=last_interacted or "",
+        focused_run_id=focused,
+    )
+
+
+def planning_run_manager(session_state: dict[str, Any]) -> RunManager:
+    """Return the session-local in-memory RunManager."""
+
+    existing = session_state.get(_RUN_MANAGER_KEY)
+    if isinstance(existing, RunManager):
+        return existing
+    manager = RunManager()
+    session_state[_RUN_MANAGER_KEY] = manager
+    return manager
+
+
+__all__ = [
+    "PlanningRunPreview",
+    "create_planning_run_preview",
+    "format_planning_run_preview",
+    "planning_run_manager",
+]

--- a/nova_backend/src/conversation/task_understanding_preview.py
+++ b/nova_backend/src/conversation/task_understanding_preview.py
@@ -1,0 +1,119 @@
+"""Conversation-facing Task Understanding preview helpers.
+
+These helpers expose the Brain planning scaffold to conversation code without
+turning it into a route, approval, or execution path.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable
+
+from src.brain.task_understanding import SimpleTaskPlan, build_simple_task_plan
+
+
+_TASK_LIKE_RE = re.compile(
+    r"\b("
+    r"task|plan|planning|scene plan|summari[sz]e|summary|clarif(?:y|ication)|"
+    r"bounded|envelope|assumptions?|constraints?|next step|steps?|run scaffold|"
+    r"turn this|convert this|make this"
+    r")\b",
+    re.IGNORECASE,
+)
+_CASUAL_RE = re.compile(
+    r"^\s*(?:hi|hello|hey|thanks|thank you|that sounds good|ok|okay|yes|no|sure)\s*[.!?]*\s*$",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class TaskUnderstandingPreview:
+    enabled: bool
+    plan: SimpleTaskPlan | None = None
+    prompt_block: str = ""
+
+    @property
+    def authority_effect(self) -> str:
+        return "none"
+
+
+def build_task_understanding_preview(
+    message: str,
+    *,
+    session_context: dict[str, str] | None = None,
+    stable_memory: Iterable[str] | None = None,
+    include_envelope: bool = True,
+) -> TaskUnderstandingPreview:
+    """Return a planning-only preview for task-like requests.
+
+    Casual/general chat returns a disabled preview. Enabled previews are still
+    non-authorizing and do not execute anything.
+    """
+
+    text = (message or "").strip()
+    if not _looks_task_like(text):
+        return TaskUnderstandingPreview(enabled=False)
+
+    plan = build_simple_task_plan(
+        text,
+        session_context=session_context,
+        stable_memory=stable_memory,
+    )
+    return TaskUnderstandingPreview(
+        enabled=True,
+        plan=plan,
+        prompt_block=format_task_understanding_preview(plan, include_envelope=include_envelope),
+    )
+
+
+def format_task_understanding_preview(plan: SimpleTaskPlan, *, include_envelope: bool = True) -> str:
+    """Format a compact preview block for prompt/UI use."""
+
+    understanding = plan.understanding
+    lines = [
+        "Task understanding preview (planning-only, non-authorizing):",
+        f"Goal: {understanding.goal}",
+        f"Context used: {_context_summary(understanding)}",
+        f"Constraints: {'; '.join(understanding.constraints) or 'none'}",
+        f"Assumptions: {'; '.join(understanding.assumptions) or 'none'}",
+        f"Confidence: {understanding.confidence:.2f}",
+        f"Clarification needed: {str(understanding.clarification_needed).lower()}",
+        f"Suggested next step: {understanding.suggested_next_step}",
+        "Authority effect: none. No tools, capabilities, Governor calls, OpenClaw, browser tabs, file writes, email, scheduling, or account actions.",
+    ]
+    if include_envelope:
+        envelope = plan.envelope
+        lines.extend(
+            [
+                "Task envelope:",
+                f"Allowed actions: {'; '.join(envelope.allowed_actions)}",
+                f"Blocked actions: {'; '.join(envelope.blocked_actions)}",
+                f"Environment scope: {'; '.join(envelope.environment_scope)}",
+                f"Step limit: {envelope.step_limit}",
+                f"Approval level: {envelope.approval_level.value}",
+                f"Stop condition: {envelope.stop_condition}",
+                f"Failure behavior: {envelope.failure_behavior}",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def _looks_task_like(text: str) -> bool:
+    if not text or _CASUAL_RE.match(text):
+        return False
+    return bool(_TASK_LIKE_RE.search(text))
+
+
+def _context_summary(plan_understanding) -> str:
+    context_items = list(plan_understanding.context_used or ())
+    if not context_items:
+        return "none"
+    return "; ".join(f"{item.source.value}:{item.label}" for item in context_items)
+
+
+__all__ = [
+    "TaskUnderstandingPreview",
+    "build_task_understanding_preview",
+    "format_task_understanding_preview",
+]

--- a/nova_backend/tests/brain/test_run_manager.py
+++ b/nova_backend/tests/brain/test_run_manager.py
@@ -1,0 +1,153 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from src.brain.run_manager import Run, RunManager, RunStatus, RunStep
+from src.brain.task_understanding import TaskUnderstanding, build_simple_task_plan
+from src.conversation.task_understanding_preview import build_task_understanding_preview
+
+
+def _manager() -> RunManager:
+    return RunManager(
+        id_factory=lambda: "run_test_1",
+        clock=lambda: datetime(2026, 4, 30, 12, 0, tzinfo=timezone.utc),
+    )
+
+
+def test_run_can_be_created_from_task_understanding_preview():
+    preview = build_task_understanding_preview(
+        "summarize this task",
+        session_context={"task": "Prepare a planning-only implementation outline."},
+    )
+    assert preview.plan is not None
+
+    manager = _manager()
+    run = manager.create_run(preview.plan)
+
+    assert run.run_id == "run_test_1"
+    assert run.status == RunStatus.PLANNING
+    assert run.goal == "summarize this task"
+    assert run.planning_only is True
+    assert run.execution_performed is False
+    assert run.authorization_granted is False
+    assert run.authority_effect == "none"
+    assert run.envelope.blocked_actions
+    assert manager.get_run("run_test_1") == run
+
+
+def test_run_steps_are_planning_only_and_non_authorizing():
+    plan = build_simple_task_plan(
+        "make a bounded task envelope",
+        session_context={"task": "Plan a safe repo review."},
+    )
+    run = _manager().create_run(plan)
+
+    assert run.steps
+    assert all(step.status == "planned" for step in run.steps)
+    assert all(step.authority_effect == "none" for step in run.steps)
+    assert all(step.execution_performed is False for step in run.steps)
+    assert all(step.authorization_granted is False for step in run.steps)
+
+
+def test_run_lifecycle_list_pause_cancel():
+    manager = _manager()
+    run = manager.create_run(build_simple_task_plan("find what clarification is needed"))
+
+    assert manager.list_runs() == (run,)
+
+    paused = manager.pause_run(run.run_id, reason="waiting for source material")
+    assert paused is not None
+    assert paused.status == RunStatus.PAUSED
+    assert paused.pause_reason == "waiting for source material"
+    assert paused.execution_performed is False
+    assert manager.get_run(run.run_id) == paused
+
+    cancelled = manager.cancel_run(run.run_id, reason="user changed direction")
+    assert cancelled is not None
+    assert cancelled.status == RunStatus.CANCELLED
+    assert cancelled.cancel_reason == "user changed direction"
+    assert cancelled.authorization_granted is False
+    assert manager.get_run(run.run_id) == cancelled
+
+
+def test_pause_cancel_unknown_run_return_none():
+    manager = _manager()
+
+    assert manager.get_run("missing") is None
+    assert manager.pause_run("missing") is None
+    assert manager.cancel_run("missing") is None
+    assert manager.update_focus("missing") is None
+
+
+def test_focus_tracking_uses_last_interacted_run():
+    ids = iter(["run_one", "run_two"])
+    manager = RunManager(id_factory=lambda: next(ids))
+
+    one = manager.create_run(build_simple_task_plan("summarize this task", session_context={"task": "one"}))
+    two = manager.create_run(build_simple_task_plan("make a bounded task envelope"))
+
+    assert manager.last_interacted_run_id == two.run_id
+    assert manager.last_interacted_run() == two
+
+    focused = manager.update_focus(one.run_id)
+    assert focused == one
+    assert manager.last_interacted_run_id == one.run_id
+    assert manager.last_interacted_run() == one
+
+
+def test_run_dict_serializes_without_permission_claims():
+    run = _manager().create_run(build_simple_task_plan("make a bounded task envelope"))
+    payload = run.to_dict()
+
+    assert payload["status"] == "planning"
+    assert payload["planning_only"] is True
+    assert payload["authority_effect"] == "none"
+    assert payload["execution_performed"] is False
+    assert payload["authorization_granted"] is False
+    assert payload["envelope"]["authority_effect"] == "none"
+    assert "execute" not in payload
+
+
+def test_run_manager_rejects_non_planning_plan():
+    plan = build_simple_task_plan("make a bounded task envelope")
+    bad_plan = type(
+        "BadPlan",
+        (),
+        {
+            "planning_only": False,
+            "execution_performed": False,
+            "authorization_granted": False,
+        },
+    )()
+
+    manager = _manager()
+    assert plan.planning_only is True
+    with pytest.raises(ValueError, match="planning-only"):
+        manager.create_run(bad_plan)  # type: ignore[arg-type]
+
+
+def test_models_reject_execution_or_authorization_fields():
+    with pytest.raises(ValueError, match="must not record executed"):
+        RunStep(step_id="bad", description="bad", execution_performed=True)
+
+    understanding = TaskUnderstanding(goal="bad")
+    plan = build_simple_task_plan("make a bounded task envelope")
+    with pytest.raises(ValueError, match="must not grant authorization"):
+        Run(
+            run_id="bad",
+            goal="bad",
+            status=RunStatus.PLANNING,
+            created_at="2026-04-30T12:00:00+00:00",
+            updated_at="2026-04-30T12:00:00+00:00",
+            understanding=understanding,
+            envelope=plan.envelope,
+            authorization_granted=True,
+        )
+
+
+def test_run_manager_has_no_execution_method():
+    manager = _manager()
+
+    assert not hasattr(manager, "execute")
+    assert not hasattr(manager, "execute_run")
+    assert not hasattr(manager, "run_capability")

--- a/nova_backend/tests/brain/test_task_understanding.py
+++ b/nova_backend/tests/brain/test_task_understanding.py
@@ -1,0 +1,141 @@
+import pytest
+
+from src.brain.task_understanding import (
+    ApprovalLevel,
+    ContextSource,
+    TaskEnvelope,
+    TaskUnderstanding,
+    build_simple_task_plan,
+    build_task_envelope,
+    understand_task,
+)
+
+
+def test_task_understanding_returns_structured_output():
+    out = understand_task("summarize this task", session_context={"task": "Prepare a planning-only outline."})
+    payload = out.to_dict()
+
+    assert payload["goal"] == "summarize this task"
+    assert payload["context_used"][0]["source"] == "session_context"
+    assert payload["constraints"]
+    assert payload["assumptions"] == []
+    assert 0.0 <= payload["confidence"] <= 1.0
+    assert payload["clarification_needed"] is False
+    assert payload["suggested_next_step"]
+
+
+def test_task_understanding_does_not_execute_or_authorize():
+    out = understand_task("open browser tabs and compare these sites")
+
+    assert out.execution_performed is False
+    assert out.authorization_granted is False
+    assert out.authority_effect == "none"
+    assert "no browser tabs opened" in out.constraints
+    assert "no OpenClaw execution" in out.constraints
+
+
+def test_task_understanding_rejects_authorizing_instances():
+    with pytest.raises(ValueError, match="non-authorizing"):
+        TaskUnderstanding(
+            goal="bad",
+            authority_effect="approved",
+        )
+
+
+def test_ambiguous_task_triggers_clarification():
+    out = understand_task("turn this script into a scene plan")
+
+    assert out.clarification_needed is True
+    assert out.suggested_next_step == "Ask one focused clarification before making a plan."
+    assert "No script text was available in session context." in out.assumptions
+
+
+def test_known_session_context_reduces_unnecessary_clarification():
+    out = understand_task(
+        "turn this script into a scene plan",
+        session_context={"script": "A founder interviews customers and revises the prototype."},
+    )
+
+    assert out.clarification_needed is False
+    assert out.confidence > 0.7
+    assert any(item.source == ContextSource.SESSION_CONTEXT for item in out.context_used)
+    assert "The provided session script is the source material to plan from." in out.assumptions
+
+
+def test_stable_memory_is_distinguished_from_session_context_when_provided():
+    out = understand_task(
+        "make a bounded task envelope",
+        session_context={"task": "Plan a repo review."},
+        stable_memory=["User prefers small implementation steps."],
+    )
+
+    sources = [item.source for item in out.context_used]
+    assert ContextSource.SESSION_CONTEXT in sources
+    assert ContextSource.STABLE_MEMORY in sources
+    assert ContextSource.SYSTEM_LIMITATION not in sources
+
+
+def test_missing_memory_integration_is_stubbed_honestly():
+    out = understand_task("make a bounded task envelope")
+
+    assert any(item.source == ContextSource.SYSTEM_LIMITATION for item in out.context_used)
+    assert "No runtime memory integration was read" in " ".join(item.value for item in out.context_used)
+
+
+def test_task_envelope_includes_blocked_actions_and_stop_condition():
+    envelope = build_task_envelope(step_limit=3)
+
+    assert envelope.allowed_actions
+    assert "use OpenClaw" in envelope.blocked_actions
+    assert "send email" in envelope.blocked_actions
+    assert envelope.stop_condition
+    assert envelope.failure_behavior.startswith("Ask for clarification")
+    assert envelope.approval_level == ApprovalLevel.USER_REVIEW_ONLY
+    assert envelope.authority_effect == "none"
+
+
+def test_task_envelope_rejects_invalid_step_limit():
+    with pytest.raises(ValueError, match="step_limit"):
+        TaskEnvelope(
+            allowed_actions=("summarize",),
+            blocked_actions=("execute",),
+            environment_scope=("local_conversation",),
+            step_limit=0,
+            approval_level=ApprovalLevel.USER_REVIEW_ONLY,
+            stop_condition="stop",
+            failure_behavior="ask",
+        )
+
+
+def test_simple_task_mode_stays_planning_only():
+    plan = build_simple_task_plan(
+        "find what clarification is needed",
+        session_context={"task": "Compare two unnamed websites."},
+    )
+
+    assert plan.mode == "simple_task_mode"
+    assert plan.planning_only is True
+    assert plan.execution_performed is False
+    assert plan.authorization_granted is False
+    assert "open browser tabs" in plan.envelope.blocked_actions
+    assert "authorize capabilities" in plan.envelope.blocked_actions
+    assert plan.plan_steps == (
+        "List what is known.",
+        "List what is missing or ambiguous.",
+        "Ask the smallest useful clarification.",
+    )
+
+
+def test_simple_task_mode_scene_plan_uses_only_provided_context():
+    plan = build_simple_task_plan(
+        "turn this script into a scene plan",
+        session_context={"script": "A customer discovers Nova, tests it, and approves the plan."},
+    )
+
+    assert plan.understanding.clarification_needed is False
+    assert plan.envelope.environment_scope == (
+        "local_conversation",
+        "provided_session_context",
+        "caller_provided_stable_memory",
+    )
+    assert plan.plan_steps[-1] == "Return the scene plan for user review."

--- a/nova_backend/tests/conversation/test_planning_run_preview.py
+++ b/nova_backend/tests/conversation/test_planning_run_preview.py
@@ -1,0 +1,145 @@
+import asyncio
+
+from src.base_skill import SkillResult
+from src.conversation.general_chat_runtime import run_general_chat_fallback
+from src.conversation.planning_run_preview import (
+    create_planning_run_preview,
+    planning_run_manager,
+)
+from src.conversation.task_understanding_preview import build_task_understanding_preview
+
+
+class _FakeGeneralChatSkill:
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def can_handle(self, query: str) -> bool:
+        return bool(query.strip())
+
+    async def handle(self, query: str, context=None, session_state=None):
+        self.calls.append({"query": query, "session_state": dict(session_state or {})})
+        return SkillResult(success=True, message="ok", skill="general_chat")
+
+
+def _noop_memory(query, *, session_state, project_threads):
+    return []
+
+
+def test_create_planning_run_preview_from_task_understanding_preview():
+    task_preview = build_task_understanding_preview(
+        "summarize this task",
+        session_context={"task": "Prepare a planning-only run preview."},
+    )
+    assert task_preview.plan is not None
+
+    session_state = {}
+    run_preview = create_planning_run_preview(task_preview.plan, session_state=session_state)
+
+    assert run_preview is not None
+    assert run_preview.run_id
+    assert run_preview.title == "summarize this task"
+    assert run_preview.goal == "summarize this task"
+    assert run_preview.status == "planning"
+    assert run_preview.current_step
+    assert run_preview.next_step
+    assert run_preview.planning_only is True
+    assert run_preview.authority_effect == "none"
+    assert run_preview.execution_performed is False
+    assert run_preview.authorization_granted is False
+    assert session_state["planning_run_preview"]["run_id"] == run_preview.run_id
+    assert session_state["last_interacted_run_id"] == run_preview.run_id
+
+
+def test_create_planning_run_preview_none_plan_creates_nothing():
+    session_state = {}
+
+    assert create_planning_run_preview(None, session_state=session_state) is None
+    assert "planning_run_preview" not in session_state
+    assert "last_interacted_run_id" not in session_state
+
+
+def test_planning_run_preview_focus_updates_safely():
+    session_state = {}
+    first = build_task_understanding_preview("summarize this task", session_context={"task": "one"})
+    second = build_task_understanding_preview("make a bounded task envelope")
+
+    assert first.plan is not None
+    assert second.plan is not None
+    first_preview = create_planning_run_preview(first.plan, session_state=session_state)
+    second_preview = create_planning_run_preview(second.plan, session_state=session_state)
+    assert first_preview is not None
+    assert second_preview is not None
+
+    manager = planning_run_manager(session_state)
+    focused = manager.update_focus(first_preview.run_id)
+
+    assert focused is not None
+    assert manager.last_interacted_run_id == first_preview.run_id
+    assert focused.execution_performed is False
+    assert focused.authorization_granted is False
+
+
+def test_general_chat_task_like_prompt_creates_planning_run_preview():
+    skill = _FakeGeneralChatSkill()
+    session_state = {"conversation_context": {"user_goal": "Plan the next safe Brain slice."}}
+
+    asyncio.run(
+        run_general_chat_fallback(
+            "summarize this task",
+            general_chat_skill=skill,
+            session_state=session_state,
+            session_context=[],
+            project_threads=object(),
+            select_relevant_memory_context=_noop_memory,
+        )
+    )
+
+    passed_state = skill.calls[0]["session_state"]
+    preview = passed_state["planning_run_preview"]
+
+    assert preview["run_id"]
+    assert preview["status"] == "planning"
+    assert preview["current_step"]
+    assert preview["next_step"]
+    assert preview["last_interacted_run_id"] == preview["run_id"]
+    assert preview["focused_run_id"] == preview["run_id"]
+    assert preview["authority_effect"] == "none"
+    assert preview["execution_performed"] is False
+    assert preview["authorization_granted"] is False
+    assert session_state["planning_run_preview"]["run_id"] == preview["run_id"]
+    assert session_state["last_interacted_run_id"] == preview["run_id"]
+
+
+def test_general_chat_casual_prompt_does_not_create_run():
+    skill = _FakeGeneralChatSkill()
+    session_state = {}
+
+    asyncio.run(
+        run_general_chat_fallback(
+            "hey how are you",
+            general_chat_skill=skill,
+            session_state=session_state,
+            session_context=[],
+            project_threads=object(),
+            select_relevant_memory_context=_noop_memory,
+        )
+    )
+
+    passed_state = skill.calls[0]["session_state"]
+
+    assert "planning_run_preview" not in passed_state
+    assert "planning_run_preview" not in session_state
+    assert "last_interacted_run_id" not in session_state
+
+
+def test_planning_run_preview_does_not_create_execution_surface():
+    session_state = {}
+    task_preview = build_task_understanding_preview("make a bounded task envelope")
+    assert task_preview.plan is not None
+
+    create_planning_run_preview(task_preview.plan, session_state=session_state)
+    manager = planning_run_manager(session_state)
+
+    assert not hasattr(manager, "execute")
+    assert not hasattr(manager, "execute_run")
+    assert not hasattr(manager, "run_capability")

--- a/nova_backend/tests/conversation/test_planning_run_preview.py
+++ b/nova_backend/tests/conversation/test_planning_run_preview.py
@@ -1,8 +1,12 @@
 import asyncio
+import json
+
+import pytest
 
 from src.base_skill import SkillResult
 from src.conversation.general_chat_runtime import run_general_chat_fallback
 from src.conversation.planning_run_preview import (
+    PlanningRunPreview,
     create_planning_run_preview,
     planning_run_manager,
 )
@@ -58,6 +62,28 @@ def test_create_planning_run_preview_none_plan_creates_nothing():
     assert "last_interacted_run_id" not in session_state
 
 
+def test_planning_run_preview_rejects_non_planning_values():
+    kwargs = {
+        "run_id": "run_1",
+        "title": "title",
+        "goal": "goal",
+        "status": "planning",
+        "current_step": "understand request",
+        "next_step": "build task envelope",
+        "last_interacted_run_id": "run_1",
+        "focused_run_id": "run_1",
+    }
+
+    with pytest.raises(ValueError, match="planning-only"):
+        PlanningRunPreview(**kwargs, planning_only=False)
+    with pytest.raises(ValueError, match="non-authorizing"):
+        PlanningRunPreview(**kwargs, authority_effect="approved")
+    with pytest.raises(ValueError, match="must not record executed"):
+        PlanningRunPreview(**kwargs, execution_performed=True)
+    with pytest.raises(ValueError, match="must not grant authorization"):
+        PlanningRunPreview(**kwargs, authorization_granted=True)
+
+
 def test_planning_run_preview_focus_updates_safely():
     session_state = {}
     first = build_task_understanding_preview("summarize this task", session_context={"task": "one"})
@@ -77,6 +103,29 @@ def test_planning_run_preview_focus_updates_safely():
     assert manager.last_interacted_run_id == first_preview.run_id
     assert focused.execution_performed is False
     assert focused.authorization_granted is False
+
+
+def test_existing_focused_run_does_not_create_extra_hidden_run():
+    session_state = {}
+    first = build_task_understanding_preview("summarize this task", session_context={"task": "one"})
+    second = build_task_understanding_preview("make a bounded task envelope")
+    assert first.plan is not None
+    assert second.plan is not None
+
+    first_preview = create_planning_run_preview(first.plan, session_state=session_state)
+    assert first_preview is not None
+    manager = planning_run_manager(session_state)
+    before_count = len(manager.list_runs())
+
+    focused_preview = create_planning_run_preview(
+        second.plan,
+        session_state=session_state,
+        focused_run_id=first_preview.run_id,
+    )
+
+    assert focused_preview is not None
+    assert focused_preview.run_id == first_preview.run_id
+    assert len(manager.list_runs()) == before_count
 
 
 def test_general_chat_task_like_prompt_creates_planning_run_preview():
@@ -108,6 +157,9 @@ def test_general_chat_task_like_prompt_creates_planning_run_preview():
     assert preview["authorization_granted"] is False
     assert session_state["planning_run_preview"]["run_id"] == preview["run_id"]
     assert session_state["last_interacted_run_id"] == preview["run_id"]
+    json.dumps(session_state["planning_run_preview"])
+    assert "_planning_run_manager" not in preview
+    assert "_planning_run_manager" not in passed_state
 
 
 def test_general_chat_casual_prompt_does_not_create_run():
@@ -130,6 +182,57 @@ def test_general_chat_casual_prompt_does_not_create_run():
     assert "planning_run_preview" not in passed_state
     assert "planning_run_preview" not in session_state
     assert "last_interacted_run_id" not in session_state
+
+
+def test_general_chat_casual_prompt_does_not_leak_prior_preview_to_skill_state():
+    skill = _FakeGeneralChatSkill()
+    session_state = {
+        "planning_run_preview": {"run_id": "old_run"},
+        "task_understanding_preview": object(),
+        "task_understanding_prompt_block": "old task block",
+        "task_understanding_envelope": object(),
+    }
+
+    asyncio.run(
+        run_general_chat_fallback(
+            "hey how are you",
+            general_chat_skill=skill,
+            session_state=session_state,
+            session_context=[],
+            project_threads=object(),
+            select_relevant_memory_context=_noop_memory,
+        )
+    )
+
+    passed_state = skill.calls[0]["session_state"]
+    assert "planning_run_preview" not in passed_state
+    assert passed_state["task_understanding_preview"] is None
+    assert passed_state["task_understanding_prompt_block"] == ""
+    assert "task_understanding_envelope" not in passed_state
+
+
+def test_private_run_manager_does_not_leak_to_skill_state_on_later_turn():
+    skill = _FakeGeneralChatSkill()
+    session_state = {}
+    task_preview = build_task_understanding_preview("make a bounded task envelope")
+    assert task_preview.plan is not None
+    create_planning_run_preview(task_preview.plan, session_state=session_state)
+    assert "_planning_run_manager" in session_state
+
+    asyncio.run(
+        run_general_chat_fallback(
+            "summarize this task",
+            general_chat_skill=skill,
+            session_state=session_state,
+            session_context=[],
+            project_threads=object(),
+            select_relevant_memory_context=_noop_memory,
+        )
+    )
+
+    passed_state = skill.calls[0]["session_state"]
+    assert "_planning_run_manager" not in passed_state
+    json.dumps(passed_state["planning_run_preview"])
 
 
 def test_planning_run_preview_does_not_create_execution_surface():

--- a/nova_backend/tests/conversation/test_request_understanding_formatter.py
+++ b/nova_backend/tests/conversation/test_request_understanding_formatter.py
@@ -237,6 +237,9 @@ def test_run_general_chat_fallback_casual_greeting_block_is_empty():
 
     block = skill.calls[0]["session_state"]["request_understanding_prompt_block"]
     assert block == ""  # no boundary noise for casual greetings
+    assert skill.calls[0]["session_state"]["task_understanding_preview"] is None
+    assert skill.calls[0]["session_state"]["task_understanding_prompt_block"] == ""
+    assert "planning_run_preview" not in skill.calls[0]["session_state"]
 
 
 def test_run_general_chat_fallback_general_chat_block_is_empty():
@@ -313,6 +316,61 @@ def test_run_general_chat_fallback_no_capability_execution_triggered():
     assert len(skill.calls) == 1
     understanding = skill.calls[0]["session_state"]["request_understanding"]
     assert understanding.authority_effect == "none"
+
+
+def test_run_general_chat_fallback_injects_task_understanding_preview_for_task_like_request():
+    skill = _FakeGeneralChatSkill(SkillResult(success=True, message="ok", skill="general_chat"))
+
+    asyncio.run(
+        run_general_chat_fallback(
+            "summarize this task",
+            general_chat_skill=skill,
+            session_state={"conversation_context": {"user_goal": "Prepare a bounded repo plan."}},
+            session_context=[],
+            project_threads=object(),
+            select_relevant_memory_context=_noop_memory,
+        )
+    )
+
+    passed_state = skill.calls[0]["session_state"]
+    preview = passed_state["task_understanding_preview"]
+
+    assert preview is not None
+    assert preview.planning_only is True
+    assert preview.execution_performed is False
+    assert preview.authorization_granted is False
+    assert "task_understanding_envelope" in passed_state
+    assert "planning_run_preview" in passed_state
+    assert passed_state["planning_run_preview"]["status"] == "planning"
+    assert passed_state["planning_run_preview"]["current_step"]
+    assert passed_state["planning_run_preview"]["next_step"]
+    assert "Task understanding preview" in passed_state["task_understanding_prompt_block"]
+    assert "Task understanding preview" in passed_state["request_understanding_prompt_block"]
+    assert "Authority effect: none" in passed_state["request_understanding_prompt_block"]
+
+
+def test_run_general_chat_fallback_task_preview_uses_relevant_memory_as_context():
+    skill = _FakeGeneralChatSkill(SkillResult(success=True, message="ok", skill="general_chat"))
+
+    def memory_context(query, *, session_state, project_threads):
+        return [{"content": "User prefers planning-only answers before implementation."}]
+
+    asyncio.run(
+        run_general_chat_fallback(
+            "make a bounded task envelope",
+            general_chat_skill=skill,
+            session_state={},
+            session_context=[],
+            project_threads=object(),
+            select_relevant_memory_context=memory_context,
+        )
+    )
+
+    preview = skill.calls[0]["session_state"]["task_understanding_preview"]
+
+    assert preview is not None
+    assert any(item.source.value == "stable_memory" for item in preview.understanding.context_used)
+    assert preview.understanding.authorization_granted is False
 
 
 # ---------------------------------------------------------------------------

--- a/nova_backend/tests/conversation/test_task_understanding_preview.py
+++ b/nova_backend/tests/conversation/test_task_understanding_preview.py
@@ -1,0 +1,66 @@
+from src.brain.task_understanding import SimpleTaskPlan
+from src.conversation.task_understanding_preview import (
+    build_task_understanding_preview,
+    format_task_understanding_preview,
+)
+
+
+def test_casual_chat_does_not_enable_task_understanding_preview():
+    preview = build_task_understanding_preview("hey")
+
+    assert preview.enabled is False
+    assert preview.plan is None
+    assert preview.prompt_block == ""
+    assert preview.authority_effect == "none"
+
+
+def test_task_like_request_gets_structured_preview_block():
+    preview = build_task_understanding_preview(
+        "summarize this task",
+        session_context={"task": "Prepare a bounded planning-only summary."},
+    )
+
+    assert preview.enabled is True
+    assert isinstance(preview.plan, SimpleTaskPlan)
+    assert preview.plan.execution_performed is False
+    assert preview.plan.authorization_granted is False
+    assert "Task understanding preview" in preview.prompt_block
+    assert "Goal: summarize this task" in preview.prompt_block
+    assert "Confidence:" in preview.prompt_block
+    assert "Clarification needed: false" in preview.prompt_block
+    assert "Suggested next step:" in preview.prompt_block
+    assert "Authority effect: none" in preview.prompt_block
+
+
+def test_preview_block_can_include_task_envelope():
+    preview = build_task_understanding_preview("make a bounded task envelope")
+
+    assert preview.plan is not None
+    block = format_task_understanding_preview(preview.plan, include_envelope=True)
+
+    assert "Task envelope:" in block
+    assert "Allowed actions:" in block
+    assert "Blocked actions:" in block
+    assert "use OpenClaw" in block
+    assert "send email" in block
+    assert "Stop condition:" in block
+    assert "Failure behavior:" in block
+
+
+def test_preview_block_can_omit_task_envelope():
+    preview = build_task_understanding_preview("make a bounded task envelope")
+
+    assert preview.plan is not None
+    block = format_task_understanding_preview(preview.plan, include_envelope=False)
+
+    assert "Task understanding preview" in block
+    assert "Task envelope:" not in block
+
+
+def test_ambiguous_task_preview_preserves_clarification_needed():
+    preview = build_task_understanding_preview("turn this script into a scene plan")
+
+    assert preview.plan is not None
+    assert preview.plan.understanding.clarification_needed is True
+    assert "Clarification needed: true" in preview.prompt_block
+    assert "Ask one focused clarification" in preview.prompt_block


### PR DESCRIPTION
## Summary
- add planning-only TaskUnderstanding, TaskEnvelope, and SimpleTaskPlan scaffolds
- add conversation Task Understanding preview and session-local planning Run Preview
- add in-memory non-authorizing RunManager and focused tests
- update Brain docs to state what is implemented and what remains future-only

## Hardening added
- PlanningRunPreview now enforces planning-only / non-authorizing invariants
- focused_run_id reuses an existing focused run instead of creating an extra hidden run
- private session-local _planning_run_manager is stripped from public skill-state copies
- preview payloads are covered by JSON-serialization and leak-guard tests

## Boundaries
- no execution method
- no new capabilities
- no Governor routing
- no OpenClaw connection
- no browser/file/email/calendar/account actions
- no persistence or Co-Work page

## Validation
- python -m pytest tests\\brain -q
- python -m pytest tests\\conversation\\test_task_understanding_preview.py tests\\conversation\\test_planning_run_preview.py tests\\conversation\\test_request_understanding_formatter.py tests\\conversation\\test_general_chat_runtime.py tests\\conversation\\test_session_router.py -q
- python -m pytest tests\\governance -q
- python scripts\\check_runtime_doc_drift.py
- git diff --check