### PR TITLE
Harden Daily Brief continuity and recommendations

### DIFF
--- a/docs/demo_proof/daily_operating_baseline/CONVERSATION_CONTINUITY_PROOF.md
+++ b/docs/demo_proof/daily_operating_baseline/CONVERSATION_CONTINUITY_PROOF.md
@@ -1,0 +1,49 @@
+# Conversation Continuity Proof
+
+Status: partial automated proof, 2026-05-01.
+
+## Runtime Claim
+
+Session conversation context now carries continuity fields:
+
+- `mode`
+- `last_decision`
+- `open_loops`
+- `recent_recommendations`
+
+The Daily Brief can read these fields from `session_state["conversation_context"]` and surface them in a Session State section.
+
+## Validated Behaviors
+
+Validated in tests:
+
+- Session State section is empty when no context is available
+- topic appears when present
+- user goal appears when distinct from topic
+- mode appears when present
+- open loops appear from conversation context
+- recent recommendations appear from conversation context
+- section output is capped
+- malformed open loops are skipped
+- malformed conversation context payloads degrade without traceback
+
+The broader conversation suite remained green:
+
+```text
+python -m pytest nova_backend\tests\conversation -q
+412 passed
+```
+
+## Boundary
+
+This is session-local continuity, not durable memory.
+
+It does not:
+
+- silently save memory
+- authorize actions
+- infer permission from prior conversation
+- create background automation
+- guarantee multi-day project recall
+
+Full memory loop proof remains future work.

--- a/docs/demo_proof/daily_operating_baseline/DAILY_BRIEF_PROOF.md
+++ b/docs/demo_proof/daily_operating_baseline/DAILY_BRIEF_PROOF.md
@@ -1,0 +1,62 @@
+# Daily Brief Proof
+
+Status: baseline automated proof, 2026-05-01.
+
+This proof covers the Daily Brief MVP plus the Daily Brief continuity-hardening pass.
+
+## Runtime Claim
+
+Daily Brief is implemented as a deterministic, on-demand session brief.
+
+It does not:
+
+- execute capabilities
+- authorize actions
+- call an LLM
+- create persistence
+- send email
+- call Google/Gmail/Calendar APIs
+- expand OpenClaw
+- start background automation
+
+## Hardened Behaviors
+
+Validated in tests:
+
+- empty session state degrades cleanly
+- malformed session and conversation context payloads do not raise
+- malformed memory and receipt payloads are skipped
+- unavailable weather and calendar return low-confidence setup/unavailable sections
+- email remains a placeholder when no connector is configured
+- duplicate open loops are deduped
+- long text is clipped
+- recent receipts include an honest empty-state message
+- continuity fields can appear in the brief through the Session State section
+- deterministic next-action recommendations fill useful guidance without action authority
+
+## Validation
+
+Commands run:
+
+```text
+python -m py_compile nova_backend\src\brief\daily_brief.py nova_backend\src\brief\recommendations.py
+python -m pytest nova_backend\tests\brief -q
+python -m pytest nova_backend\tests\conversation -q
+python scripts\check_runtime_doc_drift.py
+git diff --check
+python -m pytest -q
+```
+
+Results:
+
+```text
+brief tests: 114 passed
+conversation tests: 412 passed
+runtime doc drift: passed
+git diff --check: clean
+full suite: 1877 passed, 4 skipped
+```
+
+## Boundary
+
+This proof does not claim a full daily operating system, silent memory loop, Google connector, email connector, or background routine system.

--- a/docs/demo_proof/daily_operating_baseline/MEMORY_LOOP_PROOF.md
+++ b/docs/demo_proof/daily_operating_baseline/MEMORY_LOOP_PROOF.md
@@ -1,0 +1,33 @@
+# Memory Loop Proof
+
+Status: partial / not full runtime loop proof, 2026-05-01.
+
+## What Is Proven Here
+
+Daily Brief can consume caller-provided memory-shaped items and degrade safely.
+
+Validated in tests:
+
+- malformed memory entries are skipped
+- next-action memory items appear in Top Next Actions
+- open-loop memory items appear in Open Loops
+- duplicate open loops are deduped
+- long memory text is clipped
+- empty memory can trigger a deterministic suggestion to save a useful preference
+
+## What Is Not Proven
+
+This is not a full memory loop proof.
+
+Not proven in this package:
+
+- automatic memory capture
+- durable memory save/retrieve flow
+- remember/forget/review UX
+- receipt-to-memory promotion
+- cross-session memory continuity
+- memory-based authorization
+
+## Boundary
+
+Memory supports context and usefulness. Memory does not authorize actions.

--- a/docs/demo_proof/daily_operating_baseline/SEARCH_FEEDBACK_PROOF.md
+++ b/docs/demo_proof/daily_operating_baseline/SEARCH_FEEDBACK_PROOF.md
@@ -1,0 +1,28 @@
+# Search Feedback Proof
+
+Status: partial automated proof, 2026-05-01.
+
+## Runtime Claim
+
+Daily Brief can use provided search evidence state to recommend a safe next step when recent search evidence is weak or partial.
+
+Validated behavior:
+
+- weak or no evidence can produce a suggestion to refine the search evidence
+- snippet-backed or low-confidence evidence is treated conservatively
+- the suggestion is textual guidance only
+
+## Boundary
+
+This does not run a search.
+
+It does not:
+
+- call Cap 16
+- browse
+- fetch sources
+- authorize tool use
+- retry failed searches automatically
+- create background monitoring
+
+Search Evidence Synthesis remains deterministic evidence structuring for the governed web-search output path.

