### PR TITLE
docs: close runtime truth audit lock

### DIFF
--- a/docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_RUNTIME_TRUTH_AUDIT.md
+++ b/docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_RUNTIME_TRUTH_AUDIT.md
@@ -1,12 +1,14 @@
 # Active Priority Lock - 2026-05-06 Runtime Truth Audit
 
-Status: active priority lock.
+Status: completed.
+
+Completed by PR #110: `docs: audit runtime truth after OpenClaw proof`.
 
 This is human-maintained priority guidance, not generated runtime truth. Generated runtime docs and actual code remain authoritative if they conflict with this lock.
 
-This lock selects a narrow verification workstream after the completed OpenClaw priority-lock chain.
+This lock selected a narrow verification workstream after the completed OpenClaw priority-lock chain.
 
-## Selected Workstream
+## Completed Workstream
 
 ```text
 Runtime truth regeneration / audit after OpenClaw proof chain
@@ -14,9 +16,9 @@ Runtime truth regeneration / audit after OpenClaw proof chain
 
 ## Purpose
 
-Verify whether generated runtime truth and human-maintained runtime docs accurately reflect the newly merged OpenClaw governance/proof surfaces.
+Verified whether generated runtime truth and human-maintained runtime docs accurately reflected the newly merged OpenClaw governance/proof surfaces.
 
-This is a verification and alignment lock, not a product expansion lock.
+This was a verification and alignment lock, not a product expansion lock.
 
 ## Required Inputs
 
@@ -31,16 +33,18 @@ This is a verification and alignment lock, not a product expansion lock.
 - `docs/current_runtime/RUNTIME_FINGERPRINT.md`
 - `docs/status/OPENCLAW_PRIORITY_LOCK_CLOSEOUT_2026-05-06.md`
 
-## Allowed Work
+## Completed Actions
 
-- run the runtime auditor/generator if needed
-- compare generated runtime truth against code and proof packages
-- update generated runtime docs only through the generator path
-- update human-maintained status/todo docs if they are stale
-- add a small proof/audit package under `docs/demo_proof/` if useful
-- record any mismatch as a blocker or follow-up rather than patching truth by hand
+- runtime docs were regenerated through `scripts/generate_runtime_docs.py`
+- generated runtime truth changed through the generator path only
+- runtime fingerprint/hash alignment was updated
+- audit evidence was added under `docs/demo_proof/2026-05-06_runtime_truth_audit_after_openclaw/`
+- OpenClawMediator remained documented as non-executing
+- first read-only workflow proof remained documented as non-authorizing
+- proof-artifact over-indexing in generated MOCs was found and corrected
+- `docs/demo_proof/**/raw/*` and `docs/demo_proof/**/screenshots/*` are excluded from generated MOC indexing while proof reports remain browsable
 
-## Not Approved
+## Still Not Approved
 
 - no broad OpenClaw automation
 - no browser/computer-use expansion
@@ -53,24 +57,16 @@ This is a verification and alignment lock, not a product expansion lock.
 - no workflow automation expansion
 - no claim that OpenClaw has full governed hands
 
-## Acceptance Gate
+## Acceptance Gate Result
 
-This lock is complete only when a reviewable branch answers:
+This lock is complete.
 
-1. Do generated runtime docs need regeneration after PRs #103-#108?
-2. If regenerated, are changes generator-consistent and code-grounded?
-3. Do runtime docs distinguish active runtime surfaces from proof-only/supporting artifacts?
-4. Do docs preserve that OpenClawMediator and first read-only workflow proof do not grant execution authority?
-5. Are any discrepancies listed with exact files and recommended next action?
-
-## Expected Output
-
-A small audit/regeneration PR that either:
-
-- confirms runtime truth is already aligned, or
-- updates generated runtime truth through the generator and records why, or
-- records blockers/discrepancies without manually inflating runtime claims.
+1. Generated runtime docs needed regeneration after PRs #103-#108 for fingerprint/hash alignment.
+2. Regenerated changes were generator-consistent and code-grounded.
+3. Runtime docs and MOCs now better distinguish active runtime surfaces from proof-only/supporting artifacts.
+4. Docs preserve that OpenClawMediator and first read-only workflow proof do not grant execution authority.
+5. The discovered discrepancy, proof raw/screenshot over-indexing in generated MOCs, was recorded and fixed through generator policy.
 
 ## Boundary Rule
 
-If work is not runtime-truth audit/regeneration/alignment, it is outside this lock.
+Do not start new feature or runtime expansion from this completed lock. Select the next workstream only through a new reviewed priority lock.

--- a/docs/status/CURRENT_WORK_STATUS.md
+++ b/docs/status/CURRENT_WORK_STATUS.md
@@ -1,6 +1,6 @@
 # Nova Current Work Status
 
-Last reviewed: 2026-05-06 (runtime truth audit lock selected)
+Last reviewed: 2026-05-06 (runtime truth audit completed)
 
 This is a human-maintained continuity note for the current development slice.
 
@@ -10,17 +10,17 @@ Generated runtime docs and actual code win if they conflict with this note.
 
 ---
 
-## Priority Lock (2026-05-06)
+## Priority Lock Status (2026-05-06)
 
-Active priority lock:
+Completed priority lock:
 
 ```text
 Runtime truth regeneration / audit after OpenClaw proof chain
 ```
 
-The four-step OpenClaw sequence is complete. The current workstream is limited to runtime truth audit/regeneration/alignment.
+The four-step OpenClaw sequence and the follow-up runtime truth audit are complete.
 
-Current next todo: review the runtime truth audit branch and confirm generated runtime docs/proof evidence before selecting another lock.
+Current next todo: select the next reviewed priority lock before starting new work.
 
 ---
 
@@ -67,6 +67,10 @@ Current next todo: review the runtime truth audit branch and confirm generated r
   caller-provided sample input only, explicit allowed input scope, and receipt/non-action statements.
   No OpenClaw execution, Governor/capability calls, Cap 63 shortcut, filesystem/browser/network action,
   external account action, or workflow automation expansion was added.
+- **Completed runtime truth audit lock:** Runtime truth regeneration/audit merged in PR #110. Runtime
+  docs were regenerated through the generator path, runtime fingerprint/hash alignment updated, proof
+  artifact over-indexing in generated MOCs corrected, and OpenClawMediator/read-only workflow proof
+  remained documented as non-executing/non-authorizing.
 - Cap 64 remains confirmation-bound local `mailto:` draft only. No SMTP, inbox access, or
   autonomous send.
 - Cap 65 remains read-only Shopify intelligence. No Shopify writes.
@@ -82,7 +86,7 @@ Refer to: `docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_RUNTIME_TRUTH_AUDIT.md`
 Current lock state:
 
 1. OpenClaw priority-lock sequence is complete and closed.
-2. Runtime truth regeneration / audit is the only selected next workstream.
-3. The active audit branch regenerated runtime docs through the generator path, found fingerprint/hash alignment changes only, and preserved proof/runtime authority boundaries.
+2. Runtime truth regeneration / audit merged in PR #110 and is complete.
+3. Runtime docs were regenerated through the generator path and remained code-grounded.
 4. The audit surfaced proof-artifact over-indexing in generated MOCs; the overlay generator now excludes `docs/demo_proof/**/raw/*` and `docs/demo_proof/**/screenshots/*` from topical/runtime aggregation while keeping proof reports browsable.
 5. Broad OpenClaw automation, browser/computer-use, external writes, email/calendar/Shopify/account actions, direct Cap 63 shortcut use, autonomous workflow execution, and Google connector expansion remain not approved.

--- a/docs/todo/ACTIVE_TODO.md
+++ b/docs/todo/ACTIVE_TODO.md
@@ -1,34 +1,36 @@
 # Active TODO - Nova
 
-## ACTIVE PRIORITY LOCK (2026-05-06)
+## PRIORITY LOCK STATUS (2026-05-06)
 
 Refer to: `docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_RUNTIME_TRUTH_AUDIT.md`
 
-Updated: 2026-05-06 after OpenClaw priority-lock closeout.
+Updated: 2026-05-06 after runtime truth audit completion.
 
-Active path:
+Completed workstream:
 
 ```text
 Runtime truth regeneration / audit after OpenClaw proof chain
 ```
 
-The four-step OpenClaw priority lock is complete. The current selected workstream is a narrow runtime truth audit/regeneration pass.
+The four-step OpenClaw priority lock and the runtime truth audit/regeneration pass are complete.
+
+No new active workstream is selected.
 
 ---
 
 ## Current Next TODO
 
-Review the runtime truth regeneration / audit pass.
+Create or review the next priority lock before starting new work.
 
-Purpose:
+Current completed audit outcomes:
 
-- confirm generated runtime docs changed only through the generator path
-- confirm runtime truth changes are code-grounded and generator-consistent
-- confirm proof-only OpenClaw artifacts were not inflated into runtime authority
-- confirm raw proof evidence and screenshot folders are excluded from generated runtime/reference topical MOCs
-- review recorded diff/proof evidence before selecting another lock
+- generated runtime docs changed only through the generator path
+- runtime truth changes remained code-grounded and generator-consistent
+- proof-only OpenClaw artifacts were not inflated into runtime authority
+- raw proof evidence and screenshot folders are excluded from generated runtime/reference topical MOCs
+- runtime truth audit merged in PR #110
 
-Do not broaden OpenClaw or start product/runtime expansion under this lock.
+Do not broaden OpenClaw or start product/runtime expansion without a new reviewed priority lock.
 
 References:
 
@@ -37,10 +39,10 @@ References:
 
 ## Lock Progress
 
-Current lock:
+Completed runtime truth audit lock:
 
-- Step 1 pending:
-  - runtime truth regeneration / audit after OpenClaw proof chain is on the active audit branch
+- Step 1 complete:
+  - runtime truth regeneration / audit after OpenClaw proof chain merged in PR #110
 
 Completed previous lock:
 


### PR DESCRIPTION
## Summary

Closes the completed runtime truth audit lock after PR #110 merged.

Updates stale human-maintained status/todo wording so the repo state now correctly reflects:
- runtime truth audit completed
- runtime truth audit merged in PR #110
- no new workstream currently selected
- next step requires a new reviewed priority lock

## Updated files

- docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_RUNTIME_TRUTH_AUDIT.md
- docs/status/CURRENT_WORK_STATUS.md
- docs/todo/ACTIVE_TODO.md

## Boundary

Docs-only.
No runtime code changes.
No generated runtime truth changes.
No MOC regeneration.
No new priority lock selection.

## Review goal

Confirm repo continuity docs now accurately match the already-merged runtime truth audit state.