### PR TITLE
docs: correct routine test counts after second-pass additions

### DIFF
--- a/docs/status/CURRENT_WORK_STATUS.md
+++ b/docs/status/CURRENT_WORK_STATUS.md
@@ -161,7 +161,7 @@ Implemented:
 - `DAILY_BRIEF_GRAPH` — 8-block Daily Brief RoutineGraph definition
 - `run_daily_brief_routine()` — wraps compose_daily_brief() with named blocks, produces
   (RoutineRun, RoutineReceipt)
-- 58 tests: test_routine_graph.py (32) + test_daily_brief_routine.py (26)
+- 60 tests: test_routine_graph.py (27) + test_daily_brief_routine.py (33)
 - Merged: PR #93 2026-05-03
 
 Boundary: RoutineGraph is planning and record-keeping vocabulary. It does not add

--- a/docs/todo/ACTIVE_TODO.md
+++ b/docs/todo/ACTIVE_TODO.md
@@ -47,7 +47,7 @@
 
 ### Step 6 - Routine and workflow surfaces
 
-- [x] Convert Daily Brief into RoutineGraph v0 — PR #93 2026-05-03; 58 tests; RoutineBlock,
+- [x] Convert Daily Brief into RoutineGraph v0 — PR #93 2026-05-03; 60 tests; RoutineBlock,
       RoutineGraph, RoutineRun, RoutineReceipt frozen non-authorizing dataclasses;
       run_daily_brief_routine() wraps compose_daily_brief() with named blocks + receipt
 - [ ] Capture one everyday workflow demo: plan my week from tasks, notes, calendar context, and priorities, with approval boundary and receipt
@@ -146,7 +146,7 @@ Canonical audit: `docs/future/OPENCLAW_ROBUST_HARDENING_AUDIT_2026-05-01.md`
 
 - RoutineGraph v0 — Daily Brief as first governed routine; RoutineBlock, RoutineGraph,
   RoutineRun, RoutineReceipt frozen non-authorizing dataclasses; run_daily_brief_routine()
-  wraps compose_daily_brief() with 8 named blocks + RoutineReceipt; 58 tests green;
+  wraps compose_daily_brief() with 8 named blocks + RoutineReceipt; 60 tests green;
   PR #93 2026-05-03
 - Stage 6 wiring — Context Pack and BrainTrace live in general_chat_runtime.py; every
   general-chat turn now enforces budget limits, source labels, stale/conflict detection,


### PR DESCRIPTION
Second-pass (PR #95) added 2 routine tests but docs weren't updated.

- 58 → **60** total routine tests
- test_routine_graph.py: 32 → **27**
- test_daily_brief_routine.py: 26 → **33**

No code changes. Docs only.