### PR TITLE
docs: finalize Nova agent stack architecture

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -24,11 +24,20 @@ Generated runtime truth files are the authority for exact live status.
 Nova is a governed local AI runtime focused on separating reasoning from execution.
 Use the product docs above first, then use runtime truth docs for exact capability state.
 
-## Brain and Runtime Planning
+## Brain, Memory, Learning, and Agent Stack Planning
 - [Nova Brain Overview](brain.md)
 - [Brain Architecture Package](brain/README.md)
 - [Brain Runtime Architecture](brain/NOVA_BRAIN_RUNTIME_ARCHITECTURE.md)
 - [Brain Implementation Roadmap](brain/IMPLEMENTATION_ROADMAP.md)
+- [Nova Brain Human Guide](future/BRAIN_HUMAN_GUIDE.md)
+- [Brain + Memory Human Guide](future/BRAIN_MEMORY_HUMAN_GUIDE.md)
+- [Nova Agent Stack Recommendations](future/NOVA_AGENT_STACK_RECOMMENDATIONS.md)
+- [Context Pack Specification](future/CONTEXT_PACK_SPEC.md)
+- [Learning Layer Specification](future/LEARNING_LAYER_SPEC.md)
+- [Routine Layer Specification](future/ROUTINE_LAYER_SPEC.md)
+- [Daily Brief Routine Specification](future/DAILY_BRIEF_ROUTINE_SPEC.md)
+- [Guard System Specification](future/GUARD_SYSTEM_SPEC.md)
+- [Trace and Observability Specification](future/TRACE_AND_OBSERVABILITY_SPEC.md)
 - [OpenClaw Environment Model](brain/OPENCLAW_ENVIRONMENT_MODEL.md)
 - [OpenClaw Robust Hardening Audit - 2026-05-01](future/OPENCLAW_ROBUST_HARDENING_AUDIT_2026-05-01.md)
 

--- a/docs/future/CONTEXT_PACK_SPEC.md
+++ b/docs/future/CONTEXT_PACK_SPEC.md
@@ -1,0 +1,160 @@
+# Context Pack Specification
+
+Status: planning.
+
+This document defines the planned Context Pack layer for Nova. It is not implemented runtime behavior.
+
+## Purpose
+
+Context Pack is the bounded bridge between Memory/Learning/Search/Project state and the Brain.
+
+The Brain should not scan all memory, all docs, all learning items, or all search results directly.
+
+## Core rule
+
+```text
+No Context Pack means no durable memory or learning influence on Brain.
+```
+
+## Responsibilities
+
+Context Pack should:
+
+- select relevant context
+- label every source
+- preserve authority levels
+- enforce budgets
+- surface stale/conflict warnings
+- explain why context was selected
+- prevent memory/learning overload
+
+## Non-responsibilities
+
+Context Pack must not:
+
+- authorize action
+- execute tools
+- promote memory
+- confirm learning
+- override runtime truth
+- silently hide conflicts
+
+## Inputs
+
+Future inputs may include:
+
+- current user message
+- session continuity
+- active project
+- confirmed memories
+- candidate memory prompts
+- confirmed learning items
+- learning health warnings
+- project capsule
+- search evidence summary
+- runtime truth summary
+- receipts
+- calendar/weather summaries
+
+## Output shape
+
+```json
+{
+  "project": "novalis",
+  "mode": "repo-review",
+  "sources": [],
+  "project_capsule": {},
+  "confirmed_memories": [],
+  "confirmed_learning": [],
+  "open_loops": [],
+  "search_evidence": {},
+  "runtime_truth": {},
+  "warnings": [],
+  "budget": {},
+  "why_selected": []
+}
+```
+
+## Source labels
+
+Use stable source labels:
+
+- `runtime_truth`
+- `current_conversation`
+- `session_continuity`
+- `confirmed_memory`
+- `candidate_memory`
+- `confirmed_learning`
+- `candidate_learning`
+- `project_capsule`
+- `search_evidence`
+- `receipt`
+- `calendar_summary`
+- `weather_summary`
+- `assumption`
+
+## Authority labels
+
+Use stable authority labels:
+
+- `runtime_truth`
+- `current_instruction`
+- `confirmed_project_memory`
+- `confirmed_personal_memory`
+- `confirmed_learning`
+- `candidate_memory`
+- `candidate_learning`
+- `scratchpad`
+- `assumption`
+
+## Budget defaults
+
+Suggested first budget:
+
+- max 1 project capsule
+- max 5 confirmed memories
+- max 3 confirmed learning items
+- max 3 open loops
+- max 2 candidate prompts
+- max 2 stale/conflict warnings
+- max 1 search evidence summary
+
+## Warning types
+
+- `stale_memory`
+- `stale_learning`
+- `conflicting_sources`
+- `runtime_truth_unknown`
+- `weak_search_evidence`
+- `unclear_scope`
+- `budget_exceeded`
+
+## Brain use rule
+
+Brain may use Context Pack to:
+
+- improve recommendations
+- understand project state
+- identify open loops
+- explain why memory was used
+- detect uncertainty
+- prepare candidate memory/learning proposals
+
+Brain may not use Context Pack to:
+
+- authorize action
+- bypass Governor
+- treat candidate memory as fact
+- treat planning docs as runtime truth
+
+## Proof requirements
+
+Before claiming Context Pack is implemented, prove:
+
+- budgets are enforced
+- source labels are present
+- stale/conflict warnings are surfaced
+- candidate items are not treated as confirmed
+- runtime truth outranks memory
+- forgotten memory is not selected
+- Brain can explain why context was selected

