### PR TITLE
docs: link Auralis social content pack in index and future guide

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -65,6 +65,7 @@ Use the product docs above first, then use runtime truth docs for exact capabili
 - [OpenClaw Robust Hardening Audit - 2026-05-01](future/OPENCLAW_ROBUST_HARDENING_AUDIT_2026-05-01.md)
 - [Nova x Auralis Digital Website Engine](future/NOVA_AURALIS_DIGITAL_WEBSITE_ENGINE.md)
 - [Auralis Website Coworker Workflow](future/AURALIS_WEBSITE_COWORKER_WORKFLOW.md)
+- [Auralis Social Content Workflow Pack](future/auralis_digital/SOCIAL_CONTENT_WORKFLOW_PACK.md)
 - [Auralis Mock Lead Fixtures](future/auralis_mock_leads/README.md)
 - [YouTubeLIS Tool Folder](tools/youtubelis.md)
 - [Governed Media and E-Commerce Engine](future/NOVA_GOVERNED_MEDIA_AND_ECOMMERCE_ENGINE.md)

--- a/docs/future/README.md
+++ b/docs/future/README.md
@@ -33,6 +33,10 @@ These docs define future architecture direction. They are not live runtime capab
 - `GUARD_SYSTEM_SPEC.md` - planned Brain/Mode/Context/Routine/Memory/Learning/OpenClaw guard layers.
 - `TRACE_AND_OBSERVABILITY_SPEC.md` - planned safe trace and observability surfaces.
 
+## Auralis Workflow Packs (Future)
+
+- `auralis_digital/SOCIAL_CONTENT_WORKFLOW_PACK.md` - governed local-business social content workflow (draft-only, no autonomous posting).
+
 ## Optional Workflow Planning
 
 These docs preserve possible workflow directions. They are not live runtime


### PR DESCRIPTION
Adds discoverability links for the Auralis Social Content Workflow Pack in docs/INDEX.md and docs/future/README.md.