### PR TITLE
Add YouTubeLIS planning tool folder

### DIFF
--- a/docs/tools/youtubelis.md
+++ b/docs/tools/youtubelis.md
@@ -1,0 +1,65 @@
+# YouTubeLIS Tool Folder
+
+YouTubeLIS lives at `tools/youtubelis/`.
+
+It is a planning-first content-production tool folder for turning YouTube video ideas into reviewable artifacts: angle, hook, outline, script, claim validation, scene plan, asset list, editing plan, and title/thumbnail options.
+
+---
+
+## Current Status
+
+Current status: planning-only tool folder.
+
+This is not yet a Nova runtime capability.
+
+Do not claim YouTubeLIS has live governed execution, upload, publishing, account access, or background automation until those paths exist in code, pass tests, and are reflected by generated runtime truth.
+
+---
+
+## Allowed Current Use
+
+- Content strategy
+- Topic and angle planning
+- Script structure
+- Claim validation design
+- Production planning
+- Scene planning
+- Packaging ideas
+- Planning-run templates
+
+---
+
+## Blocked Current Use
+
+- Uploading videos
+- Publishing videos
+- Account actions
+- Purchases
+- Deletions
+- Background automation loops
+- OpenClaw execution
+- YouTube Studio control
+- Claiming runtime capability status
+
+---
+
+## Integration Direction
+
+The safe path is:
+
+1. Keep `tools/youtubelis/` as docs and planning templates.
+2. Build a planning-only module later under `nova_backend/src/tools/youtubelis/`.
+3. Add tests for planning-only behavior.
+4. Add connector package metadata as `status: design` only after a real module path exists.
+5. Add a real capability only after the planning module is stable and the governance path is implemented.
+6. Regenerate runtime docs only after runtime code changes exist.
+
+---
+
+## Governance Rule
+
+Planning may be rich. Authority remains bounded.
+
+Memory, prior runs, or documentation do not grant permission to publish, upload, purchase, or control accounts.
+
+Future execution must go through Nova's governed action path and produce reviewable results.

--- a/tools/youtubelis/README.md
+++ b/tools/youtubelis/README.md
@@ -100,7 +100,7 @@ NovaLIS may help with:
 - Producing voiceover drafts
 - Creating shot lists
 - Planning animation overlays
-- Coordinating OpenClaw or desktop automation
+- Preparing future execution plans for OpenClaw or desktop automation, without claiming that execution is live
 - Tracking performance after publishing
 - Recommending what to double down on
 