--- a/docs/future/DAILY_BRIEF_ROUTINE_SPEC.md
+++ b/docs/future/DAILY_BRIEF_ROUTINE_SPEC.md
@@ -1,0 +1,67 @@
+# Daily Brief Routine Specification
+
+Status: planning.
+
+## Definition
+
+Daily Brief is a routine and user-facing surface.
+
+It is not the Brain.
+It is not an executor.
+It is not an authority system.
+
+## Purpose
+
+Package the current operating state of Nova into a clear, actionable summary for the user.
+
+## Inputs
+
+Daily Brief may consume:
+
+- session continuity
+- project capsule
+- memory health
+- learning health
+- receipts
+- open loops
+- search summaries
+- calendar/weather summaries
+- optional Brain synthesis
+
+## RoutineGraph
+
+```text
+Trigger
+→ Gather Session State
+→ Gather Project Capsule
+→ Gather Memory Health
+→ Gather Learning Health
+→ Gather Receipts
+→ Gather Search/Calendar/Weather
+→ Build Context Pack
+→ Optional Brain Summary
+→ Render Brief
+→ Write Receipt
+```
+
+## Outputs
+
+- current focus
+- project summary
+- open loops
+- recommended next step
+- memory candidates to review
+- learning candidates to review
+- warnings (stale/conflict)
+
+## Rules
+
+- no execution
+- no authority
+- no automatic memory promotion
+- no learning promotion
+- no external action
+
+## Future
+
+May become a scheduled routine only after Routine Layer and OpenClaw governance are hardened.

--- a/docs/future/GUARD_SYSTEM_SPEC.md
+++ b/docs/future/GUARD_SYSTEM_SPEC.md
@@ -1,0 +1,156 @@
+# Guard System Specification
+
+Status: planning.
+
+This document defines planned guard layers for Nova. It is not implemented runtime behavior.
+
+## Purpose
+
+Guards prevent reasoning, routines, memory, learning, and execution surfaces from crossing authority boundaries.
+
+## Guard layers
+
+- BrainGuard
+- ModeGuard
+- ContextPackGuard
+- RoutineGuard
+- MemoryGuard
+- LearningGuard
+- OpenClawGuard
+
+## BrainGuard
+
+Protects Brain reasoning.
+
+Blocks:
+
+- Brain execution
+- Brain authorization
+- silent memory writes
+- memory as permission
+- planning docs as runtime truth
+- direct OpenClaw handoff
+
+## ModeGuard
+
+Enforces behavior by mode.
+
+### Brainstorm mode
+
+- no file writes
+- no issues
+- no commits
+- no PRs
+- explore ideas only unless explicitly asked
+
+### Repo-review mode
+
+- inspect state before recommending
+- summarize truth/gaps/next step
+- no code changes unless asked
+
+### Implementation mode
+
+- create branch before edits
+- focused diff
+- validation
+- summary
+
+### Merge mode
+
+- review diff/PR
+- avoid stale branches
+- merge only requested branch
+- update docs/status if needed
+
+### Action-review mode
+
+- show planned action
+- show boundary
+- require user/Governor approval where needed
+
+## ContextPackGuard
+
+Enforces:
+
+- source labels
+- authority labels
+- budget limits
+- stale/conflict warnings
+- no forgotten memory
+- no candidate-as-truth behavior
+
+## RoutineGuard
+
+Controls routine behavior.
+
+Fields:
+
+- allowed sources
+- allowed blocks
+- max runtime
+- max outputs
+- approval points
+- receipt requirements
+
+RoutineGuard blocks:
+
+- hidden execution
+- unsurfaced schedule changes
+- external actions without approval
+- memory/learning promotion
+
+## MemoryGuard
+
+Controls durable memory lifecycle.
+
+Blocks:
+
+- autosave as confirmed memory
+- memory without scope
+- memory without source
+- forgotten memory reuse
+- memory as authority
+
+## LearningGuard
+
+Controls adaptation.
+
+Blocks:
+
+- hidden learning
+- sensitive inference
+- learning from client data by default
+- learning as permission
+- learning that conflicts with current user instruction
+
+## OpenClawGuard
+
+Controls future OpenClaw execution.
+
+Requires:
+
+- mandatory envelope
+- allowed paths/domains/tools
+- max steps/time
+- boundary detection
+- approval checkpoints
+- stop/pause/recovery
+- run/step/action receipts
+
+Blocks:
+
+- freeform unbounded goals
+- login/payment/publish/upload/delete without explicit boundary review
+- browser/computer-use expansion before hardening
+
+## Success criteria
+
+Guard system is successful when:
+
+- Brain cannot execute
+- routines cannot silently act
+- memory cannot authorize
+- learning cannot change permission
+- OpenClaw cannot run outside envelope
+- all boundary crossings are visible and reviewable

