### PR TITLE
fix: Stage 6 wiring second pass — authority_label, trace isolation, edge case tests

### DIFF
--- a/nova_backend/src/conversation/general_chat_runtime.py
+++ b/nova_backend/src/conversation/general_chat_runtime.py
@@ -195,12 +195,13 @@ async def run_general_chat_fallback(
             "scope": item.scope,
             "thread_name": item.thread_name,
             "source": item.source_label,
+            "authority_label": item.authority_label,
         }
         for item in pack.items
     ]
 
     # Stage 6: classify brain mode and record a non-authorizing trace for visibility.
-    # The trace is stored in session_state only — it does not affect routing or authority.
+    # Stored in session_state only — does not affect routing or authority.
     mode_result = classify_mode(normalized_query)
     brain_trace = compose_brain_trace(
         mode=mode_result.mode,
@@ -211,7 +212,6 @@ async def run_general_chat_fallback(
         ],
         warnings=[w.reason for w in pack.warnings[:3]],
     )
-    session_state["last_brain_trace"] = brain_trace.to_dict()
 
     chat_context = list(session_state.get("general_chat_context") or session_context)
     skill_state = dict(session_state)
@@ -224,6 +224,10 @@ async def run_general_chat_fallback(
     ):
         skill_state.pop(transient_key, None)
     skill_state["relevant_memory_context"] = packed_context
+
+    # Write trace to session_state after skill_state snapshot — keeps diagnostic
+    # data out of the prompt assembly pipeline.
+    session_state["last_brain_trace"] = brain_trace.to_dict()
 
     understanding = build_request_understanding(normalized_query)
     skill_state["request_understanding"] = understanding

--- a/nova_backend/tests/conversation/test_general_chat_runtime.py
+++ b/nova_backend/tests/conversation/test_general_chat_runtime.py
@@ -109,6 +109,50 @@ def test_context_pack_wiring_brain_trace_mode_is_string():
     assert len(trace["mode"]) > 0
 
 
+def test_context_pack_wiring_packed_context_includes_authority_label():
+    _, skill, _ = _run_fallback()
+    packed = skill.calls[0]["session_state"]["relevant_memory_context"]
+    assert len(packed) == 1
+    assert "authority_label" in packed[0]
+    assert packed[0]["authority_label"] == "confirmed_project_memory"
+
+
+def test_brain_trace_not_in_skill_state():
+    # Trace must be stored on session_state only — not passed into skill_state,
+    # which flows into prompt assembly.
+    _, skill, session_state = _run_fallback()
+    assert "last_brain_trace" in session_state
+    assert "last_brain_trace" not in skill.calls[0]["session_state"]
+
+
+def test_brain_trace_not_stored_when_query_empty():
+    result = SkillResult(success=True, message="A.", skill="general_chat")
+    skill = _FakeGeneralChatSkill(result)
+    session_state: dict = {}
+
+    outcome = asyncio.run(
+        run_general_chat_fallback(
+            "",
+            general_chat_skill=skill,
+            session_state=session_state,
+            session_context=[],
+            project_threads=object(),
+            select_relevant_memory_context=lambda *a, **kw: [],
+        )
+    )
+    assert outcome is None
+    assert "last_brain_trace" not in session_state
+
+
+def test_memory_items_without_source_become_candidate():
+    item = {"id": "x", "title": "T", "content": "Some content"}  # no 'source'
+    _, skill, _ = _run_fallback(memory_items=[item])
+    packed = skill.calls[0]["session_state"]["relevant_memory_context"]
+    assert len(packed) == 1
+    assert packed[0]["source"] == "candidate_memory"
+    assert packed[0]["authority_label"] == "candidate_memory"
+
+
 def test_resolve_pending_escalation_confirm_updates_state_and_context():
     skill = _FakeGeneralChatSkill(
         SkillResult(


### PR DESCRIPTION
## Summary
Second-pass fixes on the Stage 6 Context Pack / brain mode wiring from PR #89.

## Fixes
- **Missing `authority_label`** — packed_context dict was missing `authority_label` from `ContextItem`. Downstream code used `.get()` so no crash, but the contract was broken. Added.
- **Trace polluted skill_state** — `session_state["last_brain_trace"]` was set before `skill_state = dict(session_state)`, so the trace dict entered the prompt assembly pipeline on every turn. Moved the assignment to after the snapshot so it stays diagnostic-only.

## New tests (11 total, was 7)
- `test_context_pack_wiring_packed_context_includes_authority_label` — verifies the field is present and correct
- `test_brain_trace_not_in_skill_state` — verifies trace does not enter prompt assembly path
- `test_brain_trace_not_stored_when_query_empty` — early-return path leaves session_state clean
- `test_memory_items_without_source_become_candidate` — sourceless items correctly labelled

## Test plan
- [x] 11 general_chat_runtime tests pass
- [x] 713 brain + memory + conversation tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)