### PR TITLE
docs: close OpenClaw priority lock

### DIFF
--- a/docs/status/ACTIVE_PRIORITY_LOCK_2026-05-04.md
+++ b/docs/status/ACTIVE_PRIORITY_LOCK_2026-05-04.md
@@ -1,14 +1,14 @@
 # Active Priority Lock — 2026-05-04
 
-Status: active priority override.
+Status: completed.
 
 This is human-maintained priority guidance, not generated runtime truth. Generated runtime docs and actual code remain authoritative if they conflict with this lock.
 
-This document pauses all new work except the OpenClaw hardening path below.
+This document recorded the completed OpenClaw hardening path below.
 
-Last updated: 2026-05-06 after PR #106 merged; first read-only OpenClaw workflow proof selected next.
+Last updated: 2026-05-06 after PR #107 merged; OpenClaw priority-lock sequence complete.
 
-## Only Active Sequence
+## Completed Sequence
 
 ```text
 RequestUnderstanding trust/action-history review card
@@ -19,11 +19,11 @@ RequestUnderstanding trust/action-history review card
 
 ## Meaning
 
-This is a control and safety phase, not a feature-expansion phase.
+This was a control and safety phase, not a feature-expansion phase.
 
-If a task does not directly advance one of the four steps above, it is paused.
+The sequence is now complete. A new workstream must be selected by a new reviewed priority lock before new feature work begins.
 
-## Active Steps
+## Completed Steps
 
 1. RequestUnderstanding trust/action-history review card
    - show request understanding, boundary, risk class, and relevant action/receipt history
@@ -51,32 +51,23 @@ If a task does not directly advance one of the four steps above, it is paused.
    - prove useful OpenClaw work in a read-only workflow
    - recommended proof: Project Foreman Brief or Business Follow-Up Brief using safe/sample/local read-only inputs
    - output must include a receipt/non-action statement showing what did and did not happen
-   - next selected todo as of 2026-05-06
+   - current status: merged in PR #107
 
-## Explicitly Paused
+## Still Not Approved
 
-- Plan My Week UI/API proof capture
-- business workflow demos
-- governed workflow workspace shell
-- workflow object model or workflow template schema
+- broad OpenClaw automation
+- OpenClaw browser/computer-use expansion
+- external write authority
+- email/calendar/Shopify/account actions
+- direct Cap 63 shortcut use
+- autonomous workflow execution
+- claim that OpenClaw has full governed hands
 - Google OAuth connector runtime work
 - Gmail/Calendar/Drive/Contacts runtime connector work
 - Gmail/Calendar/Drive write or send capabilities
-- Cap 64 P5 live signoff + lock
-- Cap 65 P5 live signoff + lock
 - Shopify write operations
-- OpenClaw broad automation
-- OpenClaw browser/computer-use expansion
 - OpenClaw scheduled external actions
-- Voice / ElevenLabs expansion
-- dashboard polish not directly required for the review card or signoff matrix
-- README screenshots/GIFs
-- waitlist activation
-- one-click installer work
-- Auralis social content runtime integration
-- YouTubeLIS runtime integration
-- free-first runtime enforcement beyond existing metadata unless directly required by signoff safety
-- general doc cleanup unless it directly supports this lock
+- workflow automation expansion
 
 ## Hard Boundaries
 
@@ -88,6 +79,6 @@ If a task does not directly advance one of the four steps above, it is paused.
 - No browser/computer-use OpenClaw expansion.
 - No claim that OpenClaw has full governed hands until mediator, envelope, approval, boundary, and receipt proof exists.
 
-## Rule
+## Closure Rule
 
-If it does not move one of the four active steps forward, it is paused.
+Do not start a new workstream from this completed lock. Open a new reviewed priority lock before new feature or runtime expansion work begins.

--- a/docs/status/CURRENT_WORK_STATUS.md
+++ b/docs/status/CURRENT_WORK_STATUS.md
@@ -1,6 +1,6 @@
 # Nova Current Work Status
 
-Last reviewed: 2026-05-06 (first read-only OpenClaw workflow proof branch started)
+Last reviewed: 2026-05-06 (OpenClaw priority lock completed)
 
 This is a human-maintained continuity note for the current development slice.
 
@@ -12,7 +12,7 @@ Generated runtime docs and actual code win if they conflict with this note.
 
 ## Priority Lock (2026-05-04)
 
-Active development is restricted to:
+Completed priority lock sequence:
 
 ```text
 RequestUnderstanding review card
