### PR TITLE
docs: harden web UI proof lock wording

### DIFF
--- a/docs/PROOFS/UI-Commands/README.md
+++ b/docs/PROOFS/UI-Commands/README.md
@@ -77,6 +77,47 @@ No command should bypass GovernorMediator for actions.
 
 ---
 
+## Verification Matrix
+
+Use this matrix shape for each UI/button/command proof pass:
+
+| Surface | Button/Command | Expected Result | Actual Result | Governance Boundary | Status | Evidence | Regression Risk |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| TBD | TBD | TBD | TBD | TBD | not-yet-tested | TBD | TBD |
+
+Allowed statuses:
+
+- `pass`
+- `fail`
+- `blocked`
+- `setup-dependent`
+- `not-yet-tested`
+- `not-applicable`
+
+---
+
+## Truthful UI Rule
+
+UI must not imply:
+
+- execution occurred when it did not
+- authority was granted when it was not
+- data is live/current when stale
+- a command succeeded when degraded
+- a capability exists when setup is missing
+- a blocked action is available
+
+Preferred visible states:
+
+- `working`
+- `blocked`
+- `setup-required`
+- `degraded`
+- `offline`
+- `unsupported`
+
+---
+
 ## Stress-Test Focus
 
 Stress tests should simulate:

--- a/docs/PROOFS/Web-News-Reporting/README.md
+++ b/docs/PROOFS/Web-News-Reporting/README.md
@@ -43,6 +43,25 @@ Active lock:
 
 ---
 
+## Required Evidence Pattern
+
+Each proof should record:
+
+- what was requested
+- what happened
+- what did not happen
+- governance boundary
+- source labels and freshness caveats
+- failure/degraded behavior
+- hallucination observations
+- prompt-injection observations when relevant
+- raw transcript or payload evidence
+- screenshot only if it proves a visible UI state
+
+Expected outcome is truthful behavior, not guaranteed success.
+
+---
+
 ## Required Boundaries
 
 The proof package must not:

--- a/docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_WEB_NEWS_PROOF_STRESS_TEST.md
+++ b/docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_WEB_NEWS_PROOF_STRESS_TEST.md
@@ -39,6 +39,8 @@ No silent failures.
 
 No misleading authority.
 
+Expected outcome is truthful behavior, not guaranteed success.
+
 ---
 
 ## Capability Scope
@@ -160,6 +162,30 @@ Use Codex/Claude/reviewer systems to simulate:
 - command alias/typo handling
 - degraded-state rendering
 
+The pass condition for stress tests is honest bounded behavior: work when approved and available, clear refusal when blocked, exact setup/degraded messaging when dependencies are missing, and no implication that execution or authority occurred when it did not.
+
+---
+
+## Truthful UI Rule
+
+Nova UI must never imply:
+
+- execution occurred when it did not
+- authority was granted when it was not
+- data is live/current when stale
+- a command succeeded when degraded
+- a capability exists when setup is missing
+- a blocked action is available
+
+Standard visible states for this lock:
+
+- `working`
+- `blocked`
+- `setup-required`
+- `degraded`
+- `offline`
+- `unsupported`
+
 ---
 
 ## Explicitly Not Approved
@@ -188,8 +214,10 @@ This lock is complete only if:
 6. Codex/Claude stress-test prompts exist.
 7. Visible UI/button/command behavior is verified.
 8. Buttons/commands either work, refuse safely, or clearly explain setup/block state.
-9. No authority drift or execution expansion occurs.
-10. Runtime truth claims remain grounded.
+9. Proofs distinguish success, failure, blocked, setup-dependent, degraded, unsupported, and not-yet-tested behavior.
+10. UI/runtime/docs mismatches are recorded as blockers or follow-ups instead of papered over.
+11. No authority drift or execution expansion occurs.
+12. Runtime truth claims remain grounded.
 
 ---
 
@@ -198,3 +226,13 @@ This lock is complete only if:
 This lock exists to validate and pressure-test existing governed information/reporting and UI/command surfaces.
 
 It does not authorize broader automation or OpenClaw execution expansion.
+
+## Next After This Lock
+
+After this proof/stress-test lock closes, the recommended next reviewed workstream is:
+
+```text
+Trust Review Card MVP / Visible Non-Action Receipt Surface
+```
+
+Do not resume Trust Review Card implementation from this lock.

--- a/docs/todo/ACTIVE_TODO.md
+++ b/docs/todo/ACTIVE_TODO.md
@@ -38,6 +38,7 @@ Required proof focus:
 - confirmation prompts
 - blocked-action behavior
 - setup-required states
+- truthful UI state labels: working, blocked, setup-required, degraded, offline, unsupported
 - voice/media/system controls
 - analysis/memory/document surfaces
 
@@ -58,6 +59,8 @@ Required stress-test focus:
 - blocked-action coercion attempts
 - degraded-state rendering
 - prompt injection from article content
+
+Expected proof outcome is truthful behavior, not guaranteed success.
 
 Current completed audit outcomes:
 


### PR DESCRIPTION
## Summary

Hardens the already-active Web/News/Reporting + UI/Commands proof/stress-test lock wording after the duplicate stale Codex branch was superseded.

Adds/clarifies:
- Truthful UI Rule
- standard visible states: working, blocked, setup-required, degraded, offline, unsupported
- UI verification matrix expectations
- stress-test pass condition: truthful bounded behavior, not guaranteed success
- sharper acceptance gates
- Next After This Lock points back to Trust Review Card MVP

## Boundary

Docs-only.
No runtime code changes.
No generated runtime truth hand-edits.
No capability registry changes.
No OpenClaw execution expansion.
No browser/computer-use expansion.
No external writes.
No autonomous workflow expansion.
No direct Cap 63 shortcut approval.
No Google connector runtime expansion.

## Review goal

Confirm this only hardens proof/stress-test wording and does not alter runtime authority or active scope.