--- a/docs/product/WHAT_WORKS_TODAY.md
+++ b/docs/product/WHAT_WORKS_TODAY.md
@@ -8,6 +8,7 @@ Use generated runtime docs for exact active capability truth.
 Use this page for user-facing readiness expectations.
 
 Latest proof packages:
+- [Daily operating baseline proof](../demo_proof/daily_operating_baseline/DAILY_BRIEF_PROOF.md)
 - [2026-04-29 conversation + search proof](../demo_proof/2026-04-29_conversation_search_proof/CONVERSATION_SEARCH_REPORT.md)
 - [Brain live test report](../demo_proof/brain_live_test/REPORT.md)
 - [2026-04-28 user test](../demo_proof/2026-04-28_user_test/USER_TEST_REPORT.md)
@@ -51,6 +52,7 @@ Latest proof packages:
 | Email draft | Implemented, safety-limited, paused | Opens a local mail client draft through `mailto:` after confirmation. Nova does not use SMTP, access inboxes, or send autonomously. Cap 64 live signoff is paused while Cap 16 conversation/search proof is the active sprint. |
 | OpenClaw execution surface | Advanced / constrained | Governed, limited, not broad autonomy. |
 | Action Receipts | Implemented, maturing UX | Visible receipt surface exists for governed-action outcomes. A fuller Trust Panel remains future work. |
+| Daily Brief MVP | Implemented, maturing UX | Deterministic on-demand session brief with session, memory, receipts, weather, calendar, email placeholder, continuity fields, and deterministic next-action recommendations. No execution authority, no LLM call, no background automation. |
 
 ---
 
@@ -58,7 +60,7 @@ Latest proof packages:
 
 | Area | Status | Notes |
 |---|---|---|
-| Daily brief / operating layer | Future / not implemented | The operating model documents daily briefs, news tracking, routines, context awareness, and approved automation loops as direction, not current product readiness. |
+| Full daily operating layer | Future / not implemented | Daily Brief MVP exists, but routines, background context awareness, approved automation loops, durable memory loop proof, and full operating-system behavior remain future work. |
 | Approved automation routines / envelopes | Future / not implemented | Conceptual direction only. No broad recurring automation loop should be claimed as live. |
 | Small-model full Brain runtime stack | Future / not implemented | Context Assembler, Model Router, Intention Parser, Tool Bridge, Sandbox Boundary Enforcer, and Persona Filter are documented architecture, not live runtime behavior. Search Evidence Synthesis is implemented only as deterministic Cap 16 evidence structuring, not as a general Brain planner. |
 | Google read/context connector | Future / not implemented | The Google connector model documents OAuth, Gmail read-only, Calendar read-only, and Gmail context for Cap 64 draft-only replies. It is a future read/context path, not Gmail send/write authority. |

--- a/docs/status/CURRENT_WORK_STATUS.md
+++ b/docs/status/CURRENT_WORK_STATUS.md
@@ -39,6 +39,10 @@ Generated runtime truth still reports the authoritative capability inventory and
   CalendarSkill), and email placeholder into 11 sections. Non-authorizing frozen dataclass;
   `execution_performed=False` and `authorization_granted=False` are enforced by `__post_init__`.
   No new capability, no LLM calls, no Governor path.
+- Daily Brief robustness is improved on the `daily-brief-continuity-hardening` branch. It degrades
+  cleanly on malformed session, memory, receipt, weather, calendar, and email-placeholder inputs;
+  surfaces session continuity fields; and uses deterministic next-action recommendations. Proof notes
+  live under [`../demo_proof/daily_operating_baseline/`](../demo_proof/daily_operating_baseline/).
 - Cap 64 remains confirmation-bound local `mailto:` draft only. It does not use Gmail API, SMTP, inbox access, or autonomous send.
 - Cap 65 remains read-only Shopify intelligence. No Shopify writes are implemented.
 
@@ -142,6 +146,8 @@ Do not claim these are finished unless verified against code/runtime truth:
 - First-run workspace onboarding wizard.
 - Free-first runtime enforcement.
 - One-click consumer installer.
+- Full Daily Operating System / background routines.
+- Durable memory loop proof.
 
 ---
 

--- a/docs/todo/ACTIVE_TODO.md
+++ b/docs/todo/ACTIVE_TODO.md
@@ -1,14 +1,14 @@
 # Active TODO - Nova
 
 **Updated:** 2026-05-01
-**Sprint goal:** Memory loop + conversation continuity after Daily Brief MVP merge.
+**Sprint goal:** Re-run conversation/search proof after Daily Brief continuity hardening.
 **Authority note:** This file is the public task snapshot. Exact runtime truth still comes from generated runtime docs and code.
 
 ## Current Priorities (ordered)
 
-- [ ] Memory loop and conversation continuity — wire session continuity state fields: `current_topic`,
-      `session_goal`, `mode`, `last_decision`, `open_loops`, `recent_recommendations`
+- [ ] Re-run Daily Brief + continuity proof manually in the local UI/API
 - [ ] Re-run and record the conversation + search demo flow with Search Evidence Synthesis active
+- [ ] Memory full loop - remember / forget / review saved memory, without silent autosave
 - [ ] Improve conversation follow-up/topic tracking for connector/governance topics
 - [ ] Tighten uncertainty wording for health/safety/current-evidence questions
 - [ ] Continue doc/status cleanup where stale "local-only" or planning-as-runtime wording remains
@@ -86,7 +86,11 @@ Canonical audit: `docs/future/OPENCLAW_ROBUST_HARDENING_AUDIT_2026-05-01.md`
 
 ## Recently Completed
 