@@ -21,9 +21,9 @@ RequestUnderstanding review card
 → read-only workflow proof
 ```
 
-All other workstreams are intentionally paused to prevent premature expansion before execution governance boundaries are proven.
+The four-step sequence is complete. No new workstream is selected until a new reviewed priority lock is created.
 
-Current next todo: review the first read-only OpenClaw workflow proof.
+Current next todo: create or review the next priority lock before starting new feature/runtime work.
 
 ---
 
@@ -65,6 +65,11 @@ Current next todo: review the first read-only OpenClaw workflow proof.
 - **Priority lock step 3:** OpenClawMediator skeleton merged in PR #106. It adds a non-executing
   envelope -> decision -> receipt boundary with hardened blocked-action matching, no runtime routes,
   no OpenClaw execution, and no Governor/capability/filesystem/browser/network calls.
+- **Priority lock step 4:** First read-only OpenClaw workflow proof merged in PR #107. It proves a
+  deterministic Project Foreman Brief proof output through OpenClawMediator using caller-provided
+  sample input only, explicit allowed input scope, and receipt/non-action statements. No OpenClaw
+  execution, Governor/capability calls, Cap 63 shortcut, filesystem/browser/network action, external
+  account action, or workflow automation expansion was added.
 - Cap 64 remains confirmation-bound local `mailto:` draft only. No SMTP, inbox access, or
   autonomous send.
 - Cap 65 remains read-only Shopify intelligence. No Shopify writes.
@@ -73,12 +78,12 @@ Current next todo: review the first read-only OpenClaw workflow proof.
 
 ## Planning-Only / Future Direction
 
-All future direction remains valid but is currently paused under the priority lock.
+All future direction remains valid but requires a new reviewed priority lock before work starts.
 
 Refer to: `docs/status/ACTIVE_PRIORITY_LOCK_2026-05-04.md`
 
-Near-term sequence:
+Closeout state:
 
-1. Review first read-only OpenClaw workflow proof and proof package.
-2. Confirm it remains sample/local, read-only, mediator-gated, and receipt-backed.
-3. Do not broaden OpenClaw beyond the reviewed proof path.
+1. OpenClaw priority-lock sequence is complete.
+2. Broad OpenClaw automation, browser/computer-use, external writes, email/calendar/Shopify/account actions, direct Cap 63 shortcut use, autonomous workflow execution, and Google connector expansion remain not approved.
+3. Select the next workstream only through a new reviewed priority lock.

--- a/docs/status/OPENCLAW_PRIORITY_LOCK_CLOSEOUT_2026-05-06.md
+++ b/docs/status/OPENCLAW_PRIORITY_LOCK_CLOSEOUT_2026-05-06.md
@@ -1,0 +1,64 @@
+# OpenClaw Priority Lock Closeout - 2026-05-06
+
+Status: complete / awaiting next reviewed priority lock
+
+## Purpose
+
+This document closes the 2026-05-04 OpenClaw priority lock without opening a new workstream.
+
+Generated runtime truth and code remain authoritative. This closeout is human-maintained status documentation only.
+
+## Completed Proof Chain
+
+- PR #103 planning-task preview runtime handoff proof
+- PR #104 RequestUnderstanding review-card payload contract
+- PR #105 local capability signoff matrix
+- PR #106 OpenClawMediator skeleton
+- PR #107 first read-only OpenClaw workflow proof
+
+## Completed Sequence
+
+```text
+RequestUnderstanding trust/action-history review card foundation
+-> local capability signoff matrix
+-> OpenClawMediator skeleton
+-> first read-only OpenClaw workflow proof
+```
+
+## What Was Proven
+
+- planning-task preview behavior is non-authorizing and non-executing
+- RequestUnderstanding review-card payload is immutable and non-authorizing
+- local/runtime capability surfaces were classified before OpenClaw reliance
+- OpenClawMediator exists as an envelope -> decision -> receipt boundary
+- the first read-only Project Foreman Brief proof routes through OpenClawMediator
+- proof output is rendered from caller-provided sample input only
+- receipts/non-action statements record what did and did not happen
+
+## Still Not Approved
+
+- broad OpenClaw automation
+- browser/computer-use expansion
+- filesystem writes
+- external writes
+- email/calendar/Shopify/account actions
+- direct Cap 63 shortcut use
+- autonomous workflow execution
+- Google connector expansion
+- claiming OpenClaw has full governed hands
+
+## Boundary Statement
+
+This closeout does not enable any capability.
+
+This closeout does not grant OpenClaw authority.
+
+This closeout does not approve browser/computer-use.
+
+This closeout does not approve external write actions.
+
+This closeout does not create or approve a new workstream.
+
+## Next Step
+
+Select the next workstream only through a new reviewed priority lock.

--- a/docs/todo/ACTIVE_TODO.md
+++ b/docs/todo/ACTIVE_TODO.md
@@ -4,9 +4,9 @@
 
 Refer to: `docs/status/ACTIVE_PRIORITY_LOCK_2026-05-04.md`
 
-Updated: 2026-05-06 after PR #106 merged.
+Updated: 2026-05-06 after PR #107 merged.
 
-Only active path:
+Completed lock path:
 
 ```text
 RequestUnderstanding trust/action-history review card
