### PR TITLE
docs: align all status docs with Stage 5 complete and Stage 6 active

### DIFF
--- a/docs/reference/HUMAN_GUIDES/07_CURRENT_STATE.md
+++ b/docs/reference/HUMAN_GUIDES/07_CURRENT_STATE.md
@@ -20,8 +20,8 @@ For the current implementation stage, see:
 | 2 | Status update after proof | Complete |
 | 3 | Memory loop | **Complete** |
 | 4 | Context Pack | **Complete** |
-| 5 | Brain discipline / trace | **Active** |
-| 6 | Routine surfaces | Not started |
+| 5 | Brain discipline / trace | **Complete** |
+| 6 | Routine surfaces | **Active** |
 
 ## What Is Implemented and Proven
 
@@ -40,15 +40,18 @@ For the current implementation stage, see:
 - Proven by 69 tests and CONTEXT_PACK_PROOF.md
 - Not yet wired into live prompt assembly — Stage 5/6 integration work
 
-**Brain mode contracts (Stage 5)**
+**Brain mode contracts and Context Pack wiring (Stage 5 + Stage 6 start)**
 - Seven modes defined: brainstorm, repo_review, implementation, merge, planning,
   action_review, casual
 - Each mode specifies can / cannot / may_mutate_repo / requires_context
 - Only implementation and merge modes may mutate the repo
 - Safe BrainTrace: records mode and structural decisions — never private reasoning
 - Lightweight classify_mode() function with no LLM call
-- Proven by 85 tests and BRAIN_MODE_PROOF.md
-- Not yet surfaced in the UI or wired into per-turn mode detection
+- Context Pack now wired into general_chat_runtime.py — raw memory items pass through
+  compose_context_pack() before prompt assembly on every general-chat turn; brain trace
+  stored in session_state["last_brain_trace"] for visibility
+- Proven by 87 tests and BRAIN_MODE_PROOF.md
+- Brain mode visible in session trace; not yet surfaced per-turn in the UI
 
 ## What Is Runtime-Capable Today
 Strong today:
@@ -63,10 +66,9 @@ Strong today:
 ## What Is Not Done Yet
 
 Important things still not complete:
-- Context Pack injection into live prompt assembly
-- Brain mode detection per turn (code exists, not yet wired)
+- Brain mode surfaced in the UI per turn (classification runs; not yet visible to the user)
 - Memory UX surfaces beyond the conversational loop
-- Daily Brief RoutineGraph v0 (Stage 6)
+- Daily Brief RoutineGraph v0 (Stage 6 — active)
 - Connector setup (Google, richer calendar/email integrations)
 - Approval-gated coding and operator flows
 

--- a/docs/reference/HUMAN_GUIDES/CURRENT_STAGE_GUIDE.md
+++ b/docs/reference/HUMAN_GUIDES/CURRENT_STAGE_GUIDE.md
@@ -1,4 +1,4 @@
-# Current Stage Guide — Stages 3, 4, and 5
+# Current Stage Guide — Stages 3, 4, 5, and 6
 Updated: 2026-05-02
 
 ## What This File Is
@@ -102,4 +102,31 @@ Stages 3, 4, and 5 together mean:
 
 The core infrastructure for memory, context, and mode discipline is implemented and tested.
 
-What remains is wiring those foundations into every user-facing surface — that is Stage 6.
+Stage 6 has begun — the first wiring is already live.
+
+---
+
+## Stage 6 — Routine Surfaces (Active)
+
+**What it means in plain language:**
+Nova's memory, context, and mode foundations are now connected to the live prompt path.
+Stage 6 is about building the first visible routines on top of that foundation — starting
+with a governed Daily Brief and an everyday workflow demo.
+
+**What is working now (Stage 6 start):**
+- Context Pack is wired into `general_chat_runtime.py` — every general-chat turn now enforces
+  budget limits, source labels, stale/conflict detection, and authority ranking before memory
+  reaches the prompt
+- Brain mode is classified on every turn and a BrainTrace is recorded in session state
+- Memory items confirmed by the user (source: explicit_user_save) are preferred over
+  auto-extracted candidates — every turn, not just in tests
+
+**What is being built next:**
+- Daily Brief RoutineGraph v0 — a governed, non-authorizing daily brief backed by receipts
+- Everyday workflow demo: plan my week from tasks, notes, calendar context, and priorities,
+  with an approval boundary and a receipt
+
+**What is NOT yet live:**
+- Brain mode is not yet surfaced per-turn in the UI (classified and traced internally)
+- Routine execution with real approval gates (next Stage 6 work)
+- Memory UX beyond the conversational loop (dedicated page, export)