--- a/tools/youtubelis/README.md
+++ b/tools/youtubelis/README.md
@@ -1,0 +1,156 @@
+# YouTubeLIS
+
+YouTubeLIS is a governed YouTube content-production system for creating high-quality videos about the most important and exciting developments in AI and technology.
+
+It is designed to eventually integrate with NovaLIS as a controlled, reviewable content pipeline — not an uncontrolled automation bot.
+
+---
+
+## Core Idea
+
+> Break down the AI race, major breakthroughs, robotics, automation, and how they impact jobs, businesses, and everyday people.
+
+YouTubeLIS is not a generic AI news channel. It is intended to be a signal-focused explainer and story engine.
+
+The channel should prioritize:
+
+- Signal over noise
+- Reality over hype
+- Explanation over repetition
+- Real evidence over vague speculation
+- Human impact over technical trivia
+
+---
+
+## System Model
+
+YouTubeLIS should treat each video as a governed planning run:
+
+```text
+Idea -> Task Understanding -> Planning Run -> Content Build -> Validation -> Production Plan -> Review Stop
+```
+
+NovaLIS may help with thinking, structure, drafting, validation, and production planning. Publishing, account actions, purchases, uploads, and external execution remain human-approved actions.
+
+---
+
+## Content Focus
+
+YouTubeLIS focuses on:
+
+- AI breakthroughs that actually change things
+- The AI race between companies, labs, open-source ecosystems, and infrastructure builders
+- Robotics and real-world automation
+- Job loss, job transformation, and new AI-enabled work
+- What is real now versus what is hype
+- What may happen next, grounded in visible evidence
+
+---
+
+## Video Style
+
+The preferred format is:
+
+> Real footage for proof + animation for explanation + narration for story.
+
+Videos should feel like short documentary/explainer pieces, not automated filler.
+
+A strong YouTubeLIS video should:
+
+- Show what is actually happening
+- Explain it in plain language
+- Connect it to why people care
+- Separate verified reality from speculation
+- End with a grounded takeaway
+
+---
+
+## Repeatable Video Structure
+
+1. Hook
+   - Open with the exciting, alarming, or surprising point.
+
+2. Real Evidence
+   - Use demos, footage, screenshots, product releases, papers, or public examples when available.
+
+3. Simple Explanation
+   - Use animation, overlays, captions, or diagrams to explain what is happening.
+
+4. The AI Race Context
+   - Explain who is building it and why the competition matters.
+
+5. Human Impact
+   - Explain what this could change for jobs, businesses, creators, workers, or daily life.
+
+6. What Comes Next
+   - End with a grounded prediction, open question, or practical takeaway.
+
+---
+
+## NovaLIS Integration
+
+YouTubeLIS should eventually plug into NovaLIS as a governed workflow.
+
+NovaLIS may help with:
+
+- Finding and ranking video ideas
+- Generating outlines and scripts
+- Structuring claims
+- Separating evidence from speculation
+- Producing voiceover drafts
+- Creating shot lists
+- Planning animation overlays
+- Coordinating OpenClaw or desktop automation
+- Tracking performance after publishing
+- Recommending what to double down on
+
+Human approval remains required before publishing, buying tools, using accounts, uploading content, or representing claims as factual.
+
+See `docs/NOVALIS_INTEGRATION.md` for the full planning-run, task-envelope, and live-vs-planned integration model.
+
+---
+
+## Governed Automation Principle
+
+> Maximum useful automation, not uncontrolled automation.
+
+YouTubeLIS should be powerful, but task-scoped and reviewable.
+
+No component should have broad unchecked authority. Any automation should be:
+
+- Declared before execution
+- Limited to an approved task scope
+- Approved by the user when risk exists
+- Stopped when the task is done
+- Logged for review
+
+---
+
+## Current Status
+
+Planning and architecture phase.
+
+This repo should not claim to be a complete automated YouTube system until actual workflows, tools, tests, and video production paths exist.
+
+Current honest baseline:
+
+```text
+Task Understanding: planning-only model
+Task Envelope: planning-only model
+Planning Run: target workflow model
+Execution integration: not implemented in this repo
+Publishing: manual only
+```
+
+Start with documentation, workflow design, and one reliable pilot video pipeline.
+
+---
+
+## Documentation Map
+
+- `docs/CONTENT_STRATEGY.md` — niche, audience, pillars, and video formats
+- `docs/VIDEO_PIPELINE.md` — production pipeline from idea to publish
+- `docs/PLANNING_RUN_TEMPLATE.md` — standard planning-only run format for turning an idea into reviewable artifacts
+- `docs/GOVERNED_AUTOMATION.md` — NovaLIS/OpenClaw governance model
+- `docs/NOVALIS_INTEGRATION.md` — planning-run, task-envelope, and live-vs-planned NovaLIS integration model
+- `docs/FIRST_VIDEO_IDEAS.md` — starter ideas for the first content batch

--- a/tools/youtubelis/docs/CONTENT_STRATEGY.md
+++ b/tools/youtubelis/docs/CONTENT_STRATEGY.md
@@ -1,0 +1,57 @@
+# Content Strategy (YouTubeLIS)
+
+## Core Positioning
+
+YouTubeLIS explains the most important and exciting changes in AI and technology and why they matter to real people.
+
+---
+
+## Audience
+
+Primary audience:
+
+- People curious about how AI affects their future
+- Builders and entrepreneurs
+- Workers concerned about job impact
+- Tech-interested general viewers
+
+---
+
+## Content Pillars
+
+1. Breakthroughs
+- Major capabilities or releases
+
+2. The AI Race
+- Competition between companies and ecosystems
+
+3. Jobs and Impact
+- Job loss, job shifts, new opportunities
+
+4. What’s Next
+- Realistic future direction
+
+---
+
+## Content Rules
+
+- Show real evidence when possible
+- Avoid generic AI lists
+- Avoid repeating news without insight
+- Explain why it matters
+- Separate fact from speculation
+
+---
+
+## Tone
+
+- Clear
+- Grounded
+- Slightly urgent when appropriate
+- Not hype-driven
+
+---
+
+## Goal
+
+Build trust and retention through clarity, not volume.