@@ -15,28 +15,25 @@ RequestUnderstanding trust/action-history review card
 → first read-only OpenClaw workflow proof
 ```
 
-All other work is paused. If a task does not advance one of these four steps, it is paused.
+The four-step OpenClaw priority lock is complete. No new active workstream is selected in this file.
 
 ---
 
 ## Current Next TODO
 
-Build the first read-only OpenClaw workflow proof.
+Create or review the next priority lock before starting new work.
 
 Purpose:
 
-- prove one narrow workflow through the reviewed OpenClawMediator boundary
-- use safe caller-provided sample/local input only
-- require explicit allowed input scope
-- produce a read-only proof artifact and receipt/non-action statement
-- keep browser/computer-use, filesystem writes, external writes, direct Cap 63 shortcut use, and workflow automation blocked
+- preserve a clean stopping point after the completed OpenClaw hardening sequence
+- avoid silently moving from proof work into broad automation
+- require an explicit reviewed next lock before feature/runtime expansion
 
-Do not broaden OpenClaw beyond this proof path.
+Do not broaden OpenClaw beyond the reviewed proof path without a new priority lock.
 
-Branch/proof targets:
+Closeout reference:
 
-- `nova_backend/src/openclaw/read_only_workflow_proof.py`
-- `docs/demo_proof/2026-05-06_first_read_only_openclaw_workflow/`
+- `docs/status/OPENCLAW_PRIORITY_LOCK_CLOSEOUT_2026-05-06.md`
 
 ## Lock Progress
 
@@ -50,12 +47,23 @@ Branch/proof targets:
   - local capability signoff matrix merged in PR #105
 - Step 3 complete:
   - OpenClawMediator skeleton merged in PR #106
-- Step 4 is now the recommended next work item:
-  - first read-only OpenClaw workflow proof
+- Step 4 complete:
+  - first read-only OpenClaw workflow proof merged in PR #107
+
+## Still Not Approved After Closeout
+
+- broad OpenClaw automation
+- browser/computer-use expansion
+- external writes
+- email/calendar/Shopify/account actions
+- direct Cap 63 shortcut use
+- autonomous workflow execution
+- Google connector expansion
+- claiming OpenClaw has full governed hands
 
 ---
 
-**Historical baseline below is retained for completed-context only. It is not the active sprint while the priority lock is in force.**
+**Historical baseline below is retained for completed-context only. A new reviewed priority lock is required before a new active sprint starts.**
 
 **Updated:** 2026-05-03 (cost posture pass)
 **Previous sprint goal:** Stage 6 — Routine surfaces. Context Pack and BrainTrace now live in prompt path.
@@ -72,7 +80,7 @@ Branch/proof targets:
 - Cost posture metadata — visibility only, no runtime enforcement
 - Google read-only connector foundation plan — planning only, no OAuth/runtime connector
 
-## Paused While Priority Lock Is Active
+## Previously Paused During The Completed Priority Lock
 
 - Plan My Week UI/API proof capture
 - business workflow demos


### PR DESCRIPTION
## Summary

Closes the completed 2026-05-04 OpenClaw priority lock.

Includes:
- marks the four-step lock sequence complete
- adds a closeout note
- preserves boundaries for what remains unapproved
- leaves the next workstream explicitly unselected until a new reviewed lock exists

## Completed chain

- PR #103 planning-task preview runtime handoff proof
- PR #104 RequestUnderstanding review-card payload contract
- PR #105 local capability signoff matrix
- PR #106 OpenClawMediator skeleton
- PR #107 first read-only OpenClaw workflow proof

## Boundary

Docs-only.
No runtime code changes.
No generated runtime truth changes.
No new capabilities.
No broad OpenClaw automation.
No browser/computer-use.
No external writes.
No email/calendar/Shopify/account actions.
No direct Cap 63 shortcut.
No claim that OpenClaw has full governed hands.

## Review goal

Confirm the priority lock is closed cleanly and that no new workstream is selected or implied.