--- a/docs/status/CURRENT_WORK_STATUS.md
+++ b/docs/status/CURRENT_WORK_STATUS.md
@@ -37,7 +37,7 @@ Generated runtime truth still reports the authoritative capability inventory and
 - Daily Brief MVP is implemented as a deterministic, on-demand session brief (PR #68). It synthesizes session state, memory, receipts, weather (live via WeatherService), calendar (local ICS via CalendarSkill), and email placeholder into 11 sections. Non-authorizing frozen dataclass; `execution_performed=False` and `authorization_granted=False` are enforced by `__post_init__`. No new capability, no LLM calls, no Governor path.
 - Daily Brief robustness is improved on the `daily-brief-continuity-hardening` branch. It degrades cleanly on malformed session, memory, receipt, weather, calendar, and email-placeholder inputs; surfaces session continuity fields; and uses deterministic next-action recommendations. Proof notes live under [`../demo_proof/daily_operating_baseline/`](../demo_proof/daily_operating_baseline/).
 - Stage 3 Memory Loop is implemented as an explicit user-initiated conversational memory skill: remember / review-list / update / forget / why-used, with memory receipts. It does not silently autosave, does not authorize action, and does not register a new capability.
-- Stage 4 Context Pack is implemented as a bounded, labeled context bridge with ContextItem, ContextPackWarning, ContextPack, source labels, authority labels, budget enforcement, stale/conflict warnings, warning cap, deleted-memory filtering, legacy format output, and render_context_block. It does not authorize action and is not yet live-wired into brain prompt assembly.
+- Stage 4 Context Pack is implemented as a bounded, labeled context bridge with ContextItem, ContextPackWarning, ContextPack, source labels, authority labels, budget enforcement, stale/conflict warnings, warning cap, deleted-memory filtering, legacy format output, and render_context_block. It does not authorize action. As of Stage 6, it is live-wired into general_chat_runtime.py — raw memory items now pass through compose_context_pack() before prompt assembly on every general-chat turn.
 - Cap 64 remains confirmation-bound local `mailto:` draft only. It does not use Gmail API, SMTP, inbox access, or autonomous send.
 - Cap 65 remains read-only Shopify intelligence. No Shopify writes are implemented.
 
@@ -130,26 +130,42 @@ Boundary: Context Pack is implemented and proven, but live prompt wiring and Bra
 
 ---
 
-## Active Sprint: Stage 5 — Brain Discipline / Trace
+## Stage 5 — Brain Discipline / Trace — Closed 2026-05-02
+
+Implemented:
+
+- 7 mode contracts: brainstorm, repo_review, implementation, merge, planning, action_review, casual
+- classify_mode() — lightweight regex classifier, no LLM call, confidence 0.0–1.0
+- BrainTrace — non-authorizing frozen dataclass; execution_performed, authorization_granted,
+  private_reasoning_exposed always False; enforced in __post_init__
+- Context Pack wired into general_chat_runtime.py — every general-chat turn now passes raw memory
+  items through compose_context_pack() before prompt assembly; packed_context replaces
+  relevant_memory_context in skill_state; brain trace stored in session_state["last_brain_trace"]
+
+Proof: `docs/demo_proof/daily_operating_baseline/BRAIN_MODE_PROOF.md` — PASS.
+Merged: PRs #85, #87, #88, #89 — all 2026-05-02.
+
+---
+
+## Active Sprint: Stage 6 — Routine Surfaces
 
 Active scope:
 
-- Brain mode contracts for brainstorm, repo-review, implementation, merge, planning, and action-review
-- Safe BrainTrace fields that do not expose private chain-of-thought
-- Context Pack live wiring into `brain_server.py` prompt assembly
-- Cleanup of overly broad memory/context wording during trace/context review
+- Daily Brief RoutineGraph v0
+- Routine receipt
+- Everyday workflow demo: plan my week from tasks, notes, calendar context, and priorities
+- Governance boundaries for routine execution
 
 Immediate continuation order:
 
-1. Add Brain mode contracts.
-2. Add safe BrainTrace fields.
-3. Wire Context Pack into live prompt assembly without authorizing action.
-4. Continue doc/status cleanup where stale "local-only" or planning-as-runtime wording remains.
-5. Plan cost posture metadata as the next design-to-runtime step, without hard blocking first.
-6. Plan Google read-only connector foundations only after cost posture and connector governance are clear.
-7. Keep OpenClaw expansion frozen until envelope issuance, approval, execution-guard, and receipt gaps are closed.
+1. Convert Daily Brief into RoutineGraph v0 — non-authorizing, receipt-backed.
+2. Capture one everyday workflow demo with approval boundary and receipt.
+3. Continue doc/status alignment as work progresses.
+4. Plan cost posture metadata as the next free-first implementation step.
+5. Plan Google read-only connector foundations only after cost posture and connector governance are clear.
+6. Keep OpenClaw expansion frozen until envelope issuance, approval, execution-guard, and receipt gaps are closed.
 
-Do not start new write/action capabilities from this status pass.
+Do not start new write/action capabilities in this sprint.
 
 ---
 
@@ -209,9 +225,7 @@ Do not claim these are finished unless verified against code/runtime truth:
 - Free-first runtime enforcement.
 - One-click consumer installer.
 - Full Daily Operating System / background routines.
-- Context Pack live prompt wiring.
-- Brain mode contracts.
-- Safe BrainTrace.
+- Brain mode surfaced in UI (classify_mode exists in code; not yet shown per-turn in the UI).
 
 ---
 

--- a/docs/status/WORKFLOW_STAGE_ROADMAP_2026-05-02.md
+++ b/docs/status/WORKFLOW_STAGE_ROADMAP_2026-05-02.md
@@ -11,10 +11,10 @@ It is not runtime truth. Exact runtime truth still comes from code and generated
 ## Current overall stage
 
 ```text
-Stage 5: Brain discipline / trace — ACTIVE
+Stage 6: Routine surfaces — ACTIVE
 ```
 
-Stages 1, 2, 3, and 4 completed 2026-05-02.
+Stages 1, 2, 3, 4, and 5 completed 2026-05-02.
 
 The current repo sequence is:
 
@@ -38,8 +38,8 @@ Proof closeout
 | 2 | Status update after proof | **Complete** 2026-05-02 | TODO/status/roadmap updated | — |
 | 3 | Memory loop | **Complete** 2026-05-02 | remember/review-list/update/forget/why-used implemented with receipts and tests | — |
 | 4 | Context Pack | **Complete** 2026-05-02 | source labels, authority labels, budgets, why-selected, stale/conflict warnings proven | — |
-| 5 | Brain discipline / trace | **Active** | mode contracts and safe BrainTrace exist | Implement on branch |
-| 6 | Routine surfaces | Not started | Daily Brief RoutineGraph v0 and workflow demos exist | Start only after memory/context/trace foundations |
+| 5 | Brain discipline / trace | **Complete** 2026-05-02 | mode contracts, BrainTrace, and Context Pack wiring proven | — |
+| 6 | Routine surfaces | **Active** | Daily Brief RoutineGraph v0 and workflow demos exist | Context Pack wired; begin RoutineGraph |
 | A | Auralis manual validation | Ready for manual work | 3 mock client packs, 30 posts, 1 calendar, 1 outreach package | Run outside Nova runtime |
 
 ---
@@ -122,53 +122,30 @@ Merged: PR #83 on 2026-05-02.
 
 ---
 
-## Stage 5 - Brain discipline / trace
-
-State: **active** 2026-05-02.
-
-Minimum scope:
-
-- source labels
-- authority labels
-- budget limits
-- why-selected metadata
-- stale/conflict warnings
-- runtime truth priority
-
-Required proof:
-
-- candidate items are not treated as confirmed
-- runtime truth outranks memory
-- budgets are enforced
-
----
-
 ## Stage 5 - Brain discipline and trace
 
-State: not started.
+State: **complete** 2026-05-02.
 
-Minimum scope:
+Implemented:
 
-- brainstorm mode contract
-- repo-review mode contract
-- implementation mode contract
-- merge mode contract
-- planning mode contract
-- action-review mode contract
-- safe BrainTrace fields
+- 7 mode contracts: brainstorm, repo_review, implementation, merge, planning,
+  action_review, casual
+- classify_mode() — lightweight regex classifier, no LLM call
+- BrainTrace — non-authorizing frozen dataclass; execution_performed,
+  authorization_granted, and private_reasoning_exposed always False
+- Context Pack wired into general_chat_runtime.py — raw memory items now
+  pass through compose_context_pack() before prompt assembly on every turn
+- Brain mode classified and trace recorded in session_state["last_brain_trace"]
+  on every general-chat turn
 
-Required proof:
-
-- brainstorm mode does not mutate repo
-- repo-review mode checks state before recommending
-- implementation mode stays focused
-- trace explains structure without exposing private chain-of-thought
+Proof: `docs/demo_proof/daily_operating_baseline/BRAIN_MODE_PROOF.md` — PASS.
+Merged: PRs #85, #87, #88, #89 on 2026-05-02.
 
 ---
 
 ## Stage 6 - Routine surfaces
 
-State: not started.
+State: **active** 2026-05-02.
 
 Minimum scope:
 
@@ -208,8 +185,8 @@ Blocked from runtime until:
 
 ## Current recommended action
 
-Stage 5 is complete. Continue to Stage 6.
+Stage 6 is active. Context Pack and BrainTrace are live in the prompt path.
 
 ```text
-Brain mode contracts and BrainTrace implemented and proven → begin Routine surfaces.
+Context Pack wired into general_chat_runtime → begin Daily Brief RoutineGraph v0.
 ```

--- a/docs/todo/ACTIVE_TODO.md
+++ b/docs/todo/ACTIVE_TODO.md
@@ -1,7 +1,7 @@
 # Active TODO - Nova
 
 **Updated:** 2026-05-02
-**Sprint goal:** Routine surfaces — Stage 6 now active.
+**Sprint goal:** Stage 6 — Routine surfaces. Context Pack and BrainTrace now live in prompt path.
 **Authority note:** This file is the public task snapshot. Exact runtime truth still comes from generated runtime docs and code.
 
 ## Stepwise Execution Order
@@ -56,7 +56,7 @@
 ## Current Priorities (ordered)
 
 - [ ] Convert Daily Brief into RoutineGraph v0 (Stage 6)
-- [ ] Inject Context Pack and BrainTrace into live brain_server.py prompt assembly (wiring pass)
+- [x] Inject Context Pack and BrainTrace into live general_chat_runtime.py prompt assembly (PR #89, 2026-05-02)
 - [ ] Re-run Daily Brief + continuity proof manually in the local UI/API
 - [ ] Capture one everyday workflow demo: plan my week from tasks, notes, calendar context
 - [ ] Continue doc/status cleanup where stale "local-only" or planning-as-runtime wording remains
@@ -142,11 +142,13 @@ Canonical audit: `docs/future/OPENCLAW_ROBUST_HARDENING_AUDIT_2026-05-01.md`
 
 ## Recently Completed
 
-- Stage 5 Brain discipline — 7 mode contracts (brainstorm/repo-review/implementation/merge/
-  planning/action-review/casual) + classify_mode() + BrainTrace non-authorizing frozen
-  dataclass; 79 tests green; BRAIN_MODE_PROOF.md PASS; 2026-05-02
+- Stage 6 wiring — Context Pack and BrainTrace live in general_chat_runtime.py; every
+  general-chat turn now enforces budget limits, source labels, stale/conflict detection,
+  and authority ranking; brain trace in session_state["last_brain_trace"]; PR #89 2026-05-02
+- Stage 5 Brain discipline — 7 mode contracts + classify_mode() + BrainTrace non-authorizing
+  frozen dataclass; 87 tests green; BRAIN_MODE_PROOF.md PASS; PRs #85/#88 2026-05-02
 - Stage 4 Context Pack — bounded, labeled context bridge with source/authority labels, budget
-  enforcement, stale/conflict detection, warning cap; 69 tests green; PR merged 2026-05-02
+  enforcement, stale/conflict detection, warning cap; 72 tests green; PRs #83/#87 2026-05-02
 - Stage 3 Memory loop — remember/review/update/forget/why-used with receipts; 62 tests;
   MEMORY_LOOP_PROOF.md PASS; PR #82 merged 2026-05-02
 - Agent stack future architecture docs, future backlog, and Auralis social content workflow pack merged and linked


### PR DESCRIPTION
## Summary
Syncs five status/guide docs to reflect what actually landed in PRs #85–#89 today.

## What changed
- `WORKFLOW_STAGE_ROADMAP` — Stage 5 marked complete; Stage 6 marked active; duplicate Stage 5 sections collapsed; Stage 5 implementation details added; recommended action updated
- `CURRENT_WORK_STATUS` — Stage 5 active sprint replaced with closed entry; Stage 6 sprint opened; Stage 4 boundary updated ("now live-wired"); stale "Do Not Overstate" entries removed for Context Pack wiring / brain mode contracts / BrainTrace
- `ACTIVE_TODO` — Context Pack/BrainTrace wiring marked done (PR #89); test counts corrected (87 brain mode, 72 context pack); recently completed updated
- `07_CURRENT_STATE.md` — Stage matrix updated; brain mode section reflects wiring; "not yet wired" removed from What Is Not Done Yet
- `CURRENT_STAGE_GUIDE.md` — Stage 6 section added; title updated to include Stage 6

## Test plan
- [x] No code files touched
- [x] All claims match actual merged PRs (#85, #87, #88, #89)
- [x] No generated runtime docs edited

🤖 Generated with [Claude Code](https://claude.com/claude-code)