--- a/tools/youtubelis/docs/FIRST_VIDEO_IDEAS.md
+++ b/tools/youtubelis/docs/FIRST_VIDEO_IDEAS.md
@@ -1,0 +1,16 @@
+# First Video Ideas (YouTubeLIS)
+
+These are starting points for initial videos.
+
+1. This AI Just Changed How Coding Works
+2. The AI Race Is Moving Faster Than People Realize
+3. These Jobs Are Already Being Replaced
+4. Why Everyone Is Building Their Own AI Now
+5. This Robot Is Closer Than You Think
+6. What Local AI Actually Means
+7. The Biggest AI Shift This Month
+8. What Happens When AI Replaces This Role
+9. This Breakthrough Might Change Small Businesses
+10. The Next Phase of AI Has Already Started
+
+Goal: pick 1–3 and execute fully.

--- a/tools/youtubelis/docs/FIRST_VIDEO_IDEAS.md
+++ b/tools/youtubelis/docs/FIRST_VIDEO_IDEAS.md
@@ -13,4 +13,4 @@ These are starting points for initial videos.
 9. This Breakthrough Might Change Small Businesses
 10. The Next Phase of AI Has Already Started
 
-Goal: pick 1–3 and execute fully.
+Goal: pick 1–3 and run them through the planning pipeline fully. Production, editing, upload, and publishing remain manual unless a future governed execution path is implemented and approved.

--- a/tools/youtubelis/docs/GOVERNED_AUTOMATION.md
+++ b/tools/youtubelis/docs/GOVERNED_AUTOMATION.md
@@ -1,0 +1,180 @@
+# Governed Automation Model (YouTubeLIS)
+
+This document defines how YouTubeLIS should use NovaLIS and OpenClaw safely.
+
+The default mode is planning. Execution is optional, future-facing, and must remain governed.
+
+---
+
+## Core Principle
+
+Automation is allowed only inside approved task boundaries.
+
+> Permission is task-scoped, not global.
+
+NovaLIS can help think, structure, draft, validate, and plan. That does not grant permission to publish, upload, purchase, change accounts, delete files, or run background loops.
+
+---
+
+## Planning vs Execution
+
+### Planning Envelope
+
+Planning work can happen without external execution.
+
+Allowed:
+
+- Brainstorming
+- Drafting
+- Outlining
+- Claim labeling
+- Scene planning
+- Asset planning
+- Packaging suggestions
+
+Blocked:
+
+- Uploading
+- Publishing
+- Account access
+- Purchases
+- Deletions
+- Background loops
+- External tool execution
+
+Planning should stop with reviewable artifacts.
+
+### Execution Envelope
+
+Execution starts only when the user approves a specific action scope.
+
+Every execution task must define:
+
+```text
+Intent:
+Steps:
+Allowed:
+Blocked:
+Environment:
+Approval required:
+Stop condition:
+Failure behavior:
+```
+
+---
+
+## Execution Flow
+
+Future execution should follow the NovaLIS governance path:
+
+```text
+User
+-> NovaLIS
+-> Run
+-> GovernorMediator
+-> CapabilityRegistry
+-> ExecuteBoundary
+-> OpenClaw or executor
+-> Result
+-> Ledger
+```
+
+OpenClaw should never operate outside this path.
+
+If the integration is not verified in runtime code, this document should be treated as a target model, not a shipped capability claim.
+
+---
+
+## Example Execution Envelope
+
+```text
+Intent: Generate voiceover
+
+Steps:
+- Open approved voice provider
+- Paste approved script
+- Generate audio
+- Download file
+
+Allowed:
+- Browser navigation inside approved provider
+- Audio generation from approved script
+- File download
+
+Blocked:
+- Purchases
+- Account changes
+- Script changes without review
+- Unrelated browsing
+- Uploading or publishing
+
+Stop condition:
+- Audio file downloaded, then stop.
+
+Failure behavior:
+- Pause and ask if login, payment, missing credits, provider error, or scope change occurs.
+```
+
+---
+
+## Rules
+
+- No execution without declared intent
+- No actions outside approved scope
+- No permission inheritance from memory or prior runs
+- Stop immediately when the task is complete
+- Pause and request approval if scope changes
+- Log execution steps when execution exists
+- Publishing remains manual unless a future governed publishing path is explicitly implemented and approved
+
+---
+
+## Risk Levels
+
+Low:
+
+- Planning-only work
+- Opening local apps
+- Reading approved data
+
+Medium:
+
+- Downloading files
+- Creating files
+- Uploading drafts
+- Generating paid-tool outputs without purchase
+
+High:
+
+- Purchases
+- Deletions
+- Account changes
+- Publishing
+- Public representation of claims as factual
+- Monetization changes
+
+High-risk actions always require explicit approval.
+
+---
+
+## Current Status
+
+This repository is currently documentation and workflow design.
+
+Treat the following as current safe baseline:
+
+```text
+Planning: allowed as a design model
+Execution: not implemented in this repo
+OpenClaw integration: future / target model
+Publishing: manual only
+Background loops: not allowed
+```
+
+Do not claim YouTubeLIS can execute governed browser or desktop actions until that path exists and is verified against NovaLIS runtime truth.
+
+---
+
+## Goal
+
+Provide maximum useful capability while preserving control, visibility, and trust.