--- a/docs/future/LEARNING_LAYER_SPEC.md
+++ b/docs/future/LEARNING_LAYER_SPEC.md
@@ -1,0 +1,221 @@
+# Learning Layer Specification
+
+Status: planning.
+
+This document defines Nova's future Learning Layer as a governed adaptation system. It is not implemented runtime behavior.
+
+## Definition
+
+Learning is a governed adaptation layer that turns reviewed user behavior, corrections, project state, source-of-truth preferences, and outcome feedback into candidate or confirmed adaptation context.
+
+Learning is separate from Brain and Memory.
+
+```text
+Brain = reasoning
+Memory = storage/context
+Learning = adaptation
+Context Pack = bounded bridge
+Governor = authority boundary
+```
+
+## Core doctrine
+
+```text
+Nova may observe.
+Nova may suggest.
+Nova may ask to remember.
+Nova may use confirmed learning through Context Pack.
+Nova may explain why learning was used.
+Nova may not silently promote learning into durable truth.
+Nova may not use learning as authority.
+```
+
+## Categories
+
+Use stable category labels:
+
+- `work_style`
+- `project_state`
+- `routine`
+- `correction`
+- `recommendation_pattern`
+- `source_of_truth_rule`
+- `staleness`
+- `contradiction`
+- `outcome_feedback`
+- `mode_behavior`
+
+## Authority labels
+
+- `observed_signal`
+- `scratchpad_note`
+- `candidate_learning`
+- `confirmed_learning`
+- `project_doctrine_or_routine`
+- `runtime_truth`
+
+## Lifecycle
+
+```text
+interaction
+→ observed signal
+→ scratchpad observation
+→ grouped pattern
+→ candidate learning
+→ user review
+→ confirmed learning
+→ Context Pack selection
+→ Brain recommendation/behavior
+→ outcome feedback
+→ health review / refresh / retire
+```
+
+## Learning item schema
+
+```json
+{
+  "id": "learn_workstyle_001",
+  "category": "work_style",
+  "scope": "personal",
+  "content": "User prefers second-pass audits before merges.",
+  "authority_level": "candidate_learning",
+  "source": "observed_interaction",
+  "evidence": [],
+  "evidence_count": 3,
+  "confidence": "medium",
+  "status": "candidate",
+  "created_at": null,
+  "updated_at": null,
+  "last_used_at": null,
+  "last_confirmed_at": null,
+  "use_count": 0,
+  "review_after": null,
+  "expires_at": null,
+  "rejected_count": 0,
+  "supersedes": [],
+  "superseded_by": null
+}
+```
+
+## Scopes
+
+Default scope should not be global.
+
+Suggested scopes:
+
+- `global`
+- `personal`
+- `personal:work_style`
+- `personal:routines`
+- `project:novalis`
+- `project:auralis`
+- `project:poursocial`
+- `project:youtubelis`
+- `mode:brainstorm`
+- `mode:implementation`
+- `mode:merge`
+
+## Sensitivity classes
+
+- `normal`
+- `private`
+- `project_internal`
+- `business_sensitive`
+- `client_sensitive`
+- `forbidden`
+
+Forbidden by default:
+
+- secrets
+- passwords
+- API keys
+- regulated data
+- client-sensitive data
+- sensitive personal data
+
+## Automatic vs approval-based
+
+Nova may automatically create low-authority items inside an approved memory sandbox:
+
+- scratchpad observations
+- candidate learning
+- pattern counts
+- stale warnings
+- contradiction warnings
+- outcome feedback notes
+
+Nova must ask before creating or changing:
+
+- confirmed personal learning
+- confirmed routine
+- project doctrine
+- long-term project memory
+- priority-changing learning
+
+Nova must never automatically create:
+
+- execution permission
+- external action approval
+- secrets/credential memory
+- sensitive/client learning by default
+
+## Receipts
+
+Suggested events:
+
+- `LEARNING_SIGNAL_OBSERVED`
+- `LEARNING_CANDIDATE_CREATED`
+- `LEARNING_CONFIRMED`
+- `LEARNING_USED`
+- `LEARNING_REJECTED`
+- `LEARNING_STALE`
+- `LEARNING_CONFLICT_DETECTED`
+- `LEARNING_RETIRED`
+
+## Context Pack rule
+
+Learning may reach Brain only through Context Pack.
+
+Suggested budget:
+
+- max 3 confirmed learning items
+- max 2 candidate learning prompts
+- max 2 stale/conflict warnings
+
+## Stop conditions
+
+Learning must stop or require review when:
+
+- confidence is low
+- scope is unclear
+- data may be sensitive
+- learning conflicts with repo/runtime truth
+- learning conflicts with current user instruction
+- user rejects or says not to remember
+- learning would affect an external action
+- learning would change permissions or authority
+
+## Build boundary
+
+Do not implement advanced learning before explicit memory lifecycle exists.
+
+Earliest safe learning slice after memory loop:
+
+- create candidate learning manually/deterministically
+- list candidates
+- approve candidate
+- reject candidate
+- emit learning receipt
+- include one confirmed learning item in Context Pack explanation
+
+## Success criteria
+
+Learning is successful when:
+
+- repeated corrections decrease
+- next-step recommendations improve
+- candidate learning is visible
+- stale/conflicting learning is surfaced
+- why-used explanations exist
+- user can reject, confirm, update, or retire learning
+- learning never grants authority

