### PR TITLE
docs: pause trust card and add web news ui proof lock

### DIFF
--- a/docs/PROOFS/UI-Commands/README.md
+++ b/docs/PROOFS/UI-Commands/README.md
@@ -1,0 +1,129 @@
+# UI / Buttons / Commands Proof Package
+
+Status: active proof/stress-test scaffold.
+
+This folder exists to verify that Nova's visible UI, buttons, commands, widgets, dashboard routes, and governed command flows work as expected before broader automation or product expansion.
+
+Active lock:
+
+`docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_WEB_NEWS_PROOF_STRESS_TEST.md`
+
+---
+
+## Purpose
+
+Confirm the user-facing Nova system behaves correctly across:
+
+- dashboard UI
+- buttons
+- command entry
+- widgets
+- governed capability triggers
+- navigation surfaces
+- status indicators
+- error states
+- disabled/blocked action states
+- trust/receipt display behavior where present
+
+The proof goal is not only that features exist, but that every visible control either works, clearly refuses, or clearly explains setup/disabled status.
+
+---
+
+## Required UI Proof Areas
+
+- dashboard load / startup state
+- chat input / send command
+- news page / news widget
+- weather widget
+- calendar snapshot widget
+- web search result widget
+- open website / article button
+- headline summary command
+- intelligence brief command
+- multi-source report command
+- topic map command
+- story tracker update/view commands
+- memory governance UI/commands
+- analysis document UI/commands
+- screen capture / screen analysis controls
+- speak text / voice output controls
+- volume / media / brightness controls
+- open file/folder command
+- email draft command
+- Shopify intelligence command
+- OpenClaw template/operator surfaces, read-only only
+- settings/status/control center surfaces
+- error banners / degraded-state messages
+- confirmation prompts
+- blocked-action messages
+
+---
+
+## Required Button/Command Rule
+
+Every visible button or command must fall into exactly one state:
+
+1. Works and produces the expected governed result.
+2. Is disabled/hidden because it is not currently approved.
+3. Refuses safely with a clear reason.
+4. Shows setup-required state with exact missing dependency.
+5. Shows degraded/error state without implying execution occurred.
+
+No button should silently fail.
+
+No button should imply authority it does not have.
+
+No command should bypass GovernorMediator for actions.
+
+---
+
+## Stress-Test Focus
+
+Stress tests should simulate:
+
+- rapid repeated clicks
+- double-submit commands
+- missing backend
+- stale WebSocket connection
+- partial backend startup
+- expired/invalid bridge token
+- missing provider/API keys
+- missing local files/folders
+- missing microphone/TTS dependencies
+- failed network requests
+- invalid URLs
+- blocked paths
+- malformed widget payloads
+- stale news/weather/calendar cache
+- empty search results
+- large result sets
+- prompt injection inside web/article content
+- attempts to trigger blocked actions through UI text
+- command aliases and typo handling
+- browser-open refusal/confirmation flows
+- external-write coercion attempts
+
+---
+
+## Proof Output Requirements
+
+Each proof should record:
+
+- surface tested
+- command/button tested
+- expected behavior
+- actual behavior
+- authority boundary
+- setup dependencies
+- evidence location
+- pass/fail/blocked/setup-dependent status
+- screenshot/log reference if available
+- regression test recommendation
+
+---
+
+## Boundary
+
+This proof package does not approve new capabilities, broad automation, browser/computer-use, external writes, autonomous workflows, or direct Cap 63 shortcut use.
+
+It verifies current UI and command surfaces only.