--- a/tools/youtubelis/docs/NOVALIS_INTEGRATION.md
+++ b/tools/youtubelis/docs/NOVALIS_INTEGRATION.md
@@ -1,0 +1,265 @@
+# NovaLIS Integration Model (YouTubeLIS)
+
+This document defines how YouTubeLIS should integrate with NovaLIS as a governed content operating system.
+
+The core idea is simple: Nova can help with thinking, structure, drafting, validation, and production planning, while the user keeps authority over publishing, accounts, purchases, and public claims.
+
+---
+
+## System Model
+
+YouTubeLIS should treat content creation as a governed workflow, not an uncontrolled automation loop.
+
+```text
+Conversation
+-> Brain
+-> Run System
+-> Governor
+-> Executor
+-> Ledger
+```
+
+For YouTube work, that becomes:
+
+```text
+Idea
+-> Task Understanding
+-> Planning Run
+-> Content Build
+-> Validation
+-> Production Plan
+-> Review Stop
+-> Optional governed execution later
+-> Iteration
+```
+
+Core invariant:
+
+> No real-world action without a run, a declared envelope, and the required approval path.
+
+---
+
+## Video Runs
+
+Each video should become a run with explicit state.
+
+```text
+Run: YouTube - <topic>
+Status: planning | waiting_for_approval | running | paused | completed
+Current step: <current step>
+Next step: <next step>
+Envelope: allowed / blocked / limits
+Stop condition: explicit delivery boundary
+```
+
+A run is the unit of inspectable work. It prevents YouTubeLIS from becoming a vague chat thread or an open-ended automation request.
+
+---
+
+## Canonical Planning Run Template
+
+A standard planning run should produce these artifacts in order:
+
+1. Define the angle and audience
+2. Craft the hook
+3. Build the outline
+4. Expand to script
+5. Validate claims and flow
+6. Plan production assets and editing
+7. Package title and thumbnail variants
+8. Stop for user review
+
+Example stop condition:
+
+```text
+Script, scene plan, asset list, editing notes, and 3 title/thumbnail directions delivered. No upload, publishing, account access, or external execution.
+```
+
+---
+
+## Task Understanding Object
+
+Every non-trivial request should be converted into a Task Understanding Object before deeper work begins.
+
+```text
+Goal
+Context used
+Constraints
+Assumptions
+Confidence
+Clarification needed
+```
+
+Clarifying questions should be used only when the answer materially changes the outcome. The system should reduce friction without removing rigor.
+
+---
+
+## Content Build Artifacts
+
+NovaLIS can help produce repeatable, inspectable artifacts:
+
+- Hook options
+- 5-7 beat outline
+- Time-coded scene plan
+- Script draft
+- Script improvement pass
+- Claim and freshness review
+- Asset list
+- Editing plan
+- Title and thumbnail variants
+
+These artifacts make a video execution-ready without letting the system execute account or publishing actions on its own.
+
+---
+
+## Validation Layer
+
+The validation pass should identify:
+
+- Weak points
+- Stronger angles
+- Missing evidence
+- Outdated examples
+- Unsupported claims
+- Speculation presented too strongly
+- Better proof points or visuals
+
+Every major claim should be framed as one of:
+
+```text
+Verified
+Supported but uncertain
+Opinion
+Speculation
+Unknown
+```
+
+---
+
+## Task Envelope
+
+Before any real action, the run must declare a task envelope.
+
+```text
+Allowed: planning, drafting, suggestions, review artifacts
+Blocked: upload, publish, account changes, purchases, automation loops
+Environment: chat by default
+Step limits: explicit
+Approval level: none for planning, required for execution
+Stop condition: explicit
+Failure behavior: pause and ask
+```
+
+Memory can inform choices, but memory never grants permission.
+
+---
+
+## Optional Governed Execution
+
+Execution is future-facing and must remain governed.
+
+Possible future execution actions:
+
+- Export a script
+- Prepare an upload draft
+- Generate captions
+- Open an approved tool
+- Download an approved asset
+- Create a local file
+
+Execution path:
+
+```text
+Run
+-> Governor
+-> Capability
+-> ExecuteBoundary
+-> NetworkMediator if needed
+-> Ledger receipt
+```
+
+No execution path should bypass NovaLIS governance.
+
+---
+
+## Hard Boundaries
+
+YouTubeLIS must not perform these actions without explicit user approval and the required governance path:
+
+- Auto-uploading
+- Auto-publishing
+- Auto-monetization changes
+- Background loops
+- Account-write actions
+- Purchases
+- Deletions
+- Public claims represented as factual without review
+
+The system may become more intelligent, but authority stays bounded.
+
+---
+
+## Modes of Operation
+
+### Simple Task Mode
+
+Use for one-pass requests such as title ideas, a short hook, or a quick outline.
+
+### Planning Run
+
+Use for multi-step work that should remain inspectable, stateful, and reviewable.
+
+### Execution Run
+
+Future mode only. Requires explicit approval, governed execution, and ledgered results.
+
+---
+
+## Current Implementation Status
+
+This repository is still documentation and workflow design. It should not claim to be a complete automated YouTube production system.
+
+Current intended baseline:
+
+```text
+Task Understanding: planning-only
+Task Envelope: planning-only
+Simple Task Mode: allowed
+Planning Run: target workflow model
+Execution: not implemented in this repo
+Publishing: manual only
+```
+
+Do not claim these are fully integrated until the implementation exists and is verified against NovaLIS runtime truth.
+
+---
+
+## Not Live Yet
+
+The following should be treated as planned or future work unless verified in code:
+
+- Persistent runs
+- Co-work page UI
+- Governor routing from YouTubeLIS runs
+- Execution integration
+- OpenClaw usage
+- Background or scheduled loops
+- Upload/publish/account automation
+
+---
+
+## Highest-ROI Build Order
+
+1. Stabilize the planning-only brain/run slice
+2. Show the active planning run in chat
+3. Add read-only run inspection commands: show, list, pause, cancel
+4. Add persistence only after the in-memory model is stable
+5. Add a Co-Work page shell
+6. Add approval UI and trust receipts
+7. Introduce governed execution only after the planning system is reliable
+
+---
+
+## One-Line Summary
+
+YouTubeLIS turns YouTube creation from ad-hoc creativity into a governed, repeatable content system: planning is rich, execution is controlled, and improvement is continuous.

