### PR TITLE
fix: brain_mode second pass — decision_notes clarity, explicit MERGE test, long-input guard

### DIFF
--- a/nova_backend/src/brain/brain_mode.py
+++ b/nova_backend/src/brain/brain_mode.py
@@ -438,7 +438,8 @@ class BrainTrace:
     mode: BrainMode
     composed_at: str
     context_sources: tuple[str, ...]   # authority labels from ContextPack items
-    decision_notes: tuple[str, ...]    # structural decisions made (not reasoning)
+    decision_notes: tuple[str, ...]    # structural decisions only — e.g. "scope limited to X",
+                                       # "no new capabilities required"; never LLM chain-of-thought
     warnings: tuple[str, ...]          # structural concerns about the turn
 
     # Non-authorizing invariants — cannot be overridden by callers

--- a/nova_backend/tests/brain/test_brain_mode.py
+++ b/nova_backend/tests/brain/test_brain_mode.py
@@ -84,6 +84,9 @@ class TestBrainstormNeverMutatesRepo:
         mutating = [m for m, c in CONTRACTS.items() if c.may_mutate_repo]
         assert set(mutating) == {BrainMode.IMPLEMENTATION, BrainMode.MERGE}
 
+    def test_merge_may_mutate_repo(self):
+        assert get_contract(BrainMode.MERGE).may_mutate_repo is True
+
 
 # ---------------------------------------------------------------------------
 # Invariant 2 — Repo-review mode requires context before recommending
@@ -406,6 +409,13 @@ class TestClassifyMode:
         # "write code" is the implementation signal, not bare "write"
         result = classify_mode("write a summary of the changes")
         assert result.mode != BrainMode.IMPLEMENTATION
+
+    def test_very_long_input_does_not_hang(self):
+        # Regex must not catastrophically backtrack on large inputs
+        long_input = "implement " + "x " * 5000
+        result = classify_mode(long_input)
+        assert result.mode is not None
+        assert 0.0 <= result.confidence <= 1.0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Clarifies `decision_notes` field comment in `BrainTrace` — structural notes only, never LLM chain-of-thought
- Adds explicit `test_merge_may_mutate_repo` test (MERGE is a high-authority mode; direct assertion is clearer than set-equality coverage alone)
- Adds `test_very_long_input_does_not_hang` — guards against regex catastrophic backtracking on large inputs

## Test plan
- [x] 87 brain mode tests pass (was 85)
- [x] 293 brain + memory tests pass (no regressions)
- [x] No runtime docs touched; no capabilities added

🤖 Generated with [Claude Code](https://claude.com/claude-code)