### PR TITLE
docs: refresh human guides for Stage 3/4/5

### DIFF
--- a/docs/reference/HUMAN_GUIDES/01_START_HERE.md
+++ b/docs/reference/HUMAN_GUIDES/01_START_HERE.md
@@ -1,5 +1,5 @@
 # Start Here
-Updated: 2026-04-20
+Updated: 2026-05-02
 
 ## What Nova Is
 Nova is a local-first, governed workspace assistant.
@@ -81,12 +81,17 @@ Today, Nova can already help with:
 - research and answer-first search
 - explanation of files, code, reports, and screen context
 - project continuity and thread recall
-- explicit governed memory and memory export
+- explicit user-initiated memory — remember, review, update, forget, and ask why something
+  was recalled (the conversational memory loop is implemented and proven)
 - bounded assistive noticing
 - governed second-opinion review and followthrough
 - draft emails for review in your mail client
 - manual and narrow scheduled home-agent tasks
 - visible Trust, Settings, and connection status
+
+The memory loop, context pack foundation, and brain mode contracts are all implemented and
+proven as of 2026-05-02. They are not yet wired into every surface, but the core behavior
+is in place and tested.
 
 ## What Nova Is Still Growing Into
 Nova is real now, but it is still growing.
@@ -96,7 +101,10 @@ Important things still maturing include:
 - more polished connector entry and non-technical setup
 - deeper OpenClaw execution work
 - installer validation and stronger packaging for non-technical users
-- more complete cross-system awareness over time
+- Context Pack wired into live prompt assembly
+- Brain mode classification surfaced in the UI
+- Memory UX beyond the conversational loop (dedicated page, export, thread-linking)
+- Daily Brief as a governed RoutineGraph (Stage 6)
 
 ## What To Read Next
 If you want the user explanation, continue with:

--- a/docs/reference/HUMAN_GUIDES/02_HOW_NOVA_WORKS.md
+++ b/docs/reference/HUMAN_GUIDES/02_HOW_NOVA_WORKS.md
@@ -1,5 +1,5 @@
 # How Nova Works
-Updated: 2026-03-28
+Updated: 2026-05-02
 
 ## The Simple Model
 Nova is easiest to understand as four connected layers:
@@ -42,6 +42,20 @@ Important boundary:
 - continuity should stay visible and resettable
 - noticing should lead to suggestions, not hidden action
 
+### Context Pack — The Bridge Layer
+When Nova pulls from memory, search, or project state before answering, it does not
+feed raw data to the reasoning layer. It assembles a Context Pack first.
+
+The Context Pack is a bounded, labeled bridge:
+- every item carries a source label (runtime_truth, confirmed_memory, candidate_memory)
+- runtime truth always outranks memory
+- budget limits prevent runaway context growth
+- stale and conflicting items are flagged before they reach the Brain
+- the pack is frozen — it cannot execute or authorize anything
+
+Context Pack is implemented and proven (Stage 4). Live prompt assembly wiring
+is Stage 5/6 work still in progress.
+
 ## 3. Governance And Trust Layer
 This is Nova's control system.
 
@@ -77,6 +91,20 @@ Important boundary:
 - OpenClaw is the worker layer inside Nova
 - the review lane can critique and improve answers, but it cannot take actions directly
 
+### Brain Mode Contracts
+When Nova reasons about a request, it operates under a mode contract — a set of
+rules about what that mode can and cannot do.
+
+Seven modes are defined: brainstorm, repo_review, implementation, merge, planning,
+action_review, and casual.
+
+Key rule: only implementation and merge modes may mutate the repo. All other modes
+are explicitly prohibited from doing so.
+
+Each mode contract is frozen and enforced in code — not a description of intended
+behavior, but a hard boundary. Brain mode classification is implemented and proven
+(Stage 5). Surfacing the active mode in the UI is Stage 6 work still in progress.
+
 ## The Typical Request Paths
 A Nova request usually follows one of these paths.
 
@@ -89,7 +117,8 @@ Examples:
 Nova will:
 1. route local-first
 2. gather relevant context, memory, or workspace state
