### PR TITLE
fix: second-pass hardening on RoutineGraph v0 and Stage 6 tests

### DIFF
--- a/nova_backend/src/routine/routine_graph.py
+++ b/nova_backend/src/routine/routine_graph.py
@@ -13,6 +13,7 @@ They do not:
 
 from __future__ import annotations
 
+import copy
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -80,6 +81,12 @@ class RoutineRun:
 
     Non-authorizing: execution_performed and authorization_granted are
     enforced False via __post_init__ and cannot be overridden by callers.
+
+    Note: `outputs` is a dict (shallow mutable). The field reference is
+    frozen (cannot be replaced), but Python does not prevent mutation of
+    the dict's contents. This is a record/snapshot — callers must not
+    mutate it after construction. to_dict() returns a deep copy so
+    serialised output is independent of the original.
     """
 
     run_id: str
@@ -105,7 +112,7 @@ class RoutineRun:
             "started_at": self.started_at,
             "completed_at": self.completed_at,
             "blocks_run": list(self.blocks_run),
-            "outputs": self.outputs,
+            "outputs": copy.deepcopy(self.outputs),
             "warnings": list(self.warnings),
             "execution_performed": False,
             "authorization_granted": False,

--- a/nova_backend/tests/conversation/test_general_chat_runtime.py
+++ b/nova_backend/tests/conversation/test_general_chat_runtime.py
@@ -125,6 +125,18 @@ def test_brain_trace_not_in_skill_state():
     assert "last_brain_trace" not in skill.calls[0]["session_state"]
 
 
+def test_session_state_snapshot_taken_before_brain_trace_write():
+    # skill_state is a snapshot of session_state taken BEFORE the trace is written.
+    # If the snapshot were taken after, the trace would appear in the prompt path.
+    _, skill, session_state = _run_fallback()
+    # Trace present in session_state (written after snapshot)
+    assert "last_brain_trace" in session_state
+    # Absent from skill_state — proves snapshot was taken before the write
+    assert "last_brain_trace" not in skill.calls[0]["session_state"]
+    # Sanity: both point to different dicts
+    assert skill.calls[0]["session_state"] is not session_state
+
+
 def test_brain_trace_not_stored_when_query_empty():
     result = SkillResult(success=True, message="A.", skill="general_chat")
     skill = _FakeGeneralChatSkill(result)

--- a/nova_backend/tests/routine/test_daily_brief_routine.py
+++ b/nova_backend/tests/routine/test_daily_brief_routine.py
@@ -147,6 +147,16 @@ def test_brief_output_authorization_granted_is_false():
 # Output shape
 # ---------------------------------------------------------------------------
 
+def test_all_output_keys_present():
+    run, _ = _run_with_content()
+    expected = {
+        "session_state", "memory_items", "recent_receipts",
+        "weather_data", "calendar_data", "important_emails",
+        "daily_brief", "routine_receipt",
+    }
+    assert set(run.outputs.keys()) == expected
+
+
 def test_outputs_daily_brief_key_present():
     run, _ = run_daily_brief_routine()
     assert "daily_brief" in run.outputs

--- a/nova_backend/tests/routine/test_routine_graph.py
+++ b/nova_backend/tests/routine/test_routine_graph.py
@@ -166,6 +166,14 @@ def test_routine_run_to_dict_auth_fields_are_always_false():
     assert d["authorization_granted"] is False
 
 
+def test_routine_run_to_dict_outputs_is_deep_copy():
+    # Mutating to_dict() output must not affect the original
+    run = _run(outputs={"key": "value"})
+    d = run.to_dict()
+    d["outputs"]["key"] = "mutated"
+    assert run.outputs["key"] == "value"
+
+
 # ---------------------------------------------------------------------------
 # RoutineReceipt — non-authorizing invariants
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Second-pass fixes from full audit of Stage 6 implementation.

**`routine_graph.py`**
- `import copy` added
- `RoutineRun.to_dict()` now returns `copy.deepcopy(self.outputs)` — serialised output is independent of the original dict; mutation of the returned dict cannot affect the run record
- Added docstring note: `outputs` is a shallow-mutable dict (Python frozen dataclass limitation); callers must not mutate after construction; `to_dict()` always returns a deep copy

**Tests — 3 new**
- `test_routine_run_to_dict_outputs_is_deep_copy` — mutating `to_dict()` result does not affect `run.outputs`
- `test_all_output_keys_present` — all 8 expected keys are present in `run.outputs`
- `test_session_state_snapshot_taken_before_brain_trace_write` — explicitly verifies `last_brain_trace` absent from `skill_state` and `skill_state is not session_state`

## Test results
826 passed (up from 823)