--- a/docs/PROOFS/Web-News-Reporting/README.md
+++ b/docs/PROOFS/Web-News-Reporting/README.md
@@ -1,0 +1,98 @@
+# Web / News / Reporting Proof Package
+
+Status: active proof/stress-test scaffold.
+
+This folder exists to validate the current governed information/reporting surfaces before broader automation or Trust Panel expansion.
+
+Active lock:
+
+`docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_WEB_NEWS_PROOF_STRESS_TEST.md`
+
+---
+
+## Target Capability Family
+
+- governed_web_search
+- open_website
+- headline_summary
+- multi_source_reporting
+- intelligence_brief
+- topic_memory_map
+- story_tracker_update
+- story_tracker_view
+
+---
+
+## Required Proof Areas
+
+- governed web search proof
+- browser/article open proof
+- headline summary proof
+- cluster comparison proof
+- multi-source report proof
+- intelligence brief proof
+- story tracker proof
+- topic map proof
+- governance-boundary proof
+- hallucination/drift review
+- adversarial stress testing
+- prompt-injection review
+- latency/reliability review
+- stale-cache behavior review
+- source-label and credibility review
+
+---
+
+## Required Boundaries
+
+The proof package must not:
+
+- approve OpenClaw execution expansion
+- approve browser/computer-use expansion
+- approve autonomous workflows
+- approve direct Cap 63 shortcut use
+- approve external writes
+- approve Google connector runtime expansion
+- overstate runtime truth
+
+---
+
+## Suggested Folder Layout
+
+```text
+Web-News-Reporting/
+├── README.md
+├── governed_web_search/
+├── open_website/
+├── headline_summary/
+├── multi_source_reporting/
+├── intelligence_brief/
+├── topic_memory_map/
+├── story_tracker/
+├── governance_boundaries/
+├── adversarial_tests/
+├── codex_simulations/
+├── hallucination_review/
+├── stale_cache_review/
+├── latency_reliability/
+└── source_credibility/
+```
+
+---
+
+## Codex Stress-Test Focus
+
+Stress tests should focus on:
+
+- conflicting narratives
+- hallucinated source attribution
+- fake/stale news
+- duplicate-story collapse
+- malformed feeds
+- prompt injection from article content
+- governance bypass attempts
+- oversized topic clusters
+- story-linking instability
+- network failure behavior
+- credibility ranking drift
+- cache inconsistency

--- a/docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_TRUST_REVIEW_CARD_MVP.md
+++ b/docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_TRUST_REVIEW_CARD_MVP.md
@@ -1,6 +1,8 @@
 # Active Priority Lock - 2026-05-06 Trust Review Card MVP
 
-Status: active.
+Status: paused by user request.
+
+Paused by: `docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_WEB_NEWS_PROOF_STRESS_TEST.md`
 
 This is human-maintained priority guidance, not generated runtime truth.
 
@@ -8,7 +10,7 @@ Generated runtime docs and actual code remain authoritative if they conflict wit
 
 ---
 