-3. present the answer in Nova's voice
+3. assemble a bounded Context Pack (source labels, budget limits, stale/conflict checks)
+4. present the answer in Nova's voice
 
 ### Path B: Governed action
 Examples:

--- a/docs/reference/HUMAN_GUIDES/03_WHAT_NOVA_CAN_DO.md
+++ b/docs/reference/HUMAN_GUIDES/03_WHAT_NOVA_CAN_DO.md
@@ -1,5 +1,5 @@
 # What Nova Can Do
-Updated: 2026-04-20
+Updated: 2026-05-02
 
 ## Overview
 Nova's active capability surface now covers these big areas:
@@ -159,30 +159,38 @@ Examples:
 - `workspace board`
 
 ## 6. Governed Memory
-Nova has active governed memory, which means it can preserve things across time under explicit user control.
+Nova has an explicit, user-initiated conversational memory loop.
+Memory is never saved silently. Every save is confirmed with a receipt.
+Memory is never used before you have had a chance to review and remove it.
 
-It can:
-- save a memory item
-- list memory items
-- show a memory item
-- lock or defer a memory item
-- unlock or delete a memory item with confirmation
-- supersede an older memory item with a newer one
-- save thread snapshots into memory
-- save thread decisions into memory
-- list memory linked to a specific thread
-- expose a dedicated Memory page for reviewing durable memory, scope distribution, linked threads, and recent items
+The implemented Stage 3 memory loop includes:
+
+- `remember [content]` — save a new memory item
+- `review memories` / `memory list` — list saved items with IDs and source labels
+- `update memory [id]: [new content]` — supersede an existing item with a newer one
+- `forget [id]` — remove an item permanently; it will not be reused
+- `why-used` / `what memory are you using` — explain which memory context is active
+  and why each item was selected
 
 Examples:
-- `save this`
 - `remember this: the client supplies alcohol`
-- `memory overview`
-- `memory list`
-- `memory show mem_...`
-- `memory lock mem_...`
-- `memory save thread deployment issue`
-- `memory save decision for deployment issue: inspect path before rebuild`
-- `memory list thread deployment issue`
+- `remember: meeting cadence is every other Tuesday`
+- `review memories`
+- `update memory MEM-20260502-061244-7794: the client now supplies only beer`
+- `forget MEM-20260502-061244-7794`
+- `why-used`
+- `what memory are you using right now`
+
+Important boundaries:
+- Nova does not save memory unless you explicitly ask it to
+- Soft-deleted items are permanently excluded from all read paths — forgotten means gone
+- Memory items saved automatically by the system (if any) are shown with their source label so
+  you can review and remove them before they influence anything
+- Memory does not authorize action — it provides context only
+
+Note: broader memory UI surfaces (dedicated Memory page, thread-linked memory, lock/defer)
+may exist in some runtime configurations but are not part of the current core memory loop.
+The commands above are the implemented and proven scope.
 
 ## 7. Trust And Workspace Visibility
 Nova now has clearer product surfaces for understanding what it is doing and where current work lives.
@@ -255,6 +263,11 @@ The biggest examples are:
 - richer visualizer stages beyond the current structured graph view
 - approval-gated patch proposal and apply flows for the future local code operator
 - delegated trigger runtime for policies
+- Context Pack injection into live prompt assembly (Stage 5 wiring — implemented but not yet
+  wired into brain_server.py prompt construction)
+- Brain mode contracts surfaced in the UI (mode classification exists as code, not yet visible
+  to the user)
+- Memory UX surfaces beyond the conversational loop (dedicated page, export, thread-linking)
 
 ## 10. Response Style Control
 Nova can expose and adjust its manual presentation tone without changing what it is allowed to do.
@@ -305,10 +318,15 @@ Today Nova can already:
 - summarize
 - inspect
 - continue project work
-- preserve governed memory
+- remember things explicitly — and forget them when asked
 - expose trust and workspace state more clearly
 - help with the current screen
 - help with the local computer in bounded ways
 - draft emails for review
 