--- a/docs/future/NOVA_AGENT_STACK_RECOMMENDATIONS.md
+++ b/docs/future/NOVA_AGENT_STACK_RECOMMENDATIONS.md
@@ -1,0 +1,505 @@
+# Nova Agent Stack Recommendations
+
+Status: planning / architecture recommendation.
+
+This document summarizes lessons from reviewing public agent and multi-agent orchestration stacks and translates them into Nova-compatible recommendations.
+
+It is not runtime truth and does not describe implemented Nova behavior unless code, tests, generated runtime docs, and proof artifacts agree.
+
+---
+
+## Reviewed Stacks
+
+Reviewed patterns from:
+
+- MateClaw
+- Microsoft AutoGen
+- Microsoft Agent Framework
+- CrewAI
+- LangGraph
+- OpenAI Swarm
+- OpenAI Agents SDK
+- AutoGPT
+
+The goal is not to copy any one stack. The goal is to extract patterns compatible with Nova's core doctrine:
+
+```text
+Intelligence is not authority.
+Reasoning may propose.
+Execution must remain governed, visible, bounded, and reviewable.
+```
+
+---
+
+## Core Conclusion
+
+The best external stacks do not imply Nova should build one giant autonomous Brain.
+
+They imply Nova should become a governed operating stack:
+
+```text
+Routine Layer
++ Context Pack
++ Brain
++ Specialist Analyzers
++ Memory
++ Learning
++ Governor
++ Receipts
++ Optional OpenClaw execution later
+```
+
+Nova's advantage should be multi-agent-style reasoning inside a governed, visible, reviewable system.
+
+---
+
+## Correct Nova Layer Model
+
+```text
+User / Trigger
+  ↓
+Routine Layer
+  ↓
+Routine Blocks
+  ↓
+Context Gatherers
+  ↓
+Context Pack
+  ↓
+Brain Orchestrator
+  ↓
+Specialist Analyzers if needed
+  ↓
+Output / Plan / Recommendation
+  ↓
+Action Review if needed
+  ↓
+Governor
+  ↓
+Executor / OpenClaw only if authorized
+  ↓
+Receipts
+```
+
+### Layer roles
+
+| Layer | Role | Must not do |
+|---|---|---|
+| Routine Layer | Defines when and how workflows run | Reason as Brain or execute as OpenClaw |
+| Daily Brief | Packages operating state for the user | Become Brain or authority |
+| Context Pack | Filters relevant context for Brain | Load everything or hide source authority |
+| Brain | Interprets, plans, prioritizes, recommends | Execute or authorize |
+| Specialist Analyzers | Return focused analysis | Use tools directly or execute |
+| Memory | Stores confirmed context | Become authority |
+| Learning | Adapts via reviewed patterns | Learn silently or change permission |
+| Governor | Controls real action | Reason as Brain |
+| OpenClaw | Future governed executor | Become Brain, scheduler, or authority |
+| Receipts | Make actions/reasoning visible | Hide material events |
+
+---
+
+## Recommendation 1: Routine Layer
+
+Daily Brief and future recurring workflows should live in a Routine Layer, not in the Brain.
+
+### Routine Layer definition
+
+```text
+Routine Layer = the layer that runs manual or scheduled workflows using bounded blocks, state, approvals, and receipts.
+```
+
+### Routine types
+
+- manual routine
+- on-demand routine
+- scheduled suggestion routine
+- future governed OpenClaw routine
+
+### First routine candidates
+
+1. Daily Brief routine
+2. Memory Review routine
+3. Learning Health routine
+4. Repo Review routine
+5. Roadmap/Status Review routine
+6. Proof Capture routine
+
+### Rule
+
+Routines may call Brain for synthesis. Routines do not become Brain.
+
+---
+
+## Recommendation 2: Routine Graph / Blocks
+
+Borrow the useful part of workflow-block systems: explicit steps and state.
+
+### Suggested objects
+
+```text
+RoutineGraph
+RoutineBlock
+RoutineRun
+RoutineState
+RoutineApprovalPoint
+RoutineReceipt
+RoutineFailure
+RoutineRecovery
+```
+
+### Example: Daily Brief RoutineGraph
+
+```text
+Trigger
+→ Gather Session State
+→ Gather Project Capsule
+→ Gather Memory Health
+→ Gather Learning Health
+→ Gather Receipts
+→ Gather Calendar / Weather / Search summaries
+→ Build Context Pack
+→ Optional Brain Summary
+→ Render Brief
+→ Write Receipt
+```
+
+### Rule
+
+Every routine should be inspectable and replayable enough for proof docs.
+
+---
+
+## Recommendation 3: Context Pack as the hard bridge
+
+The Brain should not read all memory, all docs, all learning, or all search data directly.
+
+### Context Pack should include
+
+- source labels
+- authority labels
+- memory budget
+- learning budget
+- stale/conflict warnings
+- why-selected metadata
+- project capsule summary
+- search evidence summary
+- open loops
+- active constraints
+
+### Example budget
+
+```text
+max 1 project capsule
+max 5 confirmed memories
+max 3 confirmed learning items
+max 3 open loops
+max 2 candidate prompts
+max 2 stale/conflict warnings
+```
+
+### Rule
+
+No Context Pack means no durable memory/learning influence on Brain.
+
+---
+
+## Recommendation 4: Brain Orchestrator, not giant Brain
+
+The Brain should be structured into submodules/contracts.
+
+### Recommended submodules
+
+1. Intent Interpreter
+2. Mode Classifier
+3. Context Need Detector
+4. Context Pack Consumer
+5. Task Understanding Builder
+6. Plan Builder
+7. Prioritization Engine
+8. Uncertainty Classifier
+9. Boundary Detector
+10. Recommendation Synthesizer
+11. Candidate Memory/Learning Proposer
+12. Safe Trace Builder
+
+### Rule
+
+Brain can propose action. Brain cannot execute or authorize action.
+
+---
+
+## Recommendation 5: Specialist Analyzers
+
+Borrow multi-agent handoff patterns only as analysis modules.
+
+### Good specialist pattern
+
+```text
+Brain asks RepoStatusAnalyzer for findings.
+Analyzer returns structured analysis.
+Brain synthesizes.
+Governor remains action boundary.
+```
+
+### Bad specialist pattern
+
+```text
+RepoAgent commits changes directly.
+BrowserAgent logs into accounts.
+EmailAgent sends messages.
+```
+
+### Candidate analyzers
+
+- RepoStatusAnalyzer
+- RoadmapStatusAnalyzer
+- SearchEvidenceAnalyzer
+- MemoryHealthAnalyzer
+- LearningHealthAnalyzer
+- BoundaryRiskAnalyzer
+- DailyBriefSynthesizer
+- ProofReadinessAnalyzer
+
+### Rule
+
+Specialists are analyzers, not executors.
+
+---
+
+## Recommendation 6: BrainGuard, ModeGuard, RoutineGuard, OpenClawGuard
+
+External stacks commonly use guardrails, tool guards, or workflow controls. Nova should split those into distinct guards.
+
+### BrainGuard
+
+Protects reasoning behavior.
+
+Blocks:
+
+- execution from Brain
+- silent memory writes
+- memory as authority
+- planning docs as runtime truth
+- direct OpenClaw handoff
+
+### ModeGuard
+
+Enforces behavior by mode.
+
+Examples:
+
+- brainstorm mode: no file writes, commits, issue creation, or PRs unless explicitly requested
+- repo-review mode: inspect state before recommending
+- implementation mode: branch, focused diff, validation
+- merge mode: merge only requested branch, avoid stale/reference branch merges
+
+### RoutineGuard
+
+Controls what routines may gather, summarize, propose, and schedule.
+
+Fields:
+
+- allowed data sources
+- allowed blocks
+- max runtime
+- approval points
+- output limits
+- receipt requirements
+
+### OpenClawGuard
+
+Controls future OpenClaw execution.
+
+Requires:
+
+- mandatory envelope
+- allowed paths/domains/tools
+- max steps/time
+- boundary detector
+- approval checkpoints
+- stop/pause/recovery
+- receipts
+
+---
+
+## Recommendation 7: Safe Trace and Observability
+
+Nova needs safe trace surfaces that expose structured rationale without revealing private chain-of-thought.
+
+### Trace types
+
+- BrainTrace
+- RoutineTrace
+- ContextPackTrace
+- BoundaryTrace
+- MemoryTrace
+- LearningTrace
+- OpenClawRunTrace
+
+### BrainTrace fields
+
+- detected_intent
+- selected_mode
+- context_sources_used
+- memories_used
+- learning_items_used
+- uncertainty_flags
+- recommendation_reason
+- action_boundary_detected
+- next_required_user_decision
+
+### RoutineTrace fields
+
+- routine_id
+- trigger
+- blocks_run
+- sources_accessed
+- approvals_required
+- outputs_created
+- failures
+- receipts_written
+
+---
+
+## Recommendation 8: Human-in-the-loop everywhere authority appears
+
+Human review should be a design primitive, not an afterthought.
+
+### Required review points
+
+- confirmed memory promotion
+- confirmed learning promotion
+- external action
+- file write outside narrow approved workspace
+- branch/commit/merge
+- send/publish/upload/payment/login/account actions
+- OpenClaw boundary crossings
+
+### Rule
+
+If a decision changes the outside world, durable memory, or authority posture, it needs review.
+
+---
+
+## Recommendation 9: Sandbox/OpenClaw execution later only
+
+OpenClaw can eventually become Nova's governed execution surface for routines, but only after hardening.
+
+### Required before OpenClaw routines
+
+- EnvelopeFactory mandatory
+- no unbounded freeform goals
+- routine envelope model
+- boundary detector
+- approval UI
+- run/step/action receipts
+- stop/pause/recovery controls
+- path/domain/tool allowlists
+- rollback/checkpoint plan for filesystem work
+
+### Rule
+
+OpenClaw is not Brain, not scheduler, not authority.
+
+---
+
+## Recommendation 10: Benchmarks and proof suite
+
+Nova should borrow the benchmarking/proof mindset from serious agent stacks.
+
+### Needed proof categories
+
+- Brain mode tests
+- Context Pack budget tests
+- memory lifecycle tests
+- learning candidate tests
+- boundary detection tests
+- Daily Brief routine tests
+- RoutineGraph tests
+- OpenClaw envelope tests
+- trace/receipt tests
+
+### Example proof tests
+
+- brainstorm mode does not mutate repo
+- repo-review mode checks status before recommendation
+- memory is not used before confirmation
+- forgotten memory is not reused
+- learning candidates remain candidates
+- action boundary routes to Governor
+- Daily Brief remains non-authorizing routine
+- OpenClaw cannot run without envelope
+
+---
+
+## Recommendation 11: Provider / model health later
+
+Some stacks support model failover and health routing.
+
+Nova should defer this, but eventually support:
+
+- local-first model preference
+- free-first provider policy
+- paid-provider warning
+- model health status
+- fallback model routing
+- cost posture visibility
+
+This should not come before memory/context/routine foundations.
+
+---
+
+## What Nova should not copy
+
+Do not copy:
+
+- continuous autonomous agents as default
+- role agents with direct tool authority
+- automatic memory consolidation into durable truth
+- unreviewed background learning
+- browser/file/account execution before guardrails
+- multi-agent chatter as the control plane
+- OpenClaw as Brain
+- Daily Brief as Brain
+
+---
+
+## Updated roadmap priority
+
+### Now
+
+1. Explicit memory loop
+2. Context Pack
+3. Brain/Routine doc correction
+4. Mode contracts
+
+### Next
+
+5. Safe Brain Trace
+6. Routine Layer skeleton
+7. Daily Brief as RoutineGraph v0
+8. Prioritization Engine
+9. Uncertainty Classifier
+10. Boundary Detector
+
+### Later
+
+11. Specialist analyzers
+12. Learning candidate integration
+13. RoutineGuard / OpenClawGuard
+14. OpenClaw governed routine envelope
+
+### Much later
+
+15. multi-agent specialist graph
+16. sandbox execution
+17. continuous/scheduled routines
+18. provider health/cost router
+
+---
+
+## Final architecture sentence
+
+Nova should not become a multi-agent chatbot.
+
+Nova should become a governed agent operating system where routines gather context, Brain reasons, specialists analyze, Governor controls action, OpenClaw executes only through envelopes, and receipts make the system reviewable.