--- a/tools/youtubelis/docs/PLANNING_RUN_TEMPLATE.md
+++ b/tools/youtubelis/docs/PLANNING_RUN_TEMPLATE.md
@@ -1,0 +1,257 @@
+# Planning Run Template (YouTubeLIS)
+
+This document defines the standard planning-only run format for a YouTubeLIS video.
+
+A planning run is not an execution command. It is an inspectable work container that turns a video idea into reviewable artifacts: angle, hook, outline, script, validation, scene plan, asset list, editing plan, and packaging options.
+
+---
+
+## When To Use This Template
+
+Use a planning run when the request is more than a quick one-off task.
+
+Good fit:
+
+- Build a full video script
+- Turn an idea into a production plan
+- Compare several angles for a topic
+- Create an edit-ready package
+- Improve a previous video concept
+- Validate claims before production
+
+Use Simple Task Mode instead for quick work such as one hook, five title ideas, or a short outline.
+
+---
+
+## Run Header
+
+```text
+Run: YouTube - <topic>
+Mode: Planning Run
+Status: planning
+Owner authority: user
+Execution allowed: no
+Publishing allowed: no
+```
+
+---
+
+## Task Understanding Object
+
+Every planning run starts by stating the understanding of the task.
+
+```text
+Goal:
+Context used:
+Audience:
+Tone:
+Length target:
+Constraints:
+Assumptions:
+Confidence:
+Clarification needed:
+```
+
+Clarification should be requested only when the answer materially changes the output.
+
+---
+
+## Planning Envelope
+
+Planning runs should declare their boundaries up front.
+
+```text
+Allowed:
+- Brainstorming
+- Drafting
+- Research planning
+- Claim labeling
+- Script writing
+- Scene planning
+- Packaging suggestions
+
+Blocked:
+- Uploading
+- Publishing
+- Account access
+- Purchases
+- Deletions
+- Background loops
+- External tool execution
+
+Stop condition:
+- Deliver the agreed planning artifacts and stop for review.
+
+Failure behavior:
+- Pause and ask if the task requires execution, account access, or unavailable facts.
+```
+
+---
+
+## Standard Artifact Order
+
+1. Angle and audience
+2. Hook options
+3. 5-7 beat outline
+4. Script draft
+5. Claim and flow validation
+6. Time-coded scene plan
+7. Asset list
+8. Editing plan
+9. Title and thumbnail variants
+10. Review stop
+
+---
+
+## Artifact Detail
+
+### 1. Angle and Audience
+
+Define the viewer, the reason they care, and the promise of the video.
+
+```text
+Audience:
+Core question:
+Main tension:
+Viewer payoff:
+```
+
+### 2. Hook Options
+
+Create several opening options with different risk profiles.
+
+```text
+Safe hook:
+High-curiosity hook:
+Evidence-first hook:
+Human-impact hook:
+```
+
+### 3. Outline
+
+Use 5-7 beats optimized for clarity and pacing.
+
+```text
+Beat 1: Hook / stakes
+Beat 2: What happened
+Beat 3: Proof
+Beat 4: Why it matters
+Beat 5: What changes next
+Beat 6: Caveat or uncertainty
+Beat 7: Final takeaway
+```
+
+### 4. Script Draft
+
+Write for narration, not essay structure.
+
+Rules:
+
+- Plain language
+- Short paragraphs
+- Clear transitions
+- Evidence before speculation
+- No unsupported certainty
+
+### 5. Claim and Flow Validation
+
+Label important claims before production.
+
+```text
+Verified:
+Supported but uncertain:
+Opinion:
+Speculation:
+Unknown / needs source:
+```
+
+Also review:
+
+- Weak points
+- Missing evidence
+- Outdated examples
+- Pacing issues
+- Stronger alternative angles
+
+### 6. Scene Plan
+
+Make the script edit-ready.
+
+```text
+00:00-00:15 - Hook visual
+00:15-00:45 - Proof clip or screen recording
+00:45-01:30 - Explanation overlay
+01:30-02:30 - Impact section
+02:30-03:00 - Takeaway / close
+```
+
+### 7. Asset List
+
+Separate real proof from supporting visuals.
+
+```text
+Required proof assets:
+Helpful b-roll:
+Screenshots:
+Diagrams / overlays:
+Generated visuals, if any:
+Missing assets:
+```
+
+### 8. Editing Plan
+
+Define pacing and retention decisions before editing.
+
+```text
+Pattern interrupts:
+Caption moments:
+Overlay moments:
+Cutaway moments:
+Sound / music notes:
+Risk of slow sections:
+```
+
+### 9. Packaging Options
+
+Generate multiple title and thumbnail directions.
+
+```text
+Safe title:
+High-click title:
+Curiosity title:
+Human-impact title:
+Thumbnail concept 1:
+Thumbnail concept 2:
+Thumbnail concept 3:
+```
+
+### 10. Review Stop
+
+The run ends with a clear review boundary.
+
+```text
+Delivered:
+Not performed:
+Open questions:
+Recommended next action:
+Approval needed for any execution:
+```
+
+---
+
+## Example Stop Condition
+
+```text
+Stop after delivering the script, scene plan, asset list, editing plan, and 3 title/thumbnail directions. Do not upload, publish, open accounts, make purchases, or run external tools.
+```
+
+---
+
+## Done Definition
+
+A planning run is done when the user has enough material to either:
+
+1. Manually produce the video, or
+2. Approve a separate governed execution run later.
+
+Planning is allowed to be rich. Execution remains bounded.