-## Active Workstream
+## Paused Workstream
 
 ```text
 Trust Review Card MVP / Visible Non-Action Receipt Surface
@@ -16,7 +18,24 @@ Trust Review Card MVP / Visible Non-Action Receipt Surface
 
 ---
 
-## Purpose
+## Pause Reason
+
+The user requested a pause on current work to create a proof folder and stress-test plan for the governed web/news/reporting capability family:
+
+- governed web search
+- governed browser/article opening
+- headline summaries
+- headline cluster comparison
+- structured multi-source reports
+- compact intelligence briefs
+- story tracking over time
+- topic maps of headline themes
+
+No Trust Review Card implementation work should proceed until the new proof/stress-test lock is complete or explicitly superseded.
+
+---
+
+## Original Purpose
 
 Create the first visible trust/review surface for the planning-only and read-only governance work completed in the prior OpenClaw proof chain.
 
@@ -28,21 +47,7 @@ This is not an automation-expansion lock.
 
 ---
 
-## Required Inputs
-
-- PR #103 planning-task preview runtime handoff proof
-- PR #104 RequestUnderstanding review-card payload contract
-- PR #105 local capability signoff matrix
-- PR #106 OpenClawMediator skeleton
-- PR #107 first read-only OpenClaw workflow proof
-- PR #110 runtime truth regeneration / audit
-- `docs/status/LOCAL_CAPABILITY_SIGNOFF_MATRIX_2026-05-06.md`
-- `docs/status/CURRENT_WORK_STATUS.md`
-- `docs/todo/ACTIVE_TODO.md`
-
----
-
-## Allowed Scope
+## Original Allowed Scope
 
 - render a minimal read-only RequestUnderstanding review card in the UI
 - render non-action / non-authorizing status fields clearly
@@ -58,7 +63,7 @@ This is not an automation-expansion lock.
 
 ---
 
-## Explicitly Not Approved
+## Still Not Approved While Paused
 
 - no OpenClaw execution
 - no direct Cap 63 shortcut use
@@ -75,23 +80,6 @@ This is not an automation-expansion lock.
 
 ---
 
-## Acceptance Gates
+## Resume Rule
 
-This lock is complete only if:
-
-1. The visible trust/review card remains read-only.
-2. The UI cannot imply execution or authorization occurred.
-3. Receipts clearly state what did not happen.
-4. OpenClawMediator remains non-executing and non-authorizing.
-5. No new runtime authority path bypasses GovernorMediator.
-6. No broad OpenClaw automation is added.
-7. Runtime docs remain generator-grounded if updated.
-8. Final audit confirms no authority drift.
-
----
-
-## Boundary Rule
-
-Do not use this lock to start broad OpenClaw automation or workflow expansion.
-
-This lock is only for the visible trust/review surface associated with the existing planning-only and read-only proof infrastructure.
+Resume this lock only after the web/news/reporting proof/stress-test lock is complete, closed, or explicitly superseded by a reviewed priority-lock update.

--- a/docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_WEB_NEWS_PROOF_STRESS_TEST.md
+++ b/docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_WEB_NEWS_PROOF_STRESS_TEST.md
@@ -1,4 +1,4 @@
-# Active Priority Lock - 2026-05-06 Web / News / Reporting Proof + Stress Test
+# Active Priority Lock - 2026-05-06 Web / News / Reporting + UI Proof / Stress Test
 
 Status: active.
 
@@ -11,28 +11,41 @@ Generated runtime docs and actual code remain authoritative if they conflict wit
 ## Active Workstream
 
 ```text
-Governed Web / News / Reporting Capability Proof + Stress Test
+Governed Web / News / Reporting + UI / Commands Proof + Stress Test
 ```
 
 ---
 
 ## Purpose
 
-Pause current Trust Review Card MVP implementation work and create a dedicated proof and stress-test package for the current governed web/news/reporting capability family.
+Pause current Trust Review Card MVP implementation work and create a dedicated proof and stress-test package for:
 
-The goal is to:
+1. governed web/news/reporting capability surfaces
+2. visible Nova UI/button/command behavior
+3. governance-boundary reliability
+4. stress/failure behavior
+5. simulation/adversarial testing
 
-1. Verify current runtime behavior matches claims.
-2. Create durable proof artifacts.
-3. Create simulation/stress-test plans for Codex/Claude/reviewer systems.
-4. Identify runtime drift, hallucination risk, governance bypass risk, and reliability gaps.
-5. Validate these capabilities before broader automation or Trust Panel expansion.
+The goal is to verify that Nova's visible surfaces actually behave correctly before broader automation or Trust Panel expansion.
+
+This includes verifying that all visible buttons, commands, widgets, and UI states either:
+
+- work correctly
+- refuse safely
+- clearly explain setup/dependency requirements
+- clearly show blocked/not-approved status
+
+No silent failures.
+
+No misleading authority.
 
 ---
 
 ## Capability Scope
 
-This lock focuses only on:
+This lock focuses on:
+
+### Governed information/reporting surfaces
 
 - governed_web_search
 - open_website
@@ -42,6 +55,20 @@ This lock focuses only on:
 - topic_memory_map
 - story_tracker_update
 - story_tracker_view
+
+### UI / command surfaces
+
+- dashboard UI
+- buttons
+- command entry
+- widgets
+- navigation
+- settings/status surfaces
+- confirmation prompts
+- degraded/error states
+- blocked-action messaging
+- voice/media/system controls
+- analysis/memory/document surfaces
 
 Related supporting systems allowed for proof context:
 
@@ -66,15 +93,20 @@ Nova should be able to:
 - build compact intelligence briefs
 - track stories over time
 - show topic maps of current headline themes
+- render working UI buttons/commands for approved surfaces
+- clearly refuse or explain unavailable surfaces
+- show setup-required states accurately
+- surface degraded/error states honestly
 
 ---
 
 ## Required Deliverables
 
-Create a dedicated proof folder tree for:
+Create/update proof folder trees for:
 
 ```text
 docs/PROOFS/Web-News-Reporting/