--- a/docs/future/ROADMAP.md
+++ b/docs/future/ROADMAP.md
@@ -1,45 +1,74 @@
 # Nova Roadmap
 
+Status: planning roadmap. Runtime truth still comes from code and generated runtime docs.
+
+## Core Layer Direction
+
+Nova should evolve as a governed agent operating system, not as one giant autonomous Brain.
+
+Core layers:
+
+- Brain — reasoning, planning, prioritization, recommendations
+- Memory — approved durable context
+- Learning — reviewed adaptation patterns
+- Context Pack — bounded context bridge into Brain
+- Routine Layer — on-demand/scheduled workflow orchestration
+- Governor — authority boundary
+- OpenClaw — future governed execution surface only after hardening
+- Receipts — visibility, proof, and audit trail
+
 ## Near Term
 
-- Re-run Cap 16 conversation/search proof after deterministic Search Evidence Synthesis
-- Continue doc/status cleanup so open PR, merged scaffold, and future planning are not confused
-- Plan free-first cost posture metadata and visibility before any paid-provider expansion
-- Plan Google read-only connector foundations only after connector governance and cost posture boundaries are clear
-- Prepare OpenClaw hardening before browser/computer-use expansion: mandatory EnvelopeFactory, freeform-goal gate, real approval decisions, centralized execution guard, boundary detection, step receipts, and visible active-run controls
-- Define governed workflow workspace shell for everyday workflows, independent automation, and business-owner use cases
-- Define workflow object model, workflow template schema, permission profiles, and first-run workspace onboarding
-- Finish trust receipts UI and visible governance flows
-- Improve first-run success path and onboarding
-- Add proof assets (screenshots, GIFs, demo flows)
-- Capability signoff and reliability pass
-- Daily Brief MVP
-- Dashboard home improvements
+- Implement explicit memory loop: remember / review-list / update / forget / why-used
+- Define and prove memory receipts and no-authority memory behavior
+- Build Context Pack object with source labels, authority labels, budgets, and stale/conflict warnings
+- Correct Brain/Daily Brief docs so Daily Brief is a Routine Layer surface, not a Brain component
+- Define mode contracts: brainstorm, repo-review, implementation, merge, planning, action-review
+- Add safe Brain Trace planning: detected intent, selected mode, sources used, uncertainty, recommendation reason, action boundary
+- Keep Cap 16 conversation/search proof active after deterministic Search Evidence Synthesis
+- Continue doc/status cleanup so planning docs are not confused with runtime truth
+- Plan free-first cost posture metadata and visibility before paid-provider expansion
+- Prepare OpenClaw hardening before browser/computer-use expansion: mandatory EnvelopeFactory, no freeform run, real approval decisions, centralized execution guard, boundary detection, step receipts, and visible active-run controls
 
 ## Mid Term
 