-That is enough for Nova to behave more like a personal intelligence workspace than a simple assistant.
+The memory loop (Stage 3), context pack foundation (Stage 4), and brain mode
+contracts (Stage 5) are all implemented and proven. They are not yet fully wired
+into every surface, but the core behavior is in place and tested.
+
+That is enough for Nova to behave more like a personal intelligence workspace than a simple
+assistant — one that remembers, stays bounded, and keeps you in control.

--- a/docs/reference/HUMAN_GUIDES/07_CURRENT_STATE.md
+++ b/docs/reference/HUMAN_GUIDES/07_CURRENT_STATE.md
@@ -1,5 +1,5 @@
 # Current State
-Updated: 2026-04-23
+Updated: 2026-05-02
 
 ## Runtime Truth First
 For exact live phases, enabled capabilities, and current status, use:
@@ -7,42 +7,74 @@ For exact live phases, enabled capabilities, and current status, use:
 - `docs/current_runtime/RUNTIME_CAPABILITY_REFERENCE.md`
 - `docs/current_runtime/RUNTIME_FINGERPRINT.md`
 
-## Plain Language Summary
-Nova is a governed personal intelligence workspace with a real working runtime.
+For the current implementation stage, see:
+- `docs/status/WORKFLOW_STAGE_ROADMAP_2026-05-02.md`
+- `docs/status/CURRENT_WORK_STATUS.md`
 
-Today it includes:
-- governed actions and safety controls
-- research and reporting tools
-- memory and continuity features
-- trust and visibility surfaces
-- voice input/output foundations
-- workspace and project assistance
-- bounded external reasoning lanes
-- evolving OpenClaw / agent surfaces under governance
+## Stage Summary (2026-05-02)
 
-## What Feels Mature
+| Stage | Name | Status |
+|---|---|---|
+| 0 | Architecture alignment | Complete |
+| 1 | Active proof closeout | Complete |
+| 2 | Status update after proof | Complete |
+| 3 | Memory loop | **Complete** |
+| 4 | Context Pack | **Complete** |
+| 5 | Brain discipline / trace | **Active** |
+| 6 | Routine surfaces | Not started |
+
+## What Is Implemented and Proven
+
+**Memory loop (Stage 3)**
+- Conversational remember / review / update / forget / why-used
+- Receipts for every save and delete
+- No silent autosave; no reuse of forgotten items; memory never authorizes action
+- Proven by 62 tests and MEMORY_LOOP_PROOF.md
+
+**Context Pack (Stage 4)**
+- Bounded, labeled context bridge between memory, search, and the Brain
+- Source labels (runtime_truth, confirmed_memory, candidate_memory) on every item
+- Budget enforcement; stale detection; conflict detection; warning cap
+- Runtime truth always outranks memory
+- Non-authorizing frozen dataclass: cannot execute or authorize anything
+- Proven by 69 tests and CONTEXT_PACK_PROOF.md
+- Not yet wired into live prompt assembly — Stage 5/6 integration work
+
+**Brain mode contracts (Stage 5)**
+- Seven modes defined: brainstorm, repo_review, implementation, merge, planning,
+  action_review, casual
+- Each mode specifies can / cannot / may_mutate_repo / requires_context
+- Only implementation and merge modes may mutate the repo
+- Safe BrainTrace: records mode and structural decisions — never private reasoning
+- Lightweight classify_mode() function with no LLM call
+- Proven by 85 tests and BRAIN_MODE_PROOF.md
+- Not yet surfaced in the UI or wired into per-turn mode detection
+
+## What Is Runtime-Capable Today
 Strong today:
 - governed search and reporting
 - trust visibility
-- memory review and management
-- workspace/project context
+- memory loop (conversational)
+- workspace and project context
 - screen explanation flows
 - guided user controls
+- email draft (Cap 64)
 
-## What Is Still Improving
-Still maturing:
-- richer browser context
-- smoother premium UX
-- deeper workflows and persistence
-- easier provider/connectors setup
-- broader but still governed operator flows
+## What Is Not Done Yet
 
