### PR TITLE
docs: select runtime truth audit priority lock

### DIFF
--- a/docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_RUNTIME_TRUTH_AUDIT.md
+++ b/docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_RUNTIME_TRUTH_AUDIT.md
@@ -1,0 +1,76 @@
+# Active Priority Lock - 2026-05-06 Runtime Truth Audit
+
+Status: active priority lock.
+
+This is human-maintained priority guidance, not generated runtime truth. Generated runtime docs and actual code remain authoritative if they conflict with this lock.
+
+This lock selects a narrow verification workstream after the completed OpenClaw priority-lock chain.
+
+## Selected Workstream
+
+```text
+Runtime truth regeneration / audit after OpenClaw proof chain
+```
+
+## Purpose
+
+Verify whether generated runtime truth and human-maintained runtime docs accurately reflect the newly merged OpenClaw governance/proof surfaces.
+
+This is a verification and alignment lock, not a product expansion lock.
+
+## Required Inputs
+
+- PR #103 planning-task preview runtime handoff proof
+- PR #104 RequestUnderstanding review-card payload contract
+- PR #105 local capability signoff matrix
+- PR #106 OpenClawMediator skeleton
+- PR #107 first read-only OpenClaw workflow proof
+- PR #108 OpenClaw priority-lock closeout
+- `docs/current_runtime/CURRENT_RUNTIME_STATE.md`
+- `docs/current_runtime/RUNTIME_CAPABILITY_REFERENCE.md`
+- `docs/current_runtime/RUNTIME_FINGERPRINT.md`
+- `docs/status/OPENCLAW_PRIORITY_LOCK_CLOSEOUT_2026-05-06.md`
+
+## Allowed Work
+
+- run the runtime auditor/generator if needed
+- compare generated runtime truth against code and proof packages
+- update generated runtime docs only through the generator path
+- update human-maintained status/todo docs if they are stale
+- add a small proof/audit package under `docs/demo_proof/` if useful
+- record any mismatch as a blocker or follow-up rather than patching truth by hand
+
+## Not Approved
+
+- no broad OpenClaw automation
+- no browser/computer-use expansion
+- no external writes
+- no email/calendar/Shopify/account actions
+- no direct Cap 63 shortcut use
+- no autonomous workflow execution
+- no Google connector expansion
+- no capability registry expansion
+- no workflow automation expansion
+- no claim that OpenClaw has full governed hands
+
+## Acceptance Gate
+
+This lock is complete only when a reviewable branch answers:
+
+1. Do generated runtime docs need regeneration after PRs #103-#108?
+2. If regenerated, are changes generator-consistent and code-grounded?
+3. Do runtime docs distinguish active runtime surfaces from proof-only/supporting artifacts?
+4. Do docs preserve that OpenClawMediator and first read-only workflow proof do not grant execution authority?
+5. Are any discrepancies listed with exact files and recommended next action?
+
+## Expected Output
+
+A small audit/regeneration PR that either:
+
+- confirms runtime truth is already aligned, or
+- updates generated runtime truth through the generator and records why, or
+- records blockers/discrepancies without manually inflating runtime claims.
+
+## Boundary Rule
+
+If work is not runtime-truth audit/regeneration/alignment, it is outside this lock.

--- a/docs/status/CURRENT_WORK_STATUS.md
+++ b/docs/status/CURRENT_WORK_STATUS.md
@@ -1,6 +1,6 @@
 # Nova Current Work Status
 
-Last reviewed: 2026-05-06 (OpenClaw priority lock completed)
+Last reviewed: 2026-05-06 (runtime truth audit lock selected)
 
 This is a human-maintained continuity note for the current development slice.
 
@@ -10,20 +10,17 @@ Generated runtime docs and actual code win if they conflict with this note.
 
 ---
 
-## Priority Lock (2026-05-04)
+## Priority Lock (2026-05-06)
 
-Completed priority lock sequence:
+Active priority lock:
 
 ```text
-RequestUnderstanding review card
-→ capability signoff matrix
-→ OpenClawMediator skeleton
-→ read-only workflow proof
+Runtime truth regeneration / audit after OpenClaw proof chain
 ```
 