--- a/tools/youtubelis/docs/VIDEO_PIPELINE.md
+++ b/tools/youtubelis/docs/VIDEO_PIPELINE.md
@@ -1,0 +1,257 @@
+# Video Pipeline (YouTubeLIS)
+
+This document defines the repeatable production workflow for YouTubeLIS.
+
+The goal is not to automate low-quality uploads. The goal is to make a reliable, reviewable system for producing videos that explain important AI and technology changes with real evidence, clear narration, and useful context.
+
+---
+
+## Pipeline Summary
+
+```text
+Idea
+-> Task Understanding
+-> Planning Run
+-> Research / Evidence Collection
+-> Script
+-> Claim Check
+-> Voice
+-> Visual Plan
+-> Edit
+-> Review
+-> Manual Publish
+-> Analyze
+```
+
+The planning run is the bridge between a raw idea and production work. It creates the angle, outline, script direction, validation notes, scene plan, asset list, and packaging options before any execution or publishing happens.
+
+See `docs/PLANNING_RUN_TEMPLATE.md` for the standard planning-only run format.
+
+---
+
+## 1. Idea Selection
+
+A topic is worth pursuing when it has at least one of these signals:
+
+- A real breakthrough or visible demo
+- A major company or open-source ecosystem move
+- A clear job, business, or everyday-life impact
+- A strong contrast between hype and reality
+- A future implication people care about
+
+Avoid topics that are only interesting because they are new. New is not enough. The video needs a reason for viewers to care.
+
+---
+
+## 2. Task Understanding
+
+Before writing or researching deeply, define the task.
+
+```text
+Goal:
+Audience:
+Core angle:
+Context used:
+Constraints:
+Assumptions:
+Confidence:
+Clarification needed:
+```
+
+This step prevents vague work. It should ask questions only when the answer materially changes the video.
+
+---
+
+## 3. Planning Run
+
+A planning run turns the idea into reviewable artifacts.
+
+Standard artifacts:
+
+1. Angle and audience
+2. Hook options
+3. 5-7 beat outline
+4. Script draft or script plan
+5. Claim and flow validation
+6. Time-coded scene plan
+7. Asset list
+8. Editing plan
+9. Title and thumbnail variants
+10. Review stop
+
+Planning runs are allowed to be rich and multi-step, but they do not authorize upload, publishing, account actions, purchases, or external automation.
+
+---
+
+## 4. Research / Evidence Collection
+
+Collect evidence before finalizing the script.
+
+Useful source types:
+
+- Official product announcements
+- Public demos
+- Research papers or technical reports
+- Company blog posts
+- Conference talks
+- Credible journalism
+- Publicly available video footage
+- Screen recordings of real tools
+
+Every video should separate:
+
+- What is confirmed
+- What is likely
+- What is speculation
+- What is unknown
+
+---
+
+## 5. Script
+
+A strong script should follow this structure:
+
+1. Hook
+   - Why this matters now
+
+2. What happened
+   - Simple explanation of the breakthrough, tool, robot, or trend
+
+3. Proof
+   - What real footage, demo, or public evidence shows
+
+4. Why it matters
+   - Jobs, business, daily life, competition, or future impact
+
+5. What comes next
+   - Grounded prediction or open question
+
+6. Closing line
+   - Clear final takeaway
+
+Write for narration. Use short, clear sections that can be edited into visual beats.
+
+---
+
+## 6. Claim Check
+
+Before voiceover or editing, claims should be reviewed.
+
+Each major claim should be labeled as:
+
+- Verified
+- Supported but uncertain
+- Opinion
+- Speculation
+- Unknown / needs source
+
+Do not present speculation as fact.
+
+---
+
+## 7. Voice
+
+Voiceover may be generated with tools such as ElevenLabs, Piper, or another approved voice provider.
+
+If NovaLIS/OpenClaw is used to generate voice, the task must be governed:
+
+- Approved script only
+- Approved voice provider only
+- No account changes
+- No purchases without approval
+- Stop after the audio file is generated and downloaded
+
+---
+
+## 8. Visual Plan
+
+Preferred format:
+
+> Real footage for proof + animation for explanation + narration for story.
+
+Visuals may include:
+
+- Product demos
+- Robot footage
+- Screen recordings
+- Publicly released clips
+- Diagrams
+- Timelines
+- Simple animations
+- Captions and overlays
+
+The video should not rely only on generic AI-generated visuals. Real proof is part of the channel identity.
+
+---
+
+## 9. Editing
+
+Editing should prioritize clarity and retention.
+
+Useful editing rules:
+
+- Show proof early
+- Keep pacing tight
+- Use captions for important phrases
+- Use diagrams for complicated ideas
+- Avoid long static sections
+- Do not overuse stock footage
+
+---
+
+## 10. Review
+
+Before publishing, check:
+
+- Does the title match the actual video?
+- Are claims accurate?
+- Is speculation clearly framed?
+- Are clips and visuals appropriate?
+- Does the video explain why people should care?
+- Is there any misleading hype?
+- Did the final edit stay inside the original promise?
+
+---
+
+## 11. Publish
+
+Publishing should remain a human-approved action.
+
+Publishing is high-risk because it represents the channel publicly. It should not be fully autonomous without explicit approval and a governed execution path.
+
+For the current repo status, publish manually.
+
+---
+
+## 12. Analyze
+
+After publishing, track:
+
+- Views
+- Click-through rate
+- Average view duration
+- Retention drop-offs
+- Comments
+- Topic performance
+- Hook performance
+- Thumbnail/title performance
+
+Use this information to decide what to double down on, adjust, or stop making.
+
+---
+
+## First Target Workflow
+
+The first practical workflow should be:
+
+1. Pick one video idea
+2. Run the planning template
+3. Collect evidence
+4. Write script
+5. Generate or record voiceover
+6. Create a simple shot list
+7. Manually edit the first version
+8. Publish manually
+9. Record performance notes
+
+Automation should be added only after this manual path is proven.