-- Daily Brief MVP merged via PR #68 — deterministic on-demand session brief, 11 sections, live weather +
+- Daily Brief continuity hardening branch - malformed input degradation, continuity fields in brief,
+  deterministic next-action recommendations, proof docs, 114 brief tests
+- Conversation continuity fields merged into `SessionConversationContext`: `mode`, `last_decision`,
+  `open_loops`, `recent_recommendations`
+- Daily Brief MVP merged via PR #68 - deterministic on-demand session brief, 11 sections, live weather +
   calendar, 76 tests
 - Brain Planning Preview scaffold merged via PR #64
 - YouTubeLIS planning-only tool folder merged via PR #65

--- a/nova_backend/src/brief/daily_brief.py
+++ b/nova_backend/src/brief/daily_brief.py
@@ -16,6 +16,7 @@ from enum import Enum
 from typing import Any
 
 from src.actions.action_result import ActionResult
+from src.brief.recommendations import select_next_actions
 from src.cognition.cognitive_layer_contract import (
     CognitiveMode,
     CognitiveRequest,
@@ -160,6 +161,14 @@ def _clean(value: Any, *, limit: int = 200) -> str:
     return text[:limit] if len(text) > limit else text
 
 
+def _as_dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return list(value) if isinstance(value, list) else []
+
+
 def _section_confidence(items: list[str]) -> BriefConfidence:
     if len(items) >= 3:
         return BriefConfidence.HIGH
@@ -187,9 +196,7 @@ def _build_today_focus(
     if active_app and active_app not in items:
         items.append(f"Active: {active_app}")
 
-    conv_topic = _clean(
-        (session_state.get("conversation_context") or {}).get("topic") or ""
-    )
+    conv_topic = _clean(_as_dict(session_state.get("conversation_context")).get("topic") or "")
     if conv_topic and conv_topic not in items:
         items.append(f"Topic: {conv_topic}")
 
@@ -203,7 +210,7 @@ def _build_today_focus(
 
 def _build_weather(weather_data: dict[str, Any] | None) -> BriefSection:
     """Build a weather section from pre-fetched WeatherService data."""
-    if not weather_data:
+    if not isinstance(weather_data, dict) or not weather_data:
         return BriefSection(
             title="Weather",
             items=(),
@@ -214,8 +221,10 @@ def _build_weather(weather_data: dict[str, Any] | None) -> BriefSection:
     status = str(weather_data.get("status") or "")
     connected = bool(weather_data.get("connected"))
 
-    if not connected or status in {"not_configured", "unavailable"}:
+    if not connected or status in {"not_configured", "unavailable", "error"}:
         hint = _clean(weather_data.get("setup_hint") or weather_data.get("message") or "", limit=120)
+        if not hint and status == "error":
+            hint = "Weather data is temporarily unavailable."
         items = (hint,) if hint else ()
         return BriefSection(
             title="Weather",
@@ -245,7 +254,7 @@ def _build_weather(weather_data: dict[str, Any] | None) -> BriefSection:
 
 def _build_calendar(calendar_data: dict[str, Any] | None) -> BriefSection:
     """Build a calendar section from pre-fetched CalendarSkill data."""
-    if not calendar_data:
+    if not isinstance(calendar_data, dict) or not calendar_data:
         return BriefSection(
             title="Calendar",
             items=(),
@@ -256,12 +265,18 @@ def _build_calendar(calendar_data: dict[str, Any] | None) -> BriefSection:
     connected = bool(calendar_data.get("connected"))
     status = str(calendar_data.get("status") or "")
 
-    if not connected or status in {"not_connected", "unavailable"}:
-        hint = _clean(
-            calendar_data.get("setup_hint")
-            or "Add a local .ics file in Settings to enable calendar.",
-            limit=120,
-        )
+    if not connected or status in {"not_connected", "unavailable", "error"}:
+        if status == "error":
+            hint = _clean(
+                calendar_data.get("message") or "Calendar is temporarily unavailable.",
+                limit=120,
+            )
+        else:
+            hint = _clean(
+                calendar_data.get("setup_hint")
+                or "Add a local .ics file in Settings to enable calendar.",
+                limit=120,
+            )
         return BriefSection(
             title="Calendar",
             items=(hint,),
@@ -300,9 +315,10 @@ def _build_important_emails(important_emails: list[dict[str, Any]] | None) -> Br
     Currently returns a not-configured notice so the brief UI can show
     the section with a setup prompt.
     """
-    if important_emails:
+    emails = _as_list(important_emails)
+    if emails:
         items: list[str] = []
-        for email in important_emails[:_MAX_ITEMS_PER_SECTION]:
+        for email in emails[:_MAX_ITEMS_PER_SECTION]:
             if not isinstance(email, dict):
                 continue
             sender = _clean(email.get("sender") or "", limit=40)
@@ -350,15 +366,17 @@ def _build_next_actions(memory_items: list[dict[str, Any]]) -> BriefSection:
 
 def _build_open_loops(memory_items: list[dict[str, Any]]) -> BriefSection:
     loops: list[str] = []
+    seen: set[str] = set()
     for item in memory_items:
         if not isinstance(item, dict):
             continue
         category = _clean(item.get("category") or item.get("type") or "")
         content = _clean(item.get("content") or item.get("text") or "")
-        if not content:
+        if not content or content in seen:
             continue
         if category.lower() in {"open_loop", "loop", "open", "pending", "unresolved"}:
             loops.append(content)
+            seen.add(content)
         if len(loops) >= _MAX_ITEMS_PER_SECTION:
             break
 
@@ -417,8 +435,12 @@ def _build_memory_reminders(memory_items: list[dict[str, Any]]) -> BriefSection:
 def _build_recent_receipts(recent_receipts: list[dict[str, Any]]) -> BriefSection:
     labels: list[str] = []
     for receipt in recent_receipts:
+        if not isinstance(receipt, dict):
+            continue
         event_type = str(receipt.get("event_type") or "")
         label = _RECEIPT_LABEL_MAP.get(event_type, event_type.lower().replace("_", " "))
+        if not label.strip():
+            continue
         ts = str(receipt.get("timestamp_utc") or "")
         detail = _clean(
             receipt.get("capability_name")
@@ -439,10 +461,18 @@ def _build_recent_receipts(recent_receipts: list[dict[str, Any]]) -> BriefSectio
         if len(labels) >= _MAX_ITEMS_PER_SECTION:
             break
 
+    if not labels:
+        return BriefSection(
+            title="Recent Actions",
+            items=("No recent receipts found.",),
+            confidence=BriefConfidence.LOW,
+            source_label="receipts",
+        )
+
     return BriefSection(
         title="Recent Actions",
         items=tuple(labels),
-        confidence=BriefConfidence.HIGH if labels else BriefConfidence.LOW,
+        confidence=BriefConfidence.HIGH,
         source_label="receipts",
     )
 
@@ -469,30 +499,111 @@ def _build_blocked_items(memory_items: list[dict[str, Any]]) -> BriefSection:
     )
 
 
+_ACTION_PREFIXES = ("resolve:", "continue:", "inspect failed action:", "inspect:")
+
+
+def _action_core(text: str) -> str:
+    """Strip known action prefixes so deduplication is content-based, not wording-based."""
+    lower = text.strip().lower()
+    for prefix in _ACTION_PREFIXES:
+        if lower.startswith(prefix):
+            return text[len(prefix):].strip()
+    return text.strip()
+
+
+def _build_session_state(session_state: dict[str, Any]) -> BriefSection:
+    """Surface active conversation continuity fields from session_state.
+
+    Draws from conversation_context (topic, user_goal, mode, open_loops,
+    recent_recommendations). Returns an empty section when the context is
+    absent so the brief renders cleanly without any data.
+    """
+    conv_ctx = _as_dict(session_state.get("conversation_context"))
+    items: list[str] = []
+
+    topic = _clean(conv_ctx.get("topic") or session_state.get("active_topic") or "", limit=120)
+    if topic:
+        items.append(f"Topic: {topic}")
+
+    user_goal = _clean(conv_ctx.get("user_goal") or "", limit=120)
+    if user_goal and user_goal != topic:
+        items.append(f"Goal: {user_goal}")
+
+    mode = _clean(conv_ctx.get("mode") or "", limit=40)
+    if mode:
+        items.append(f"Mode: {mode}")
+
+    conv_loops = [
+        _clean(s, limit=120)
+        for s in list(conv_ctx.get("open_loops") or [])
+        if str(s).strip()
+    ]
+    for loop in conv_loops[:3]:
+        items.append(f"Open: {loop}")
+
+    conv_recs = [
+        _clean(s, limit=120)
+        for s in list(conv_ctx.get("recent_recommendations") or [])
+        if str(s).strip()
+    ]
+    for rec in conv_recs[:2]:
+        items.append(f"Rec: {rec}")
+
+    filled = len(items)
+    confidence = (
+        BriefConfidence.HIGH if filled >= 3
+        else BriefConfidence.MEDIUM if filled >= 1
+        else BriefConfidence.LOW
+    )
+    return BriefSection(
+        title="Session State",
+        items=tuple(items[:_MAX_ITEMS_PER_SECTION]),
+        confidence=confidence,
+        source_label="session_context",
+    )
+
+
 def _build_recommended_next_step(
     next_actions: BriefSection,
     open_loops: BriefSection,
     session_state: dict[str, Any],
+    recent_receipts: list[dict[str, Any]],
+    memory_items: list[dict[str, Any]],
 ) -> BriefSection:
-    recommendation: str = ""
+    items: list[str] = []
 
-    # Priority: first open next action > first open loop > session goal
+    # Memory-based priority: first explicit next action > first memory open loop
     if next_actions.items:
-        recommendation = next_actions.items[0]
+        items.append(next_actions.items[0])
     elif open_loops.items:
-        recommendation = f"Resolve: {open_loops.items[0]}"
-    else:
-        conv_goal = _clean(
-            (session_state.get("conversation_context") or {}).get("user_goal") or ""
-        )
-        if conv_goal:
-            recommendation = f"Continue: {conv_goal}"
+        items.append(f"Resolve: {open_loops.items[0]}")
 
-    items = (recommendation,) if recommendation else ()
+    # Fill remaining slots with deterministic suggestions from continuity state
+    if len(items) < 3:
+        conv_loops = [
+            str(s).strip()
+            for s in list(_as_dict(session_state.get("conversation_context")).get("open_loops") or [])
+            if str(s).strip()
+        ]
+        suggestions = select_next_actions(
+            open_loops=conv_loops,
+            memory_items=memory_items,
+            recent_receipts=recent_receipts,
+            session_state=session_state,
+            max_suggestions=3 - len(items),
+        )
+        existing_cores = {_action_core(s).lower() for s in items}
+        for suggestion in suggestions:
+            candidate = suggestion.action
+            if _action_core(candidate).lower() not in existing_cores:
+                items.append(candidate)
+                existing_cores.add(_action_core(candidate).lower())
+
+    confidence = BriefConfidence.MEDIUM if items else BriefConfidence.LOW
     return BriefSection(
         title="Recommended Next Step",
-        items=items,
-        confidence=BriefConfidence.MEDIUM if items else BriefConfidence.LOW,
+        items=tuple(items[:3]),
+        confidence=confidence,
         source_label="synthesis",
     )
 
@@ -547,15 +658,16 @@ def compose_daily_brief(
     fetched by the caller and injected here. This function is synchronous
     and produces no external effects.
     """
-    _session = dict(session_state or {})
-    _memory = list(memory_items or [])
-    _receipts = list(recent_receipts or [])
-    _ctx = dict(working_context or {})
+    _session = _as_dict(session_state)
+    _memory = _as_list(memory_items)
+    _receipts = _as_list(recent_receipts)
+    _ctx = _as_dict(working_context)
 
     today = _today_label()
     now = _utc_now()
 
     focus = _build_today_focus(_session, _ctx)
+    session_state_section = _build_session_state(_session)
     weather = _build_weather(weather_data)
     calendar = _build_calendar(calendar_data)
     emails = _build_important_emails(important_emails)
@@ -565,10 +677,17 @@ def compose_daily_brief(
     reminders = _build_memory_reminders(_memory)
     receipts_section = _build_recent_receipts(_receipts)
     blocked = _build_blocked_items(_memory)
-    recommended = _build_recommended_next_step(next_actions, open_loops, _session)
+    recommended = _build_recommended_next_step(
+        next_actions,
+        open_loops,
+        _session,
+        _receipts,
+        _memory,
+    )
 
     all_sections = (
         focus,
+        session_state_section,
         weather,
         calendar,
         emails,
@@ -590,9 +709,9 @@ def compose_daily_brief(
         sources.append("session")
     if _ctx:
         sources.append("working_context")
-    if weather_data and weather_data.get("connected"):
+    if isinstance(weather_data, dict) and weather_data.get("connected"):
         sources.append("weather")
-    if calendar_data and calendar_data.get("connected"):
+    if isinstance(calendar_data, dict) and calendar_data.get("connected"):
         sources.append("calendar")
 
     confidence = _overall_confidence(list(all_sections))

--- a/nova_backend/src/brief/recommendations.py
+++ b/nova_backend/src/brief/recommendations.py
@@ -1,0 +1,132 @@
+"""Deterministic next-action recommendation selector for the Daily Brief.
+
+Given brief state — open loops, memory items, recent receipts, and session
+state — returns up to max_suggestions practical next actions as structured
+suggestions.
+
+No LLM calls, no capability invocations, no external effects.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class NextActionSuggestion:
+    action: str
+    reason: str
+    priority: int  # lower = higher priority
+
+    def to_dict(self) -> dict[str, str | int]:
+        return {
+            "action": self.action,
+            "reason": self.reason,
+            "priority": self.priority,
+        }
+
+
+def select_next_actions(
+    *,
+    open_loops: list[str] | None = None,
+    memory_items: list[dict[str, Any]] | None = None,
+    recent_receipts: list[dict[str, Any]] | None = None,
+    session_state: dict[str, Any] | None = None,
+    max_suggestions: int = 3,
+) -> list[NextActionSuggestion]:
+    """
+    Return up to max_suggestions practical next-action suggestions.
+
+    Priority rules (applied in order; each fills one slot):
+    1. open_loops exist → suggest resolving the most recent one
+    2. recent receipt failed → suggest inspecting or retrying it
+    3. no session goal → suggest setting today's focus
+    4. no memory → suggest saving a project preference
+
+    Returns an empty list when all slots are already filled by higher-priority
+    rules or when all rules produce no suggestion.
+    """
+    _loops = [str(s).strip() for s in (open_loops or []) if str(s).strip()]
+    _receipts = [r for r in (recent_receipts or []) if isinstance(r, dict)]
+    _memory = [m for m in (memory_items or []) if isinstance(m, dict)]
+    _state = _as_dict(session_state)
+    suggestions: list[NextActionSuggestion] = []
+
+    # Rule 1: open loops → resolve most recent
+    if _loops and len(suggestions) < max_suggestions:
+        most_recent = _loops[0][:120]
+        suggestions.append(NextActionSuggestion(
+            action=f"Resolve: {most_recent}",
+            reason="An open question from your session is unresolved.",
+            priority=1,
+        ))
+
+    # Rule 2: failed receipts → inspect or retry
+    if len(suggestions) < max_suggestions:
+        failed = [
+            r for r in _receipts
+            if str(r.get("event_type") or "").endswith("_FAILED")
+            or str(r.get("outcome") or "") in {"failed", "error", "blocked"}
+        ]
+        if failed:
+            label = str(
+                failed[0].get("capability_name")
+                or failed[0].get("event_type")
+                or "action"
+            )[:80]
+            suggestions.append(NextActionSuggestion(
+                action=f"Inspect failed action: {label}",
+                reason="A recent action did not complete successfully.",
+                priority=2,
+            ))
+
+    # Rule 3: weak search evidence → refine or compare sources
+    if len(suggestions) < max_suggestions:
+        search_evidence = _search_evidence_from_state(_state)
+        evidence_status = str(search_evidence.get("evidence_status") or "").strip()
+        confidence = str(search_evidence.get("confidence") or "").strip()
+        if evidence_status in {"weak_or_no_evidence", "snippet_backed"} or confidence == "low":
+            suggestions.append(NextActionSuggestion(
+                action="Refine search evidence: narrow the query or compare more sources.",
+                reason="Recent search evidence was weak, partial, or snippet-backed.",
+                priority=3,
+            ))
+
+    # Rule 4: no session goal → suggest setting focus
+    if len(suggestions) < max_suggestions:
+        conv_ctx = _as_dict(_state.get("conversation_context"))
+        user_goal = str(conv_ctx.get("user_goal") or conv_ctx.get("topic") or "").strip()
+        session_goal = str(_state.get("task_goal") or _state.get("active_topic") or "").strip()
+        if not user_goal and not session_goal:
+            suggestions.append(NextActionSuggestion(
+                action="Set today's focus: tell Nova your main goal for this session.",
+                reason="No session goal or topic is active.",
+                priority=4,
+            ))
+
+    # Rule 5: no memory → suggest saving a preference
+    if len(suggestions) < max_suggestions and not _memory:
+        suggestions.append(NextActionSuggestion(
+            action="Save a useful preference: tell Nova something about how you like to work.",
+            reason="No saved memory context was found to personalize the brief.",
+            priority=5,
+        ))
+
+    return suggestions[:max_suggestions]
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _search_evidence_from_state(session_state: dict[str, Any]) -> dict[str, Any]:
+    for key in ("search_evidence", "last_search_evidence"):
+        evidence = session_state.get(key)
+        if isinstance(evidence, dict):
+            return evidence
+
+    widget = _as_dict(session_state.get("search_widget"))
+    data = _as_dict(widget.get("data"))
+    evidence = data.get("evidence")
+    return evidence if isinstance(evidence, dict) else {}

--- a/nova_backend/tests/brief/test_daily_brief.py
+++ b/nova_backend/tests/brief/test_daily_brief.py
@@ -18,6 +18,7 @@ from src.brief.daily_brief import (
     compose_daily_brief,
     is_daily_brief_request,
 )
+from src.brief.recommendations import NextActionSuggestion, select_next_actions
 
 
 # ---------------------------------------------------------------------------
@@ -251,10 +252,15 @@ class TestComposeDailyBrief:
         assert section.items
         assert "resolve arch question" in section.items[0]
 
-    def test_recommended_next_step_empty_when_no_data(self):
+    def test_recommended_next_step_provides_guidance_when_no_data(self):
+        # With no memory, goal, or loops, the recommendation selector fills in
+        # actionable guidance (set focus, save preference) so the brief is never
+        # silently empty.
         brief = compose_daily_brief()
         section = next(s for s in brief.sections if s.title == "Recommended Next Step")
-        assert section.is_empty
+        assert not section.is_empty
+        text = " ".join(section.items).lower()
+        assert "focus" in text or "preference" in text
 
     def test_sources_consulted_populated(self):
         brief = compose_daily_brief(
@@ -279,9 +285,12 @@ class TestComposeDailyBrief:
         brief = compose_daily_brief(memory_items=memory, recent_receipts=receipts)
         assert brief.confidence == BriefConfidence.HIGH
 
-    def test_confidence_low_with_no_data(self):
+    def test_confidence_low_with_no_meaningful_data(self):
+        # The recommendation selector fills in guidance even with no data, so
+        # the overall brief reaches MEDIUM. True LOW only occurs when every
+        # section is empty, which can't happen with the fallback guidance.
         brief = compose_daily_brief()
-        assert brief.confidence == BriefConfidence.LOW
+        assert brief.confidence in {BriefConfidence.LOW, BriefConfidence.MEDIUM}
 
     def test_malformed_memory_items_skipped(self):
         memory = [
@@ -565,3 +574,310 @@ class TestIsDailyBriefRequest:
 
     def test_none_safe(self):
         assert is_daily_brief_request(None) is False  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Hardening: edge cases and degradation
+# ---------------------------------------------------------------------------
+
+
+class TestDailyBriefEdgeCases:
+    """Brief degrades cleanly on empty, malformed, or unavailable data."""
+
+    def test_completely_empty_state_returns_valid_brief(self):
+        brief = compose_daily_brief(
+            session_state={},
+            memory_items=[],
+            recent_receipts=[],
+            working_context={},
+            weather_data=None,
+            calendar_data=None,
+            important_emails=None,
+        )
+        assert isinstance(brief, DailyBrief)
+        assert brief.execution_performed is False
+        assert brief.authorization_granted is False
+
+    def test_malformed_memory_none_entries_skipped(self):
+        memory = [None, None, {"category": "action", "content": "valid"}]
+        brief = compose_daily_brief(memory_items=memory)  # type: ignore[arg-type]
+        section = next(s for s in brief.sections if s.title == "Top Next Actions")
+        assert "valid" in section.items
+
+    def test_malformed_receipt_none_entries_skipped(self):
+        receipts = [None, None, {"event_type": "ACTION_COMPLETED", "capability_name": "cap_x"}]
+        brief = compose_daily_brief(recent_receipts=receipts)  # type: ignore[arg-type]
+        section = next(s for s in brief.sections if s.title == "Recent Actions")
+        assert any("action completed" in item for item in section.items)
+
+    def test_malformed_receipt_non_dict_entries_skipped(self):
+        receipts = ["not a dict", 42, {"event_type": "MEMORY_ITEM_SAVED"}]
+        brief = compose_daily_brief(recent_receipts=receipts)  # type: ignore[arg-type]
+        section = next(s for s in brief.sections if s.title == "Recent Actions")
+        assert any("memory saved" in item for item in section.items)
+
+    def test_malformed_session_state_degrades_gracefully(self):
+        brief = compose_daily_brief(session_state="not a dict")  # type: ignore[arg-type]
+        section = next(s for s in brief.sections if s.title == "Session State")
+        assert section.is_empty
+
+    def test_malformed_conversation_context_degrades_gracefully(self):
+        brief = compose_daily_brief(
+            session_state={"conversation_context": "not a dict"}  # type: ignore[arg-type]
+        )
+        section = next(s for s in brief.sections if s.title == "Session State")
+        assert section.is_empty
+
+    def test_malformed_external_payloads_degrade_gracefully(self):
+        brief = compose_daily_brief(
+            weather_data=["bad"],  # type: ignore[arg-type]
+            calendar_data=["bad"],  # type: ignore[arg-type]
+            important_emails=42,  # type: ignore[arg-type]
+        )
+        assert any(s.title == "Weather" for s in brief.sections)
+        assert any(s.title == "Calendar" for s in brief.sections)
+        assert any(s.title == "Important Emails" for s in brief.sections)
+
+    def test_no_receipts_shows_not_found_message(self):
+        brief = compose_daily_brief(recent_receipts=[])
+        section = next(s for s in brief.sections if s.title == "Recent Actions")
+        assert not section.is_empty
+        assert any("No recent receipts" in item for item in section.items)
+        assert section.confidence == BriefConfidence.LOW
+
+    def test_weather_error_status_degrades_gracefully(self):
+        brief = compose_daily_brief(weather_data={"connected": False, "status": "error"})
+        section = next(s for s in brief.sections if s.title == "Weather")
+        assert section.confidence == BriefConfidence.LOW
+        assert any("unavailable" in item.lower() for item in section.items)
+
+    def test_calendar_error_status_degrades_gracefully(self):
+        brief = compose_daily_brief(calendar_data={"connected": False, "status": "error"})
+        section = next(s for s in brief.sections if s.title == "Calendar")
+        assert section.confidence == BriefConfidence.LOW
+        assert any("unavailable" in item.lower() for item in section.items)
+
+    def test_calendar_not_configured_shows_setup_hint(self):
+        brief = compose_daily_brief(
+            calendar_data={
+                "connected": False,
+                "status": "not_connected",
+                "setup_hint": "I don't have calendar configured yet.",
+            }
+        )
+        section = next(s for s in brief.sections if s.title == "Calendar")
+        assert any("configured" in item for item in section.items)
+
+    def test_email_placeholder_message_present(self):
+        brief = compose_daily_brief(important_emails=None)
+        section = next(s for s in brief.sections if s.title == "Important Emails")
+        text = " ".join(section.items).lower()
+        assert "not configured" in text or "connector" in text
+
+    def test_duplicate_open_loops_from_memory_deduped(self):
+        memory = [
+            {"category": "open_loop", "content": "same question"},
+            {"category": "open_loop", "content": "same question"},
+            {"category": "open_loop", "content": "different question"},
+        ]
+        brief = compose_daily_brief(memory_items=memory)
+        section = next(s for s in brief.sections if s.title == "Open Loops")
+        assert section.items.count("same question") == 1
+        assert "different question" in section.items
+
+    def test_very_long_text_clipped_in_memory_section(self):
+        long_text = "x" * 500
+        memory = [{"category": "action", "content": long_text}]
+        brief = compose_daily_brief(memory_items=memory)
+        section = next(s for s in brief.sections if s.title == "Top Next Actions")
+        assert section.items
+        assert len(section.items[0]) <= 200
+
+    def test_very_long_receipt_detail_clipped(self):
+        receipts = [{"event_type": "ACTION_COMPLETED", "capability_name": "c" * 200}]
+        brief = compose_daily_brief(recent_receipts=receipts)
+        section = next(s for s in brief.sections if s.title == "Recent Actions")
+        for item in section.items:
+            assert len(item) < 300
+
+    def test_stale_recommendation_not_duplicated_in_step(self):
+        # Same recommendation from memory and from session context open loop
+        # should only appear once.
+        memory = [{"category": "action", "content": "refactor the executor"}]
+        session = {"conversation_context": {"open_loops": ["refactor the executor"]}}
+        brief = compose_daily_brief(memory_items=memory, session_state=session)
+        section = next(s for s in brief.sections if s.title == "Recommended Next Step")
+        flat = " ".join(section.items)
+        assert flat.lower().count("refactor the executor") == 1
+
+
+# ---------------------------------------------------------------------------
+# Session State section
+# ---------------------------------------------------------------------------
+
+
+class TestSessionStateSection:
+    def test_empty_session_state_section_is_empty(self):
+        brief = compose_daily_brief(session_state={})
+        section = next(s for s in brief.sections if s.title == "Session State")
+        assert section.is_empty
+
+    def test_topic_appears_in_section(self):
+        brief = compose_daily_brief(
+            session_state={"conversation_context": {"topic": "search synthesis"}}
+        )
+        section = next(s for s in brief.sections if s.title == "Session State")
+        assert any("search synthesis" in item for item in section.items)
+
+    def test_user_goal_appears_when_different_from_topic(self):
+        brief = compose_daily_brief(
+            session_state={"conversation_context": {
+                "topic": "Nova",
+                "user_goal": "build the daily brief module",
+            }}
+        )
+        section = next(s for s in brief.sections if s.title == "Session State")
+        assert any("build the daily brief module" in item for item in section.items)
+
+    def test_mode_appears_in_section(self):
+        brief = compose_daily_brief(
+            session_state={"conversation_context": {"mode": "analysis"}}
+        )
+        section = next(s for s in brief.sections if s.title == "Session State")
+        assert any("analysis" in item for item in section.items)
+
+    def test_open_loops_from_conversation_context_appear(self):
+        brief = compose_daily_brief(
+            session_state={"conversation_context": {
+                "open_loops": ["Which framework to use?", "How long will migration take?"]
+            }}
+        )
+        section = next(s for s in brief.sections if s.title == "Session State")
+        assert any("Which framework" in item for item in section.items)
+        assert any("How long" in item for item in section.items)
+
+    def test_recent_recommendations_appear(self):
+        brief = compose_daily_brief(
+            session_state={"conversation_context": {
+                "recent_recommendations": ["Use FastAPI", "Add integration tests"]
+            }}
+        )
+        section = next(s for s in brief.sections if s.title == "Session State")
+        assert any("FastAPI" in item for item in section.items)
+
+    def test_section_capped_at_max_items(self):
+        brief = compose_daily_brief(
+            session_state={"conversation_context": {
+                "topic": "big project",
+                "user_goal": "ship it",
+                "mode": "work",
+                "open_loops": ["Q1?", "Q2?", "Q3?", "Q4?"],
+                "recent_recommendations": ["R1", "R2", "R3"],
+            }}
+        )
+        section = next(s for s in brief.sections if s.title == "Session State")
+        assert len(section.items) <= 5
+
+    def test_malformed_open_loops_in_context_skipped(self):
+        brief = compose_daily_brief(
+            session_state={"conversation_context": {
+                "open_loops": [None, "", "   ", "real question?"]
+            }}
+        )
+        section = next(s for s in brief.sections if s.title == "Session State")
+        assert any("real question?" in item for item in section.items)
+        assert all(item.strip() for item in section.items)
+
+    def test_section_source_label(self):
+        brief = compose_daily_brief(
+            session_state={"conversation_context": {"topic": "something"}}
+        )
+        section = next(s for s in brief.sections if s.title == "Session State")
+        assert section.source_label == "session_context"
+
+
+# ---------------------------------------------------------------------------
+# Recommendation selector
+# ---------------------------------------------------------------------------
+
+
+class TestSelectNextActions:
+    def test_open_loop_rule_fires_first(self):
+        suggestions = select_next_actions(open_loops=["Which framework?"])
+        assert suggestions
+        assert suggestions[0].priority == 1
+        assert "Which framework?" in suggestions[0].action
+
+    def test_failed_receipt_rule(self):
+        receipts = [{"event_type": "EMAIL_DRAFT_FAILED", "capability_name": "cap_64"}]
+        suggestions = select_next_actions(recent_receipts=receipts)
+        assert any(s.priority == 2 for s in suggestions)
+        assert any("cap_64" in s.action for s in suggestions)
+
+    def test_weak_search_evidence_rule(self):
+        suggestions = select_next_actions(
+            session_state={"last_search_evidence": {"evidence_status": "weak_or_no_evidence"}}
+        )
+        assert any(s.priority == 3 for s in suggestions)
+        assert any("search evidence" in s.action.lower() for s in suggestions)
+
+    def test_no_goal_rule(self):
+        suggestions = select_next_actions(session_state={})
+        assert any(s.priority == 4 for s in suggestions)
+        assert any("focus" in s.action.lower() for s in suggestions)
+
+    def test_no_memory_rule(self):
+        # Give a goal so rule 3 doesn't fire, then check rule 4
+        suggestions = select_next_actions(
+            session_state={"active_topic": "my project"},
+            memory_items=[],
+        )
+        assert any(s.priority == 5 for s in suggestions)
+        assert any("preference" in s.action.lower() for s in suggestions)
+
+    def test_max_suggestions_respected(self):
+        suggestions = select_next_actions(
+            open_loops=["Q1?", "Q2?"],
+            recent_receipts=[{"event_type": "ACTION_FAILED"}],
+            session_state={},
+            memory_items=[],
+            max_suggestions=2,
+        )
+        assert len(suggestions) <= 2
+
+    def test_empty_inputs_returns_list(self):
+        suggestions = select_next_actions()
+        assert isinstance(suggestions, list)
+
+    def test_none_open_loops_handled(self):
+        suggestions = select_next_actions(open_loops=None)
+        assert isinstance(suggestions, list)
+
+    def test_none_memory_handled(self):
+        suggestions = select_next_actions(memory_items=None)
+        assert isinstance(suggestions, list)
+
+    def test_non_dict_receipts_filtered(self):
+        receipts = ["not a dict", {"event_type": "ACTION_FAILED"}]
+        suggestions = select_next_actions(recent_receipts=receipts)  # type: ignore[arg-type]
+        assert isinstance(suggestions, list)
+
+    def test_to_dict_on_suggestion(self):
+        s = NextActionSuggestion(action="Do X", reason="Because Y", priority=1)
+        d = s.to_dict()
+        assert d["action"] == "Do X"
+        assert d["reason"] == "Because Y"
+        assert d["priority"] == 1
+
+    def test_with_goal_no_goal_rule_fires(self):
+        suggestions = select_next_actions(
+            session_state={"active_topic": "deploy the app"},
+        )
+        assert not any(s.priority == 3 for s in suggestions)
+
+    def test_with_memory_no_memory_rule_fires(self):
+        suggestions = select_next_actions(
+            session_state={"active_topic": "x"},
+            memory_items=[{"category": "note", "content": "something"}],
+        )
+        assert not any(s.priority == 4 for s in suggestions)


### PR DESCRIPTION
## Summary
Hardens the Daily Brief MVP by making it continuity-aware, more defensive against malformed inputs, and more useful through deterministic next-action recommendations.

## Changes
- Add Session State section to Daily Brief using conversation continuity fields.
- Add deterministic next-action selector in `nova_backend/src/brief/recommendations.py`.
- Harden malformed/empty inputs for session state, conversation context, memory, receipts, weather, calendar, and email placeholder paths.
- Add weak-search-evidence next-step guidance.
- Add daily operating baseline proof docs.
- Update human-maintained status/TODO/product docs while preserving generated runtime truth discipline.

## Boundaries
- No new capabilities.
- No Governor changes.
- No Google/Gmail connector.
- No OpenClaw expansion.
- No persistence path.
- No background automation.
- No generated runtime docs changed by hand.

## Validation
- `python -m pytest nova_backend\tests\brief -q` → 114 passed
- `python -m pytest nova_backend\tests\conversation -q` → 412 passed
- `python -m pytest -q` → 1877 passed, 4 skipped
- `python scripts\check_runtime_doc_drift.py` → passed
- `git diff --check` → clean, with CRLF warnings only for untouched generated runtime docs