-The four-step sequence is complete. No new workstream is selected until a new reviewed priority lock is created.
+The four-step OpenClaw sequence is complete. The current workstream is limited to runtime truth audit/regeneration/alignment.
 
-Current next todo: create or review the next priority lock before starting new feature/runtime work.
+Current next todo: verify whether generated runtime truth and human-maintained docs need alignment after PRs #103-#108.
 
 ---
 
@@ -39,37 +36,37 @@ Current next todo: create or review the next priority lock before starting new f
   session state, memory, receipts, weather (live via WeatherService), calendar (local ICS via
   CalendarSkill), and email placeholder into 11 sections. Non-authorizing frozen dataclass;
   `execution_performed=False` and `authorization_granted=False` enforced by `__post_init__`.
-- **Stage 3:** Memory Loop — explicit user-initiated remember / review / update / forget / why-used
+- **Stage 3:** Memory Loop - explicit user-initiated remember / review / update / forget / why-used
   with receipts. No silent autosave. Memory does not authorize action. (PR #82 2026-05-02)
-- **Stage 4:** Context Pack — bounded labeled context bridge with source labels, authority labels,
+- **Stage 4:** Context Pack - bounded labeled context bridge with source labels, authority labels,
   budget enforcement, stale/conflict warnings; live-wired into general_chat_runtime.py every turn.
   (PRs #83/#87 2026-05-02)
-- **Stage 5:** Brain Discipline / Trace — 7 mode contracts, classify_mode(), BrainTrace
+- **Stage 5:** Brain Discipline / Trace - 7 mode contracts, classify_mode(), BrainTrace
   non-authorizing frozen dataclass; stored in session_state["last_brain_trace"] each turn;
   execution_performed and authorization_granted always False. (PRs #85/#88 2026-05-02)
-- **Stage 6:** RoutineGraph v0 — RoutineBlock, RoutineGraph, RoutineRun, RoutineReceipt
+- **Stage 6:** RoutineGraph v0 - RoutineBlock, RoutineGraph, RoutineRun, RoutineReceipt
   non-authorizing frozen dataclasses; DAILY_BRIEF_GRAPH; run_daily_brief_routine(). (PR #93 2026-05-03)
-- **Stage 6:** Plan My Week Routine — WeeklyPlan, PlanMyWeekProposal (approval_required=True
+- **Stage 6:** Plan My Week Routine - WeeklyPlan, PlanMyWeekProposal (approval_required=True
   enforced), PlanApprovalRecord; two-phase runner; first RoutineGraph with request_approval block.
   (PR #98 2026-05-03)
-- **Stage 6 step 1:** Cost Posture Metadata — cost_posture field (free/free_tier/paid/unknown_cost)
+- **Stage 6 step 1:** Cost Posture Metadata - cost_posture field (free/free_tier/paid/unknown_cost)
   on all 27 capabilities; validated on load; visible in governance matrix and runtime state doc;
   metadata + visibility only, no runtime enforcement. (PR #99 2026-05-03)
-- **Priority lock step 1 foundation:** Planning-task preview runtime handoff proof merged in PR #103
-  and RequestUnderstanding review-card payload contract merged in PR #104. This establishes a
+- **Completed OpenClaw lock step 1 foundation:** Planning-task preview runtime handoff proof merged in
+  PR #103 and RequestUnderstanding review-card payload contract merged in PR #104. This establishes a
   planning-only, non-authorizing payload foundation for the future visible trust surface. No UI render,
   OpenClaw delegation, capability expansion, persistent history store, or execution authority was added.
-- **Priority lock step 2:** Local capability signoff matrix merged in PR #105. It records read-only
-  evidence and proof requirements for local/runtime surfaces before OpenClaw may rely on them; it does
-  not enable capabilities or grant OpenClaw authority.
-- **Priority lock step 3:** OpenClawMediator skeleton merged in PR #106. It adds a non-executing
-  envelope -> decision -> receipt boundary with hardened blocked-action matching, no runtime routes,
-  no OpenClaw execution, and no Governor/capability/filesystem/browser/network calls.
-- **Priority lock step 4:** First read-only OpenClaw workflow proof merged in PR #107. It proves a
-  deterministic Project Foreman Brief proof output through OpenClawMediator using caller-provided
-  sample input only, explicit allowed input scope, and receipt/non-action statements. No OpenClaw
-  execution, Governor/capability calls, Cap 63 shortcut, filesystem/browser/network action, external
-  account action, or workflow automation expansion was added.
+- **Completed OpenClaw lock step 2:** Local capability signoff matrix merged in PR #105. It records
+  read-only evidence and proof requirements for local/runtime surfaces before OpenClaw may rely on them;
+  it does not enable capabilities or grant OpenClaw authority.
+- **Completed OpenClaw lock step 3:** OpenClawMediator skeleton merged in PR #106. It adds a
+  non-executing envelope -> decision -> receipt boundary with hardened blocked-action matching, no
+  runtime routes, no OpenClaw execution, and no Governor/capability/filesystem/browser/network calls.
+- **Completed OpenClaw lock step 4:** First read-only OpenClaw workflow proof merged in PR #107. It
+  proves a deterministic Project Foreman Brief proof output through OpenClawMediator using
+  caller-provided sample input only, explicit allowed input scope, and receipt/non-action statements.
+  No OpenClaw execution, Governor/capability calls, Cap 63 shortcut, filesystem/browser/network action,
+  external account action, or workflow automation expansion was added.
 - Cap 64 remains confirmation-bound local `mailto:` draft only. No SMTP, inbox access, or
   autonomous send.
 - Cap 65 remains read-only Shopify intelligence. No Shopify writes.
@@ -80,10 +77,10 @@ Current next todo: create or review the next priority lock before starting new f
 
 All future direction remains valid but requires a new reviewed priority lock before work starts.
 
-Refer to: `docs/status/ACTIVE_PRIORITY_LOCK_2026-05-04.md`
+Refer to: `docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_RUNTIME_TRUTH_AUDIT.md`
 
-Closeout state:
+Current lock state:
 
-1. OpenClaw priority-lock sequence is complete.
-2. Broad OpenClaw automation, browser/computer-use, external writes, email/calendar/Shopify/account actions, direct Cap 63 shortcut use, autonomous workflow execution, and Google connector expansion remain not approved.
-3. Select the next workstream only through a new reviewed priority lock.
+1. OpenClaw priority-lock sequence is complete and closed.
+2. Runtime truth regeneration / audit is the only selected next workstream.
+3. Broad OpenClaw automation, browser/computer-use, external writes, email/calendar/Shopify/account actions, direct Cap 63 shortcut use, autonomous workflow execution, and Google connector expansion remain not approved.

--- a/docs/todo/ACTIVE_TODO.md
+++ b/docs/todo/ACTIVE_TODO.md
@@ -1,41 +1,47 @@
 # Active TODO - Nova
 
-## ACTIVE PRIORITY LOCK (2026-05-04)
+## ACTIVE PRIORITY LOCK (2026-05-06)
 
-Refer to: `docs/status/ACTIVE_PRIORITY_LOCK_2026-05-04.md`
+Refer to: `docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_RUNTIME_TRUTH_AUDIT.md`
 
-Updated: 2026-05-06 after PR #107 merged.
+Updated: 2026-05-06 after OpenClaw priority-lock closeout.
 
-Completed lock path:
+Active path:
 
 ```text
-RequestUnderstanding trust/action-history review card
-→ local capability signoff matrix
-→ OpenClawMediator skeleton
-→ first read-only OpenClaw workflow proof
+Runtime truth regeneration / audit after OpenClaw proof chain
 ```
 
-The four-step OpenClaw priority lock is complete. No new active workstream is selected in this file.
+The four-step OpenClaw priority lock is complete. The current selected workstream is a narrow runtime truth audit/regeneration pass.
 
 ---
 
 ## Current Next TODO
 
-Create or review the next priority lock before starting new work.
+Run the runtime truth regeneration / audit pass.
 
 Purpose:
 
-- preserve a clean stopping point after the completed OpenClaw hardening sequence
-- avoid silently moving from proof work into broad automation
-- require an explicit reviewed next lock before feature/runtime expansion
+- verify generated runtime truth after PRs #103-#108
+- confirm code/proof/doc alignment for the new OpenClaw governance surfaces
+- regenerate generated runtime docs only through the generator path if needed
+- record discrepancies without manually inflating runtime claims
 
-Do not broaden OpenClaw beyond the reviewed proof path without a new priority lock.
+Do not broaden OpenClaw or start product/runtime expansion under this lock.
 
-Closeout reference:
+References:
 
+- `docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_RUNTIME_TRUTH_AUDIT.md`
 - `docs/status/OPENCLAW_PRIORITY_LOCK_CLOSEOUT_2026-05-06.md`
 
 ## Lock Progress
+
+Current lock:
+
+- Step 1 pending:
+  - runtime truth regeneration / audit after OpenClaw proof chain
+
+Completed previous lock:
 
 - Step 1 foundation complete:
   - planning-task preview runtime handoff proof merged in PR #103
@@ -66,19 +72,19 @@ Closeout reference:
 **Historical baseline below is retained for completed-context only. A new reviewed priority lock is required before a new active sprint starts.**
 
 **Updated:** 2026-05-03 (cost posture pass)
-**Previous sprint goal:** Stage 6 — Routine surfaces. Context Pack and BrainTrace now live in prompt path.
+**Previous sprint goal:** Stage 6 - Routine surfaces. Context Pack and BrainTrace now live in prompt path.
 **Authority note:** This file is the public task snapshot. Exact runtime truth still comes from generated runtime docs and code.
 
 ## Completed Baseline Before Priority Lock
 
-- Active proof closeout — PASS (Daily Brief, Search Evidence Synthesis, conversation continuity, prior full-suite proof)
-- Stage 3 Memory Loop — explicit remember / review-list / update / forget / why-used with receipts
-- Stage 4 Context Pack — bounded labeled context bridge with proof package
-- Stage 5 Brain discipline and BrainTrace — non-authorizing trace without private chain-of-thought exposure
-- Stage 6 RoutineGraph v0 — Daily Brief routine surface, non-authorizing
-- Plan My Week routine — proposal + approval record + receipt, non-authorizing
-- Cost posture metadata — visibility only, no runtime enforcement
-- Google read-only connector foundation plan — planning only, no OAuth/runtime connector
+- Active proof closeout - PASS (Daily Brief, Search Evidence Synthesis, conversation continuity, prior full-suite proof)
+- Stage 3 Memory Loop - explicit remember / review-list / update / forget / why-used with receipts
+- Stage 4 Context Pack - bounded labeled context bridge with proof package
+- Stage 5 Brain discipline and BrainTrace - non-authorizing trace without private chain-of-thought exposure
+- Stage 6 RoutineGraph v0 - Daily Brief routine surface, non-authorizing
+- Plan My Week routine - proposal + approval record + receipt, non-authorizing
+- Cost posture metadata - visibility only, no runtime enforcement
+- Google read-only connector foundation plan - planning only, no OAuth/runtime connector
 
 ## Previously Paused During The Completed Priority Lock
 


### PR DESCRIPTION
## Summary

Selects the next reviewed priority lock after the completed OpenClaw priority-lock closeout.

The selected workstream is limited to runtime truth regeneration/audit.

Includes:
- `docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_RUNTIME_TRUTH_AUDIT.md`
- updates to `docs/todo/ACTIVE_TODO.md`
- updates to `docs/status/CURRENT_WORK_STATUS.md`

## Boundary

Docs-only priority-lock selection.
No runtime code changes.
No generated runtime truth changes.
No capability registry changes.
No OpenClaw expansion.
No browser/computer-use.
No external writes.
No connector expansion.

## Review goal

Confirm this selects only a runtime truth regeneration/audit pass and does not start feature/runtime expansion.