-## What Is Planned
-Examples:
-- optional wake word
-- richer connectors
-- stronger project tools
-- approval-gated coding/operator flows
+Important things still not complete:
+- Context Pack injection into live prompt assembly
+- Brain mode detection per turn (code exists, not yet wired)
+- Memory UX surfaces beyond the conversational loop
+- Daily Brief RoutineGraph v0 (Stage 6)
+- Connector setup (Google, richer calendar/email integrations)
+- Approval-gated coding and operator flows
 
 ## Honest Description
-Nova helps users research, understand, organize, and act inside visible governance boundaries while keeping the user in control.
+Nova is a governed AI workspace with a working runtime, a proven memory loop, a
+context pack foundation, and brain mode contracts. The core infrastructure for
+memory, context, and mode discipline is implemented and tested. Wiring those
+foundations into every user-facing surface is the Stage 6 work ahead.
+
+Nova helps users research, understand, organize, and act inside visible governance
+boundaries while keeping the user in control.

--- a/docs/reference/HUMAN_GUIDES/CURRENT_STAGE_GUIDE.md
+++ b/docs/reference/HUMAN_GUIDES/CURRENT_STAGE_GUIDE.md
@@ -1,0 +1,105 @@
+# Current Stage Guide — Stages 3, 4, and 5
+Updated: 2026-05-02
+
+## What This File Is
+A plain-language explanation of what Stages 3, 4, and 5 mean in human terms.
+
+For the authoritative implementation status, see:
+- `docs/status/CURRENT_WORK_STATUS.md`
+- `docs/status/WORKFLOW_STAGE_ROADMAP_2026-05-02.md`
+- `docs/todo/ACTIVE_TODO.md`
+
+---
+
+## Stage 3 — Memory Loop
+
+**What it means in plain language:**
+Nova can now remember things you tell it to remember, and it will tell you when it is using
+that memory. You can also update or remove memories, and Nova will never reuse something you
+deleted.
+
+**What is working now:**
+- `remember [content]` — saves a new memory item and shows you a receipt
+- `review memories` — lists saved items with IDs so you can see what Nova knows
+- `update memory [id]: [new content]` — replaces an existing item with a newer version
+- `forget [id]` — removes an item permanently; Nova will not use it again
+- `why-used` — explains which memory context is active and why each item was selected
+
+**What is NOT happening silently:**
+- Nova does not save memory unless you explicitly ask it to
+- Nova does not act on memory — memory provides context only, not authority
+- Forgotten items are gone from all read paths immediately
+
+**Proven by:** 62 tests and `docs/demo_proof/daily_operating_baseline/MEMORY_LOOP_PROOF.md`
+
+---
+
+## Stage 4 — Context Pack
+
+**What it means in plain language:**
+Before Nova answers a question that draws on your memory, search results, or project state,
+it now assembles a clean, labeled bundle called a Context Pack. This bundle has hard size
+limits, source labels on every item, and checks for stale or conflicting information — before
+any of it reaches Nova's reasoning layer.
+
+**What it means for you as a user:**
+- You will not get answers that quietly mix authoritative runtime truth with old guesses
+- Nova knows which items are confirmed memory vs. candidates vs. runtime facts
+- Nova knows when two items conflict and will flag it rather than picking one silently
+- The pack cannot execute or authorize anything — it is read-only input to reasoning
+
+**What is NOT yet live:**
+- The Context Pack is implemented and proven, but is not yet wired into live prompt assembly.
+  That wiring is Stage 5 and 6 work. Nova's live answers do not yet fully use the Context Pack
+  pipeline every turn — that integration is still in progress.
+
+**Proven by:** 69 tests and `docs/demo_proof/daily_operating_baseline/CONTEXT_PACK_PROOF.md`
+
+---
+
+## Stage 5 — Brain Mode Contracts
+
+**What it means in plain language:**
+Nova now operates under explicit mode contracts when it reasons. Each mode has a defined set
+of things it can do, things it cannot do, and whether it is allowed to make changes to the
+codebase.
+
+**The seven modes:**
+
+| Mode | Purpose | May change code? |
+|------|---------|-----------------|
+| brainstorm | Explore ideas freely | No |
+| repo_review | Review and explain existing code | No |
+| implementation | Write or modify code | Yes |
+| merge | Integrate branches and close PRs | Yes |
+| planning | Plan work and structure decisions | No |
+| action_review | Review proposed or past actions | No |
+| casual | Conversational, low-stakes answers | No |
+
+**The key rule:**
+Only `implementation` and `merge` may mutate the repo. Every other mode is prohibited from
+doing so. This is enforced in code, not just described as intended behavior.
+
+**What is NOT yet live:**
+- Brain mode classification runs in code but is not yet surfaced in the UI.
+  You cannot yet see which mode Nova is operating in during a live conversation.
+  That UI surface is Stage 6 work.
+
+**Proven by:** 85 tests and `docs/demo_proof/daily_operating_baseline/BRAIN_MODE_PROOF.md`
+
+---
+
+## What The Three Stages Add Up To
+
+Stages 3, 4, and 5 together mean:
+
+1. Nova can remember explicit things you ask it to remember, without silent autosave or
+   hidden reuse.
+2. When Nova draws on that memory, it assembles a governed, labeled bundle first — with
+   hard limits, source labels, and stale/conflict checks.
+3. When Nova reasons, it operates under a mode contract that says exactly what it is and is
+   not allowed to do in that mode.
+
+The core infrastructure for memory, context, and mode discipline is implemented and tested.
+
+What remains is wiring those foundations into every user-facing surface — that is Stage 6.