+docs/PROOFS/UI-Commands/
 ```
 
 Expected proof areas:
@@ -87,6 +119,8 @@ Expected proof areas:
 - intelligence brief proof
 - story tracker proof
 - topic map proof
+- UI/button proof
+- command proof
 - failure-mode proof
 - governance-boundary proof
 - hallucination/drift review
@@ -94,6 +128,8 @@ Expected proof areas:
 - adversarial prompt suite
 - latency/reliability observations
 - source-label and credibility verification
+- WebSocket/connectivity failure handling
+- degraded-state UI handling
 
 ---
 
@@ -115,6 +151,14 @@ Use Codex/Claude/reviewer systems to simulate:
 - network failure/retry paths
 - oversized result sets
 - prompt injection attempts from article content
+- rapid repeated button presses
+- stale WebSocket state
+- partial backend startup
+- missing API/provider configuration
+- malformed widget payloads
+- blocked-action UI coercion attempts
+- command alias/typo handling
+- degraded-state rendering
 
 ---
 
@@ -142,13 +186,15 @@ This lock is complete only if:
 4. Source-label and credibility behavior are verified.
 5. Hallucination/drift observations are documented.
 6. Codex/Claude stress-test prompts exist.
-7. No authority drift or execution expansion occurs.
-8. Runtime truth claims remain grounded.
+7. Visible UI/button/command behavior is verified.
+8. Buttons/commands either work, refuse safely, or clearly explain setup/block state.
+9. No authority drift or execution expansion occurs.
+10. Runtime truth claims remain grounded.
 
 ---
 
 ## Boundary Rule
 
-This lock exists to validate and pressure-test existing governed information/reporting surfaces.
+This lock exists to validate and pressure-test existing governed information/reporting and UI/command surfaces.
 
 It does not authorize broader automation or OpenClaw execution expansion.

--- a/docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_WEB_NEWS_PROOF_STRESS_TEST.md
+++ b/docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_WEB_NEWS_PROOF_STRESS_TEST.md
@@ -1,0 +1,154 @@
+# Active Priority Lock - 2026-05-06 Web / News / Reporting Proof + Stress Test
+
+Status: active.
+
+This is human-maintained priority guidance, not generated runtime truth.
+
+Generated runtime docs and actual code remain authoritative if they conflict with this lock.
+
+---
+
+## Active Workstream
+
+```text
+Governed Web / News / Reporting Capability Proof + Stress Test
+```
+
+---
+
+## Purpose
+
+Pause current Trust Review Card MVP implementation work and create a dedicated proof and stress-test package for the current governed web/news/reporting capability family.
+
+The goal is to:
+
+1. Verify current runtime behavior matches claims.
+2. Create durable proof artifacts.
+3. Create simulation/stress-test plans for Codex/Claude/reviewer systems.
+4. Identify runtime drift, hallucination risk, governance bypass risk, and reliability gaps.
+5. Validate these capabilities before broader automation or Trust Panel expansion.
+
+---
+
+## Capability Scope
+
+This lock focuses only on:
+
+- governed_web_search
+- open_website
+- headline_summary
+- multi_source_reporting
+- intelligence_brief
+- topic_memory_map
+- story_tracker_update
+- story_tracker_view
+
+Related supporting systems allowed for proof context:
+
+- NetworkMediator
+- LedgerWriter
+- Search Evidence Synthesis
+- News snapshot cache
+- Weather/news/current-information flows
+- analysis_document for proof writeups
+
+---
+
+## Required Proof Targets
+
+Nova should be able to:
+
+- search the web through a governed network path
+- open websites/articles through a governed browser-opening route
+- summarize headlines
+- compare headline clusters
+- build structured multi-source reports
+- build compact intelligence briefs
+- track stories over time
+- show topic maps of current headline themes
+
+---
+
+## Required Deliverables
+
+Create a dedicated proof folder tree for:
+
+```text
+docs/PROOFS/Web-News-Reporting/
+```
+
+Expected proof areas:
+
+- governed web search proof
+- browser/article open proof
+- headline summary proof
+- cluster comparison proof
+- multi-source report proof
+- intelligence brief proof
+- story tracker proof
+- topic map proof
+- failure-mode proof
+- governance-boundary proof
+- hallucination/drift review
+- Codex simulation/stress-test prompts
+- adversarial prompt suite
+- latency/reliability observations
+- source-label and credibility verification
+
+---
+
+## Stress-Test Goals
+
+Use Codex/Claude/reviewer systems to simulate:
+
+- malformed headline feeds
+- conflicting article narratives
+- stale caches
+- duplicate stories
+- fake or low-credibility sources
+- governance bypass attempts
+- direct execution coercion attempts
+- hallucinated source attribution
+- topic-map instability
+- story-linking errors
+- article-open failures
+- network failure/retry paths
+- oversized result sets
+- prompt injection attempts from article content
+
+---
+
+## Explicitly Not Approved
+
+- no OpenClaw execution expansion
+- no browser/computer-use expansion
+- no external writes
+- no autonomous workflow execution
+- no direct Cap 63 shortcut use
+- no Google connector runtime expansion
+- no capability registry expansion
+- no Trust Review Card implementation work while paused
+- no installer work
+
+---
+
+## Acceptance Gates
+
+This lock is complete only if:
+
+1. Each listed capability has at least one concrete proof artifact.
+2. Governance boundaries are explicitly tested.
+3. Failure-mode behavior is documented.
+4. Source-label and credibility behavior are verified.
+5. Hallucination/drift observations are documented.
+6. Codex/Claude stress-test prompts exist.
+7. No authority drift or execution expansion occurs.
+8. Runtime truth claims remain grounded.
+
+---
+
+## Boundary Rule
+
+This lock exists to validate and pressure-test existing governed information/reporting surfaces.
+
+It does not authorize broader automation or OpenClaw execution expansion.

--- a/docs/status/CURRENT_WORK_STATUS.md
+++ b/docs/status/CURRENT_WORK_STATUS.md
@@ -1,6 +1,6 @@
 # Nova Current Work Status
 
-Last reviewed: 2026-05-06 (Trust Review Card MVP lock active)
+Last reviewed: 2026-05-06 (Web/News/Reporting + UI/Commands proof lock active)
 
 This is a human-maintained continuity note for the current development slice.
 
@@ -15,20 +15,20 @@ Generated runtime docs and actual code win if they conflict with this note.
 Current active priority lock:
 
 ```text
