### PR TITLE
Add structured search evidence synthesis

### DIFF
--- a/nova_backend/src/brain/search_synthesis.py
+++ b/nova_backend/src/brain/search_synthesis.py
@@ -1,0 +1,217 @@
+"""Deterministic search evidence synthesis for Cap 16.
+
+This module turns governed search results into structured evidence metadata.
+It does not search, browse, call LLMs, route capabilities, or authorize action.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+
+class EvidenceConfidence(str, Enum):
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+@dataclass(frozen=True)
+class EvidenceClaim:
+    claim: str
+    source_url: str
+    source_title: str = ""
+    confidence: EvidenceConfidence = EvidenceConfidence.MEDIUM
+    uncertainty: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "claim": self.claim,
+            "source_url": self.source_url,
+            "source_title": self.source_title,
+            "confidence": self.confidence.value,
+            "uncertainty": self.uncertainty,
+        }
+
+
+@dataclass(frozen=True)
+class SearchEvidence:
+    query: str
+    claims: list[EvidenceClaim] = field(default_factory=list)
+    known: list[str] = field(default_factory=list)
+    unclear: list[str] = field(default_factory=list)
+    source_urls: list[str] = field(default_factory=list)
+    confidence: EvidenceConfidence = EvidenceConfidence.LOW
+    evidence_status: str = "no_evidence"
+    source_pages_read: int = 0
+    result_count: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "query": self.query,
+            "claims": [claim.to_dict() for claim in self.claims],
+            "known": list(self.known),
+            "unclear": list(self.unclear),
+            "source_urls": list(self.source_urls),
+            "confidence": self.confidence.value,
+            "evidence_status": self.evidence_status,
+            "source_pages_read": self.source_pages_read,
+            "result_count": self.result_count,
+        }
+
+
+def synthesize_search_evidence(
+    *,
+    query: str,
+    results: list[dict],
+    source_packets: list[dict] | None = None,
+    low_relevance: bool = False,
+) -> SearchEvidence:
+    """Build a deterministic evidence packet from governed search outputs."""
+    normalized_query = " ".join(str(query or "").split()).strip()
+    clean_results = [item for item in list(results or []) if isinstance(item, dict)]
+    clean_packets = [item for item in list(source_packets or []) if isinstance(item, dict)]
+    source_urls = _unique_urls(clean_results, clean_packets)
+
+    if low_relevance or not clean_results:
+        return SearchEvidence(
+            query=normalized_query,
+            claims=[],
+            known=[],
+            unclear=[
+                "Search returned little reliable evidence for the requested claim or entity.",
+                "The query may be misspelled, fictional, private, too new, or not covered by reliable indexed sources.",
+            ],
+            source_urls=source_urls,
+            confidence=EvidenceConfidence.LOW,
+            evidence_status="weak_or_no_evidence",
+            source_pages_read=len(clean_packets),
+            result_count=len(clean_results),
+        )
+
+    claims = _claims_from_packets(clean_packets)
+    if not claims:
+        claims = _claims_from_results(clean_results)
+
+    known: list[str] = []
+    if clean_results:
+        known.append(
+            f"Governed search returned {len(clean_results)} result{'s' if len(clean_results) != 1 else ''}."
+        )
+    if clean_packets:
+        known.append(
+            f"Nova reviewed {len(clean_packets)} source page{'s' if len(clean_packets) != 1 else ''}."
+        )
+    if source_urls:
+        known.append("Visible source URLs are available for review.")
+
+    unclear: list[str] = []
+    if not clean_packets:
+        unclear.append("Source pages were not readable, so evidence is based on result titles/snippets.")
+    elif len(clean_packets) < min(3, len(clean_results)):
+        unclear.append("Only part of the result set had readable source-page text.")
+    unclear.append("Current facts may change; use the linked sources for latest context.")
+
+    confidence = _confidence_for(clean_results, clean_packets, claims)
+    status = "source_backed" if clean_packets else "snippet_backed"
+    return SearchEvidence(
+        query=normalized_query,
+        claims=claims,
+        known=known,
+        unclear=unclear,
+        source_urls=source_urls,
+        confidence=confidence,
+        evidence_status=status,
+        source_pages_read=len(clean_packets),
+        result_count=len(clean_results),
+    )
+
+
+def render_evidence_notes(evidence: SearchEvidence) -> tuple[str, str, str]:
+    """Return user-facing confidence/known/unclear lines from evidence."""
+    confidence = evidence.confidence.value.replace("_", " ").title()
+    known = " ".join(evidence.known).strip() or "No strong evidence was found."
+    unclear = " ".join(evidence.unclear).strip() or "No major uncertainty was detected from available evidence."
+    return confidence, known, unclear
+
+
+def _claims_from_packets(source_packets: list[dict]) -> list[EvidenceClaim]:
+    claims: list[EvidenceClaim] = []
+    for packet in source_packets[:3]:
+        url = str(packet.get("url") or "").strip()
+        if not url:
+            continue
+        title = _clean_text(str(packet.get("title") or ""))
+        text = _clean_text(str(packet.get("text") or ""))
+        claim_text = _first_sentence(text) or title
+        if not claim_text:
+            continue
+        claims.append(
+            EvidenceClaim(
+                claim=claim_text,
+                source_url=url,
+                source_title=title,
+                confidence=EvidenceConfidence.MEDIUM,
+                uncertainty="Source-page excerpt was available; details may still need verification.",
+            )
+        )
+    return claims
+
+
+def _claims_from_results(results: list[dict]) -> list[EvidenceClaim]:
+    claims: list[EvidenceClaim] = []
+    for item in results[:3]:
+        url = str(item.get("url") or "").strip()
+        if not url:
+            continue
+        title = _clean_text(str(item.get("title") or ""))
+        snippet = _clean_text(str(item.get("snippet") or ""))
+        claim_text = snippet or title
+        if not claim_text:
+            continue
+        claims.append(
+            EvidenceClaim(
+                claim=claim_text,
+                source_url=url,
+                source_title=title,
+                confidence=EvidenceConfidence.LOW,
+                uncertainty="Only search result title/snippet was available.",
+            )
+        )
+    return claims
+
+
+def _confidence_for(results: list[dict], source_packets: list[dict], claims: list[EvidenceClaim]) -> EvidenceConfidence:
+    if len(source_packets) >= 2 and len(claims) >= 2:
+        return EvidenceConfidence.HIGH
+    if source_packets or results:
+        return EvidenceConfidence.MEDIUM
+    return EvidenceConfidence.LOW
+
+
+def _unique_urls(results: list[dict], source_packets: list[dict]) -> list[str]:
+    urls: list[str] = []
+    for collection in (source_packets, results):
+        for item in collection:
+            url = str(item.get("url") or "").strip()
+            if url and url not in urls:
+                urls.append(url)
+    return urls
+
+
+def _clean_text(value: str) -> str:
+    text = re.sub(r"<[^>]+>", "", str(value or ""))
+    return " ".join(text.split()).strip()
+
+
+def _first_sentence(text: str) -> str:
+    clean = _clean_text(text)
+    if not clean:
+        return ""
+    parts = re.split(r"(?<=[.!?])\s+", clean, maxsplit=1)
+    sentence = parts[0].strip()
+    if len(sentence) > 260:
+        sentence = sentence[:257].rstrip() + "..."
+    return sentence

--- a/nova_backend/src/executors/web_search_executor.py
+++ b/nova_backend/src/executors/web_search_executor.py
@@ -7,6 +7,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError, as_completed
 
 from src.actions.action_result import ActionResult
+from src.brain.search_synthesis import render_evidence_notes, synthesize_search_evidence
 from src.llm.llm_gateway import generate_chat
 from src.utils.content_extractor import extract_text_from_html
 
@@ -81,6 +82,7 @@ class WebSearchExecutor:
         *,
         researched_summary: str = "",
         source_pages_read: int = 0,
+        evidence: dict | None = None,
     ) -> dict:
         return {
             "widget": {
@@ -93,6 +95,7 @@ class WebSearchExecutor:
                     "summary": researched_summary,
                     "researched_summary": researched_summary,
                     "source_pages_read": source_pages_read,
+                    "evidence": evidence or {},
                     "follow_up_prompts": self._follow_up_prompts(query),
                     "suggested_actions": self._build_suggested_actions(query),
                     "results": [],
@@ -109,6 +112,7 @@ class WebSearchExecutor:
         *,
         researched_summary: str = "",
         source_pages_read: int = 0,
+        evidence: dict | None = None,
     ) -> dict:
         widget_summary = (researched_summary or "").strip() or self._build_summary(query, results)
         return {
@@ -122,6 +126,7 @@ class WebSearchExecutor:
                     "summary": widget_summary,
                     "researched_summary": widget_summary,
                     "source_pages_read": source_pages_read,
+                    "evidence": evidence or {},
                     "follow_up_prompts": self._follow_up_prompts(query),
                     "suggested_actions": self._build_suggested_actions(query),
                     "results": results,
@@ -555,16 +560,18 @@ class WebSearchExecutor:
 
         results = self._parse_results(data)[:5]
         if not results:
+            evidence = synthesize_search_evidence(query=query, results=[])
             return ActionResult.ok(
                 message=(
                     f"{boundary_notice} I couldn't find solid results for \"{query}\".\n"
                     "Try a more specific query, a company/site name, or a shorter topic phrase."
                 ),
-                data=self._empty_widget(query=query, provider=used_provider),
+                data=self._empty_widget(query=query, provider=used_provider, evidence=evidence.to_dict()),
                 request_id=request.request_id,
             )
 
         if self._looks_low_relevance(query, results):
+            evidence = synthesize_search_evidence(query=query, results=results, low_relevance=True)
             sources = self._format_visible_sources(results)
             message = "\n".join(
                 [
@@ -590,6 +597,7 @@ class WebSearchExecutor:
                     results=results,
                     researched_summary=f'I found little reliable evidence for "{query}".',
                     source_pages_read=0,
+                    evidence=evidence.to_dict(),
                 ),
                 request_id=request.request_id,
             )
@@ -605,7 +613,6 @@ class WebSearchExecutor:
         logger.info("web_search latency=%.2fs avg=%.2fs query=%s", elapsed_seconds, avg_latency, query[:80])
 
         provider_label = self._format_provider_label(used_provider)
-        confidence_label = "Medium" if used_provider == "brave" else "Medium-Low"
         search_deadline = started_at + SEARCH_HARD_TIMEOUT_SECONDS
         source_packets = self._collect_source_packets(
             capability_id=request.capability_id,
@@ -626,6 +633,8 @@ class WebSearchExecutor:
                 session_id=session_id,
                 timeout_seconds=min(SYNTHESIS_TIMEOUT_SECONDS, remaining_synthesis_budget),
             )
+        evidence = synthesize_search_evidence(query=query, results=results, source_packets=source_packets)
+        confidence_label, known_note, unclear_note = render_evidence_notes(evidence)
 
         report_sections = [
             f"Bottom line: {researched_summary}",
@@ -636,12 +645,8 @@ class WebSearchExecutor:
             *self._format_visible_sources(results),
             "",
             f"Confidence: {confidence_label}",
-            f"What is known: I found {len(results)} search result{'s' if len(results) != 1 else ''} and reviewed {len(source_packets)} source page{'s' if len(source_packets) != 1 else ''}.",
-            (
-                "What is unclear: Source pages were limited or not fully readable, so treat this as a starting point."
-                if len(source_packets) < min(len(results), MAX_SOURCE_READS)
-                else "What is unclear: Details may still change; use the linked sources for the latest context."
-            ),
+            f"What is known: {known_note}",
+            f"What is unclear: {unclear_note}",
             f"Source reading: reviewed {len(source_packets)} page{'s' if len(source_packets) != 1 else ''} via {provider_label}.",
             "",
             "Try next",
@@ -661,6 +666,7 @@ class WebSearchExecutor:
                 results=results,
                 researched_summary=researched_summary,
                 source_pages_read=len(source_packets),
+                evidence=evidence.to_dict(),
             ),
             request_id=request.request_id,
         )

--- a/nova_backend/tests/brain/test_search_synthesis.py
+++ b/nova_backend/tests/brain/test_search_synthesis.py
@@ -1,0 +1,114 @@
+from src.brain.search_synthesis import (
+    EvidenceConfidence,
+    render_evidence_notes,
+    synthesize_search_evidence,
+)
+
+
+def test_search_synthesis_builds_source_backed_evidence_from_packets():
+    evidence = synthesize_search_evidence(
+        query="latest AI model releases",
+        results=[
+            {
+                "title": "Model launch roundup",
+                "url": "https://example.com/models",
+                "snippet": "Several AI labs announced new models.",
+            },
+            {
+                "title": "AI release notes",
+                "url": "https://example.org/releases",
+                "snippet": "New reasoning and coding models shipped.",
+            },
+        ],
+        source_packets=[
+            {
+                "title": "Model launch roundup",
+                "url": "https://example.com/models",
+                "text": "Lab A announced a new reasoning model this week. Details may change.",
+            },
+            {
+                "title": "AI release notes",
+                "url": "https://example.org/releases",
+                "text": "Lab B released a coding model for developers.",
+            },
+        ],
+    )
+
+    assert evidence.evidence_status == "source_backed"
+    assert evidence.confidence == EvidenceConfidence.HIGH
+    assert evidence.source_pages_read == 2
+    assert evidence.result_count == 2
+    assert evidence.source_urls == ["https://example.com/models", "https://example.org/releases"]
+    assert evidence.claims[0].source_url == "https://example.com/models"
+    assert "announced a new reasoning model" in evidence.claims[0].claim
+    assert "Nova reviewed 2 source pages" in " ".join(evidence.known)
+
+
+def test_search_synthesis_falls_back_to_snippet_backed_evidence():
+    evidence = synthesize_search_evidence(
+        query="recent EV sales",
+        results=[
+            {
+                "title": "EV sales update",
+                "url": "https://example.com/ev",
+                "snippet": "EV sales grew in some regions and slowed in others.",
+            }
+        ],
+        source_packets=[],
+    )
+
+    assert evidence.evidence_status == "snippet_backed"
+    assert evidence.confidence == EvidenceConfidence.MEDIUM
+    assert evidence.claims[0].confidence == EvidenceConfidence.LOW
+    assert "Only search result title/snippet was available" in evidence.claims[0].uncertainty
+    assert any("not readable" in item for item in evidence.unclear)
+
+
+def test_search_synthesis_low_relevance_reports_weak_or_no_evidence():
+    evidence = synthesize_search_evidence(
+        query="Zorblax Quantum Sandwich Labs",
+        results=[
+            {"title": "Quantum computing news", "url": "https://example.com/q", "snippet": "General quantum news."}
+        ],
+        low_relevance=True,
+    )
+
+    assert evidence.evidence_status == "weak_or_no_evidence"
+    assert evidence.confidence == EvidenceConfidence.LOW
+    assert evidence.claims == []
+    assert "little reliable evidence" in evidence.unclear[0]
+
+
+def test_search_evidence_serializes_to_plain_dict():
+    evidence = synthesize_search_evidence(
+        query="coffee alzheimer evidence",
+        results=[
+            {
+                "title": "Coffee and health",
+                "url": "https://example.com/coffee",
+                "snippet": "Studies are mixed and do not prove prevention.",
+            }
+        ],
+    )
+
+    payload = evidence.to_dict()
+
+    assert payload["query"] == "coffee alzheimer evidence"
+    assert payload["confidence"] == "medium"
+    assert payload["claims"][0]["source_url"] == "https://example.com/coffee"
+    assert payload["source_urls"] == ["https://example.com/coffee"]
+
+
+def test_render_evidence_notes_returns_user_facing_lines():
+    evidence = synthesize_search_evidence(
+        query="current AI regulation",
+        results=[
+            {"title": "AI regulation", "url": "https://example.com/reg", "snippet": "Regulators proposed rules."}
+        ],
+    )
+
+    confidence, known, unclear = render_evidence_notes(evidence)
+
+    assert confidence == "Medium"
+    assert "Governed search returned 1 result" in known
+    assert "Current facts may change" in unclear

--- a/nova_backend/tests/executors/test_web_search_evidence.py
+++ b/nova_backend/tests/executors/test_web_search_evidence.py
@@ -1,0 +1,55 @@
+from src.actions.action_request import ActionRequest
+from src.actions.action_result import ActionResult
+from src.executors.web_search_executor import WebSearchExecutor
+from src.governor.execute_boundary.execute_boundary import ExecuteBoundary
+
+
+class _NoopNetwork:
+    def request(self, *args, **kwargs):  # pragma: no cover
+        raise AssertionError("network should not be called by this unit test")
+
+
+def _request() -> ActionRequest:
+    return ActionRequest(
+        capability_id=16,
+        params={"query": "latest AI model releases", "session_id": "test-session"},
+        request_id="search-test",
+    )
+
+
+def test_web_search_widget_includes_structured_evidence(monkeypatch):
+    monkeypatch.delenv("BRAVE_API_KEY", raising=False)
+    executor = WebSearchExecutor(_NoopNetwork(), ExecuteBoundary())
+    results = [
+        {
+            "title": "AI model release roundup",
+            "url": "https://example.com/models",
+            "snippet": "Several model releases were announced.",
+        }
+    ]
+    source_packets = [
+        {
+            "title": "AI model release roundup",
+            "url": "https://example.com/models",
+            "domain": "example.com",
+            "text": "A new AI model was announced this week with stronger coding performance.",
+        }
+    ]
+
+    monkeypatch.setattr(executor, "_parse_results", lambda data: results)
+    monkeypatch.setattr(executor, "_search_duckduckgo", lambda request, query, session_id: {"status_code": 200, "data": {}})
+    monkeypatch.setattr(executor, "_collect_source_packets", lambda **kwargs: source_packets)
+    monkeypatch.setattr(
+        executor,
+        "_synthesize_researched_summary",
+        lambda **kwargs: "A source-backed model release summary.",
+    )
+
+    action_result = executor.execute(_request())
+
+    assert isinstance(action_result, ActionResult)
+    assert action_result.success is True
+    evidence = action_result.data["widget"]["data"].get("evidence")
+    assert evidence is not None
+    assert evidence["query"] == "latest AI model releases"
+    assert evidence["evidence_status"] in {"source_backed", "snippet_backed"}


### PR DESCRIPTION
## Summary
Adds deterministic structured evidence synthesis for governed web search.

## Changes
- Add `SearchEvidence`, `EvidenceClaim`, and confidence helpers.
- Add deterministic `synthesize_search_evidence()` and `render_evidence_notes()` helpers.
- Attach evidence metadata to web search widget data.
- Use evidence-derived confidence / known / unclear notes in search responses.
- Add brain and executor tests for evidence payload behavior.

## Governance boundaries
- No new capabilities.
- No Governor changes.
- No GovernorMediator changes.
- No NetworkMediator bypass.
- No ExecuteBoundary changes.
- No OpenClaw integration.
- No persistence.
- No background automation.
- No account/browser/file/email/calendar actions.
- No generated runtime docs changed.

## Validation
- `python -m pytest nova_backend\tests\brain -q` → 72 passed
- `python -m pytest nova_backend\tests\executors -q` → 150 passed
- `python scripts\check_runtime_doc_drift.py` → passed
- `git diff --check` → passed
- `python -m pytest -q` → 1739 passed, 4 skipped