--- a/docs/reference/HUMAN_GUIDES/README.md
+++ b/docs/reference/HUMAN_GUIDES/README.md
@@ -1,5 +1,5 @@
 # Nova Human Guides
-Updated: 2026-04-23
+Updated: 2026-05-02
 Status: Explanatory guide set
 
 ## What These Documents Are
@@ -12,6 +12,17 @@ Use:
 - `docs/current_runtime/CURRENT_RUNTIME_STATE.md`
 - `docs/current_runtime/RUNTIME_CAPABILITY_REFERENCE.md`
 - `docs/current_runtime/RUNTIME_FINGERPRINT.md`
+
+## Current Stage Note
+These guides were last aligned to the Stage 3 / 4 / 5 implementation sprint (2026-05-02).
+
+For the current implementation stage in plain language, start with:
+- `CURRENT_STAGE_GUIDE.md` (this folder) — what Stages 3–5 mean in human terms
+
+For the authoritative status, see:
+- `docs/status/CURRENT_WORK_STATUS.md`
+- `docs/status/WORKFLOW_STAGE_ROADMAP_2026-05-02.md`
+- `docs/todo/ACTIVE_TODO.md`
 
 ## Start Here
 1. `01_START_HERE.md`


### PR DESCRIPTION
## Summary
- Rewrites/updates 5 existing human guide files to reflect Stage 3 (memory loop), Stage 4 (context pack), and Stage 5 (brain mode contracts) implementation truth
- Removes non-existent memory commands from `03_WHAT_NOVA_CAN_DO.md` Section 6 that were never part of the actual runtime
- Adds `CURRENT_STAGE_GUIDE.md` — plain-language explanation of what each stage means to a non-technical reader
- No runtime doc edits; no code changes; no capability additions

## What changed
- `01_START_HERE.md` — correct capability list; Stage 3/4/5 "still growing into" items
- `02_HOW_NOVA_WORKS.md` — Context Pack bridge layer section; Brain Mode Contracts section; Context Pack step in Path A
- `03_WHAT_NOVA_CAN_DO.md` — Section 6 rewritten with actual Stage 3 commands (remember/review/update/forget/why-used); non-existent commands removed
- `07_CURRENT_STATE.md` — full rewrite with Stage matrix table, proven items, and not-done items
- `README.md` — Current Stage Note section added
- `CURRENT_STAGE_GUIDE.md` — new file; Stages 3/4/5 in plain language with tables

## Test plan
- [ ] All Stage 3 memory commands in Section 6 match `MEMORY_LOOP_PROOF.md`
- [ ] All "not yet live" claims match `CURRENT_WORK_STATUS.md` and `WORKFLOW_STAGE_ROADMAP_2026-05-02.md`
- [ ] No runtime docs (`docs/current_runtime/`) were touched
- [ ] No code files were touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)