-- Unified personal assistant layer
-- Everyday workflow workspace: Today, Tasks, Projects, People/Contacts, Files/Notes, Messages/Drafts, Content, Research, Automations, Proof/Receipts, Settings/Permissions
-- Workflow template system for everyday, creator, household, research, independent contractor, and small-business workflows
-- Communication assistant flows (email queue, summaries, follow-ups)
-- Multi-input UX (chat, voice, dashboard, quick actions)
-- Governed memory system with review controls
-- Optional style/personality modes
-- Business assistant utilities as one workflow category, not the only product scope
-- First safe OpenClaw browser slice only after hardening: approved read-only isolated browser, specific URLs/domains, summarize, stop, receipt
+- Routine Layer v0: RoutineGraph, RoutineBlock, RoutineRun, RoutineReceipt
+- Daily Brief as RoutineGraph v0
+- Memory Review routine
+- Learning Health routine
+- Repo Review routine
+- Prioritization Engine: dependency, ROI, urgency, risk, proof value, user preference, project phase
+- Uncertainty Classifier: missing context, stale memory, weak evidence, conflicting sources, runtime truth unknown, ambiguous intent, unclear capability boundary
+- Boundary Detector: file write, commit/merge, email, account/login, browser/OpenClaw, publish/upload, payment, network, sensitive/client data
+- Candidate memory and candidate learning proposal flow
+- Governed workflow workspace shell for everyday workflows and independent automation
+- Trust receipts UI and visible governance flows
+- First-run success path and onboarding
+- Proof assets: screenshots, GIFs, demo flows
 
 ## Longer Term
 