+Governed Web / News / Reporting + UI / Commands Proof + Stress Test
+```
+
+Refer to: `docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_WEB_NEWS_PROOF_STRESS_TEST.md`
+
+Paused prior priority lock:
+
+```text
 Trust Review Card MVP / Visible Non-Action Receipt Surface
 ```
 
-Refer to: `docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_TRUST_REVIEW_CARD_MVP.md`
+The Trust Review Card MVP lock is paused by user request. No Trust Review Card implementation work should proceed until the active proof/stress-test lock is complete, closed, or explicitly superseded.
 
-Completed prior priority lock:
-
-```text
-Runtime truth regeneration / audit after OpenClaw proof chain
-```
-
-The four-step OpenClaw sequence and the follow-up runtime truth audit are complete.
-
-The current active workstream is limited to a visible, read-only trust/review card surface for existing planning-only and read-only proof infrastructure.
+The current active workstream is limited to validating and pressure-testing existing governed information/reporting and visible UI/button/command surfaces.
 
 This is not an automation-expansion lock.
 
@@ -82,11 +82,13 @@ This is not an automation-expansion lock.
   docs were regenerated through the generator path, runtime fingerprint/hash alignment updated, proof
   artifact over-indexing in generated MOCs corrected, and OpenClawMediator/read-only workflow proof
   remained documented as non-executing/non-authorizing.
-- **Active Trust Review Card MVP lock:** selected in PR #112. It permits only a visible, read-only
-  RequestUnderstanding/trust review surface and non-action receipt display work. It does not approve
-  OpenClaw execution, direct Cap 63 shortcut use, browser/computer-use, filesystem writes, external
-  writes, email/calendar/Shopify/account actions, autonomous workflow execution, Google connector
-  runtime work, capability registry expansion, workflow automation expansion, scheduler expansion, or installer work.
+- **Paused Trust Review Card MVP lock:** selected in PR #112 and paused by the active Web/News/Reporting
+  + UI/Commands proof/stress-test lock. It should not be implemented while this proof lock is active.
+- **Active Web/News/Reporting + UI/Commands proof lock:** validates existing governed information,
+  reporting, dashboard, button, command, widget, confirmation, degraded-state, and blocked-action surfaces.
+  It does not approve new capabilities, OpenClaw execution expansion, browser/computer-use expansion,
+  external writes, autonomous workflow execution, Google connector runtime expansion, capability registry
+  expansion, scheduler expansion, or installer work.
 - Cap 64 remains confirmation-bound local `mailto:` draft only. No SMTP, inbox access, or
   autonomous send.
 - Cap 65 remains read-only Shopify intelligence. No Shopify writes.
@@ -95,14 +97,15 @@ This is not an automation-expansion lock.
 
 ## Planning-Only / Future Direction
 
-All future direction outside the active Trust Review Card MVP lock requires a separate reviewed priority lock before work starts.
+All future direction outside the active Web/News/Reporting + UI/Commands proof/stress-test lock requires a separate reviewed priority lock before work starts.
 
-Refer to: `docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_TRUST_REVIEW_CARD_MVP.md`
+Refer to: `docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_WEB_NEWS_PROOF_STRESS_TEST.md`
 
 Current lock state:
 
 1. OpenClaw priority-lock sequence is complete and closed.
 2. Runtime truth regeneration / audit merged in PR #110 and is complete.
-3. Trust Review Card MVP priority lock was selected in PR #112 and is now active.
-4. The active lock allows only a visible read-only trust/review card surface and related non-action receipt display/proof work.
-5. Broad OpenClaw automation, browser/computer-use, external writes, email/calendar/Shopify/account actions, direct Cap 63 shortcut use, autonomous workflow execution, Google connector expansion, capability registry expansion, workflow automation expansion, scheduler expansion, and installer work remain not approved.
+3. Trust Review Card MVP priority lock was selected in PR #112 and is now paused.
+4. Web/News/Reporting + UI/Commands proof/stress-test lock is active.
+5. The active lock allows only proof scaffolding, proof artifacts, simulations, stress-test prompts, and audit work for existing surfaces.
+6. Broad OpenClaw automation, browser/computer-use expansion, external writes, email/calendar/Shopify/account actions, direct Cap 63 shortcut use, autonomous workflow execution, Google connector expansion, capability registry expansion, workflow automation expansion, scheduler expansion, installer work, and Trust Review Card implementation remain not approved.

--- a/docs/todo/ACTIVE_TODO.md
+++ b/docs/todo/ACTIVE_TODO.md
@@ -2,17 +2,17 @@
 
 ## PRIORITY LOCK STATUS (2026-05-06)
 
-Refer to: `docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_TRUST_REVIEW_CARD_MVP.md`
+Refer to: `docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_WEB_NEWS_PROOF_STRESS_TEST.md`
 
-Updated: 2026-05-06 after Trust Review Card MVP lock selection.
+Updated: 2026-05-06 after Web/News/Reporting + UI/Commands proof/stress-test lock selection.
 
 Current active workstream:
 
 ```text