### PR DESCRIPTION
## Summary

Adds YouTubeLIS into Nova as a planning-only tool folder under `tools/youtubelis/`.

This brings over the current YouTubeLIS documentation set:

- `tools/youtubelis/README.md`
- `tools/youtubelis/docs/CONTENT_STRATEGY.md`
- `tools/youtubelis/docs/VIDEO_PIPELINE.md`
- `tools/youtubelis/docs/PLANNING_RUN_TEMPLATE.md`
- `tools/youtubelis/docs/GOVERNED_AUTOMATION.md`
- `tools/youtubelis/docs/NOVALIS_INTEGRATION.md`
- `tools/youtubelis/docs/FIRST_VIDEO_IDEAS.md`

Also adds a Nova-facing pointer doc:

- `docs/tools/youtubelis.md`

## Scope

This is a docs/planning-folder integration only.

## Non-goals

This PR does not:

- add a Nova runtime capability
- modify `nova_backend/src/config/registry.json`
- modify `nova_backend/src/config/connector_packages.json`
- add OpenClaw execution
- add YouTube upload/publish/account automation
- change generated runtime truth docs

## Governance notes

YouTubeLIS is intentionally framed as planning-first. It can support content strategy, planning runs, script structure, claim validation, scene planning, and packaging ideas.

Publishing, uploading, account actions, purchases, deletions, background loops, and external execution remain blocked unless future runtime code implements a governed path with tests and regenerated runtime truth.

## Verification

Docs-only change. No runtime registry or generated runtime docs were touched.