-- Modular capability packs (business, household, creator, research)
+- Specialist analyzer graph: repo status, roadmap status, search evidence, memory health, learning health, boundary risk, proof readiness
+- Governed action bridge from Brain output to Governor action request
+- OpenClaw governed routine envelope after hardening
+- Pause/stop/recovery controls for routine and OpenClaw runs
+- Provider/model health and free-first cost routing
+- Modular capability packs: everyday, business, household, creator, research
 - Household node and family coordination surfaces
 - Governed wrappers over external systems
-- Local AI operating layer built on trust and user control
 
 ## Rule
 
 Roadmap items are directional until validated against runtime truth and active priorities.
-Future connector, Auralis, YouTubeLIS, OpenClaw, governed workflow workspace, and cost-governance docs do not describe live runtime behavior unless code, tests, generated runtime truth, and proof artifacts agree.
+Future connector, Auralis, YouTubeLIS, OpenClaw, Routine Layer, governed workflow workspace, and cost-governance docs do not describe live runtime behavior unless code, tests, generated runtime truth, and proof artifacts agree.
 
 OpenClaw browser/computer-use expansion must not begin until the hardening sequence in [`OPENCLAW_ROBUST_HARDENING_AUDIT_2026-05-01.md`](OPENCLAW_ROBUST_HARDENING_AUDIT_2026-05-01.md) is implemented and verified.
 
 The governed workflow workspace direction is tracked in [`../product/GOVERNED_WORKFLOW_WORKSPACE_ARCHITECTURE.md`](../product/GOVERNED_WORKFLOW_WORKSPACE_ARCHITECTURE.md). It broadens the product beyond independent business owners into everyday workflows and independent automation.