-Trust Review Card MVP / Visible Non-Action Receipt Surface
+Governed Web / News / Reporting + UI / Commands Proof + Stress Test
 ```
 
-This lock permits only a visible, read-only trust/review card surface and related non-action receipt display/proof work.
+This lock permits only proof scaffolding, proof artifacts, simulations, stress-test prompts, and audit work for existing governed information/reporting and visible UI/command surfaces.
 
 This is not an automation-expansion lock.
 
@@ -20,21 +20,44 @@ This is not an automation-expansion lock.
 
 ## Current Next TODO
 
-Implement the active Trust Review Card MVP priority lock.
+Build the proof/stress-test package for governed web/news/reporting and visible UI/button/command surfaces.
 
-Allowed implementation scope:
+Required proof focus:
 
-- render a minimal read-only RequestUnderstanding review card in the UI
-- render non-action / non-authorizing status fields clearly
-- render receipt fields such as:
-  - what happened
-  - what did not happen
-  - blocked actions
-  - history unavailable / not available states
-- add tests proving the trust card cannot imply execution occurred
-- improve trust wording clarity where needed
-- regenerate runtime docs through the generator path if runtime truth changes
-- audit wording for OpenClaw overstatement or authority drift
+- governed web search
+- browser/article open behavior
+- headline summaries
+- headline cluster comparison
+- multi-source reports
+- intelligence briefs
+- topic maps
+- story tracking
+- dashboard buttons/widgets
+- command entry flows
+- degraded/error states
+- confirmation prompts
+- blocked-action behavior
+- setup-required states
+- voice/media/system controls
+- analysis/memory/document surfaces
+
+Required stress-test focus:
+
+- malformed feeds
+- conflicting narratives
+- stale caches
+- duplicate stories
+- fake/low-credibility sources
+- governance bypass attempts
+- hallucinated attribution
+- topic-map instability
+- network failure paths
+- rapid repeated button presses
+- stale WebSocket state
+- malformed widget payloads
+- blocked-action coercion attempts
+- degraded-state rendering
+- prompt injection from article content
 
 Current completed audit outcomes:
 
@@ -43,29 +66,40 @@ Current completed audit outcomes:
 - proof-only OpenClaw artifacts were not inflated into runtime authority
 - raw proof evidence and screenshot folders are excluded from generated runtime/reference topical MOCs
 - runtime truth audit merged in PR #110
-- Trust Review Card MVP lock selected in PR #112
+- Trust Review Card MVP lock selected in PR #112 and later paused by user request
+- Web/News/Reporting + UI/Commands proof/stress-test lock created
 
 Do not broaden OpenClaw or start product/runtime expansion outside the active reviewed priority lock.
 
 References:
 
-- `docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_TRUST_REVIEW_CARD_MVP.md`
+- `docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_WEB_NEWS_PROOF_STRESS_TEST.md`
 - `docs/status/OPENCLAW_PRIORITY_LOCK_CLOSEOUT_2026-05-06.md`
+- `docs/PROOFS/Web-News-Reporting/README.md`
+- `docs/PROOFS/UI-Commands/README.md`
 
 ## Lock Progress
 
 Current active lock:
 
-- Trust Review Card MVP / Visible Non-Action Receipt Surface
+- Governed Web / News / Reporting + UI / Commands Proof + Stress Test
 
 Planned lock targets:
 
-- minimal visible read-only UI trust/review card render
-- receipt/non-action rendering
-- history unavailable / not available state rendering
-- trust wording clarity pass
-- tests proving the UI cannot imply execution
-- audit for authority drift after implementation
+- governed information/reporting proof artifacts
+- UI/button/command proof artifacts
+- Codex/Claude simulation prompts
+- adversarial test suite
+- degraded-state verification
+- governance-boundary verification
+- hallucination/drift review
+- source credibility review
+- WebSocket/connectivity failure handling review
+- regression-test recommendations
+
+Paused prior lock:
+
+- Trust Review Card MVP / Visible Non-Action Receipt Surface
 
 Completed runtime truth audit lock:
 
@@ -99,47 +133,8 @@ Completed previous lock:
 - workflow automation expansion
 - scheduler expansion
 - installer work
+- Trust Review Card implementation while paused
 
 ---
 
-**Historical baseline below is retained for completed-context only. Work outside the active Trust Review Card MVP lock requires a new reviewed priority lock.**
-
-**Updated:** 2026-05-03 (cost posture pass)
-**Previous sprint goal:** Stage 6 - Routine surfaces. Context Pack and BrainTrace now live in prompt path.
-**Authority note:** This file is the public task snapshot. Exact runtime truth still comes from generated runtime docs and code.
-
-## Completed Baseline Before Priority Lock
-
-- Active proof closeout - PASS (Daily Brief, Search Evidence Synthesis, conversation continuity, prior full-suite proof)
-- Stage 3 Memory Loop - explicit remember / review-list / update / forget / why-used with receipts
-- Stage 4 Context Pack - bounded labeled context bridge with proof package
-- Stage 5 Brain discipline and BrainTrace - non-authorizing trace without private chain-of-thought exposure
-- Stage 6 RoutineGraph v0 - Daily Brief routine surface, non-authorizing
-- Plan My Week routine - proposal + approval record + receipt, non-authorizing
-- Cost posture metadata - visibility only, no runtime enforcement
-- Google read-only connector foundation plan - planning only, no OAuth/runtime connector
-
-## Previously Paused During The Completed Priority Lock
-
-- Plan My Week UI/API proof capture
-- business workflow demos
-- governed workflow workspace shell
-- workflow object model or workflow template schema
-- Google OAuth connector runtime work
-- Gmail/Calendar/Drive/Contacts runtime connector work
-- Gmail/Calendar/Drive write or send capabilities
-- Cap 64 P5 live signoff + lock
-- Cap 65 P5 live signoff + lock
-- Shopify write operations
-- OpenClaw broad automation
-- OpenClaw browser/computer-use expansion
-- OpenClaw scheduled external actions
-- Voice / ElevenLabs expansion
-- dashboard polish not directly required for the review card or signoff matrix
-- README screenshots/GIFs
-- waitlist activation
-- one-click installer work
-- Auralis social content runtime integration
-- YouTubeLIS runtime integration
-- free-first runtime enforcement beyond existing metadata unless directly required by signoff safety
-- general doc cleanup unless it directly supports this lock
+**Historical baseline below is retained for completed-context only. Work outside the active Web/News/Reporting + UI/Commands proof/stress-test lock requires a new reviewed priority lock.**


### PR DESCRIPTION
## Summary

Pauses the current Trust Review Card MVP implementation track by user request and selects a new proof/stress-test lock focused on existing governed web/news/reporting and UI/button/command surfaces.

Adds:
- `docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_WEB_NEWS_PROOF_STRESS_TEST.md`
- `docs/PROOFS/Web-News-Reporting/README.md`
- `docs/PROOFS/UI-Commands/README.md`

Updates:
- `docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_TRUST_REVIEW_CARD_MVP.md`
- `docs/status/CURRENT_WORK_STATUS.md`
- `docs/todo/ACTIVE_TODO.md`

## Boundary

Docs-only.
No runtime code changes.
No generated runtime truth hand-edits.
No capability registry changes.
No OpenClaw execution expansion.
No browser/computer-use expansion.
No external writes.
No autonomous workflow expansion.
No direct Cap 63 shortcut approval.
No Google connector runtime expansion.

## Review goal

Confirm the repo now pauses Trust Review Card implementation and makes Web/News/Reporting + UI/Commands Proof + Stress Test the single active workstream.