+
+The agent stack and Routine Layer direction is tracked in:
+
+- [`NOVA_AGENT_STACK_RECOMMENDATIONS.md`](NOVA_AGENT_STACK_RECOMMENDATIONS.md)
+- [`ROUTINE_LAYER_SPEC.md`](ROUTINE_LAYER_SPEC.md)
+- [`CONTEXT_PACK_SPEC.md`](CONTEXT_PACK_SPEC.md)
+- [`DAILY_BRIEF_ROUTINE_SPEC.md`](DAILY_BRIEF_ROUTINE_SPEC.md)

--- a/docs/future/ROUTINE_LAYER_SPEC.md
+++ b/docs/future/ROUTINE_LAYER_SPEC.md
@@ -1,0 +1,41 @@
+# Routine Layer Specification
+
+Status: planning
+
+## Definition
+
+Routine Layer defines how workflows run.
+
+It is separate from Brain and OpenClaw.
+
+## Responsibilities
+
+- orchestrate steps
+- gather context
+- call Brain for synthesis
+- present outputs
+- create receipts
+
+## Not responsible for
+
+- reasoning (Brain)
+- execution authority (Governor)
+- raw execution (OpenClaw)
+
+## Core objects
+
+- RoutineGraph
+- RoutineBlock
+- RoutineRun
+- RoutineState
+- RoutineReceipt
+
+## First routine
+
+Daily Brief
+
+## Rules
+
+- no silent execution
+- no authority
+- all outputs inspectable

--- a/docs/future/TRACE_AND_OBSERVABILITY_SPEC.md
+++ b/docs/future/TRACE_AND_OBSERVABILITY_SPEC.md
@@ -1,0 +1,112 @@
+# Trace and Observability Specification
+
+Status: planning.
+
+## Purpose
+
+Provide safe, structured visibility into how Nova reasons, selects context, proposes actions, and executes routines.
+
+Trace must not expose private chain-of-thought. It must expose useful, structured signals for trust and debugging.
+
+## Trace layers
+
+- BrainTrace
+- RoutineTrace
+- ContextPackTrace
+- BoundaryTrace
+- MemoryTrace
+- LearningTrace
+- OpenClawRunTrace
+
+## BrainTrace
+
+Fields:
+
+- detected_intent
+- selected_mode
+- context_sources_used
+- memories_used
+- learning_items_used
+- uncertainty_flags
+- recommendation_reason
+- action_boundary_detected
+- next_required_user_decision
+
+## RoutineTrace
+
+Fields:
+
+- routine_id
+- trigger
+- blocks_run
+- sources_accessed
+- approvals_required
+- outputs_created
+- failures
+- receipts_written
+
+## ContextPackTrace
+
+Fields:
+
+- sources_selected
+- budget_usage
+- warnings
+- dropped_items_due_to_budget
+- why_selected
+
+## BoundaryTrace
+
+Fields:
+
+- boundary_type
+- detection_reason
+- action_required
+- approval_state
+
+## MemoryTrace
+
+Fields:
+
+- memory_used
+- why_used
+- scope
+- authority_level
+
+## LearningTrace
+
+Fields:
+
+- learning_used
+- why_used
+- category
+- confidence
+
+## OpenClawRunTrace (future)
+
+Fields:
+
+- envelope
+- steps
+- tools_used
+- approvals
+- stop/pause events
+- receipts
+
+## Rules
+
+- no hidden execution
+- no hidden memory use
+- no hidden learning influence
+- no chain-of-thought exposure
+- must be human-readable
+
+## Success criteria
+
+Trace is successful when:
+
+- user can understand why Nova responded a certain way
+- user can see what context influenced output
+- user can see when a boundary is detected
+- user can review routine execution
+- system is debuggable without exposing private reasoning


### PR DESCRIPTION
## Summary

Finalizes the planning documentation for Nova's governed agent stack architecture.

## Adds

- `docs/future/NOVA_AGENT_STACK_RECOMMENDATIONS.md`
- `docs/future/ROUTINE_LAYER_SPEC.md`
- `docs/future/CONTEXT_PACK_SPEC.md`
- `docs/future/DAILY_BRIEF_ROUTINE_SPEC.md`
- `docs/future/LEARNING_LAYER_SPEC.md`
- `docs/future/GUARD_SYSTEM_SPEC.md`
- `docs/future/TRACE_AND_OBSERVABILITY_SPEC.md`

## Updates

- `docs/future/ROADMAP.md` now reflects the layered future direction:
  - Memory
  - Context Pack
  - Brain discipline
  - Routine Layer
  - Learning
  - Guard/trace systems
  - OpenClaw later only after hardening
- `docs/INDEX.md` now links the new architecture docs.

## Boundaries

Docs-only.
No runtime code changes.
No generated runtime truth changes.
No capability changes.
No Governor/OpenClaw behavior changes.

## Core correction

Daily Brief is documented as a Routine Layer surface, not as part of the Brain.
Brain remains reasoning/planning only. Governor remains the authority boundary.