### PR TITLE
docs: sync proof library progress after PR 119

### DIFF
--- a/docs/status/CURRENT_WORK_STATUS.md
+++ b/docs/status/CURRENT_WORK_STATUS.md
@@ -1,6 +1,6 @@
 # Nova Current Work Status
 
-Last reviewed: 2026-05-06 (Web/News/Reporting + UI/Commands proof lock active)
+Last reviewed: 2026-05-07 (proof library progress sync after PR #119)
 
 This is a human-maintained continuity note for the current development slice.
 
@@ -31,6 +31,8 @@ The Trust Review Card MVP lock is paused by user request. No Trust Review Card i
 The current active workstream is limited to validating and pressure-testing existing governed information/reporting and visible UI/button/command surfaces.
 
 This is not an automation-expansion lock.
+
+PR #119 materially expanded the proof/evidence library, but it did not close the active lock.
 
 ---
 
@@ -89,6 +91,11 @@ This is not an automation-expansion lock.
   It does not approve new capabilities, OpenClaw execution expansion, browser/computer-use expansion,
   external writes, autonomous workflow execution, Google connector runtime expansion, capability registry
   expansion, scheduler expansion, or installer work.
+- **PR #119 proof-library expansion:** merged the Web/News proof library index, case-level proof files,
+  adversarial prompt suite, master UI/button/command verification matrix, friction logs, blocker logs,
+  regression recommendations, and evidence links. Generated MOCs/runtime-doc indexes were refreshed
+  through the generator path because proof docs were added to the indexed documentation surface; runtime
+  authority/capability behavior was not expanded.
 - Cap 64 remains confirmation-bound local `mailto:` draft only. No SMTP, inbox access, or
   autonomous send.
 - Cap 65 remains read-only Shopify intelligence. No Shopify writes.
@@ -107,5 +114,7 @@ Current lock state:
 2. Runtime truth regeneration / audit merged in PR #110 and is complete.
 3. Trust Review Card MVP priority lock was selected in PR #112 and is now paused.
 4. Web/News/Reporting + UI/Commands proof/stress-test lock is active.
-5. The active lock allows only proof scaffolding, proof artifacts, simulations, stress-test prompts, and audit work for existing surfaces.
-6. Broad OpenClaw automation, browser/computer-use expansion, external writes, email/calendar/Shopify/account actions, direct Cap 63 shortcut use, autonomous workflow execution, Google connector expansion, capability registry expansion, workflow automation expansion, scheduler expansion, installer work, and Trust Review Card implementation remain not approved.
+5. PR #119 added the first evidence-backed proof library and UI verification matrix for the active lock.
+6. The active lock still remains open because stale-cache/provider-failure fixtures, contradictory-reporting fixtures, source-credibility fixtures, malformed-widget proof, rapid-click/double-submit proof, and Browser Use screenshot/click-path proof still need additional evidence.
+7. The active lock allows only proof scaffolding, proof artifacts, simulations, stress-test prompts, and audit work for existing surfaces.
+8. Broad OpenClaw automation, browser/computer-use expansion, external writes, email/calendar/Shopify/account actions, direct Cap 63 shortcut use, autonomous workflow execution, Google connector expansion, capability registry expansion, workflow automation expansion, scheduler expansion, installer work, and Trust Review Card implementation remain not approved.

--- a/docs/todo/ACTIVE_TODO.md
+++ b/docs/todo/ACTIVE_TODO.md
@@ -1,10 +1,10 @@
 # Active TODO - Nova
 
-## PRIORITY LOCK STATUS (2026-05-06)
+## PRIORITY LOCK STATUS (2026-05-07)
 
 Refer to: `docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_WEB_NEWS_PROOF_STRESS_TEST.md`
 
-Updated: 2026-05-06 after Web/News/Reporting + UI/Commands proof/stress-test lock selection.
+Updated: 2026-05-07 after PR #119 added the Web/News proof library, case files, adversarial prompt suite, master UI verification matrix, and generator-consistent MOC/runtime-doc refresh.
 
 Current active workstream:
 
@@ -16,13 +16,28 @@ This lock permits only proof scaffolding, proof artifacts, simulations, stress-t
 
 This is not an automation-expansion lock.
 
+PR #119 improved proof-library coverage, but it did not close the active proof/stress-test lock.
+
 ---
 
 ## Current Next TODO
 
-Build the proof/stress-test package for governed web/news/reporting and visible UI/button/command surfaces.
+Build the next proof/stress-test pass for remaining governed web/news/reporting and visible UI/button/command gaps.
 
-Required proof focus:
+Highest-priority remaining proof gaps:
+
+- stale-cache fixtures
+- provider-failure fixtures
+- contradictory-reporting fixtures
+- source-credibility fixtures
+- rapid-click / double-submit UI behavior
+- malformed-widget payload behavior
+- Browser Use screenshot/click-path proof after runtime asset setup is fixed
+- broader visual UI/button coverage beyond command-path evidence
+
+Expected proof outcome is truthful behavior, not guaranteed success.
+
+Required proof focus retained from the active lock:
 
 - governed web search
 - browser/article open behavior
@@ -42,7 +57,7 @@ Required proof focus:
 - voice/media/system controls
 - analysis/memory/document surfaces
 
-Required stress-test focus:
+Required stress-test focus retained from the active lock:
 
 - malformed feeds
 - conflicting narratives
@@ -60,17 +75,17 @@ Required stress-test focus:
 - degraded-state rendering
 - prompt injection from article content
 
-Expected proof outcome is truthful behavior, not guaranteed success.
-
-Current completed audit outcomes:
+Current completed audit/proof outcomes:
 
 - generated runtime docs changed only through the generator path
 - runtime truth changes remained code-grounded and generator-consistent
 - proof-only OpenClaw artifacts were not inflated into runtime authority
-- raw proof evidence and screenshot folders are excluded from generated runtime/reference topical MOCs
+- raw proof evidence and screenshot folders are excluded from generated runtime/reference topical MOCs where appropriate
 - runtime truth audit merged in PR #110
 - Trust Review Card MVP lock selected in PR #112 and later paused by user request
-- Web/News/Reporting + UI/Commands proof/stress-test lock created
+- Web/News/Reporting + UI/Commands proof/stress-test lock created in PR #114
+- Web/News proof library, case-level proof files, adversarial prompt suite, and master UI/button/command matrix merged in PR #119
+- PR #119 organized already-captured raw evidence into reviewer-readable proof cases and refreshed generated MOCs/runtime-doc indexes through the generator path
 
 Do not broaden OpenClaw or start product/runtime expansion outside the active reviewed priority lock.
 
@@ -79,7 +94,10 @@ References:
 - `docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_WEB_NEWS_PROOF_STRESS_TEST.md`
 - `docs/status/OPENCLAW_PRIORITY_LOCK_CLOSEOUT_2026-05-06.md`
 - `docs/PROOFS/Web-News-Reporting/README.md`
+- `docs/PROOFS/Web-News-Reporting/PROOF_LIBRARY_INDEX.md`
+- `docs/PROOFS/Web-News-Reporting/adversarial_tests/PROMPT_SUITE_2026-05-07.md`
 - `docs/PROOFS/UI-Commands/README.md`
+- `docs/PROOFS/UI-Commands/MASTER_UI_VERIFICATION_MATRIX_2026-05-07.md`
 
 ## Lock Progress
 
@@ -87,18 +105,25 @@ Current active lock:
 
 - Governed Web / News / Reporting + UI / Commands Proof + Stress Test
 
-Planned lock targets:
+Completed under current lock:
 
-- governed information/reporting proof artifacts
-- UI/button/command proof artifacts
-- Codex/Claude simulation prompts
-- adversarial test suite
-- degraded-state verification
-- governance-boundary verification
-- hallucination/drift review
-- source credibility review
-- WebSocket/connectivity failure handling review
-- regression-test recommendations
+- proof package scaffolds created
+- Web/News proof library index created
+- case-level proof files created for governed web search, open website/article behavior, headline summaries, multi-source reporting/intelligence brief, topic map/story tracker, and governance/adversarial/degraded behavior
+- seeded adversarial prompt suite created
+- master UI/button/command verification matrix created
+- generator-consistent MOC/runtime-doc refresh completed after proof docs were added
+
+Still open under current lock:
+
+- stale-cache/provider-failure fixtures
+- contradictory reporting and timeline-drift fixtures
+- source credibility fixtures
+- rapid-click/double-submit proof
+- malformed-widget proof
+- Browser Use screenshot/click-path proof after asset setup is fixed
+- broader visual UI/button proof beyond command-path evidence
+- final lock closeout review
 
 Paused prior lock:
 


### PR DESCRIPTION
## Summary

Synchronizes human-maintained continuity docs after PR #119 merged the Web/News proof library and UI verification matrix.

Updates:
- `docs/status/CURRENT_WORK_STATUS.md`
- `docs/todo/ACTIVE_TODO.md`

## What this records

- PR #119 added proof-library progress, case files, adversarial prompt suite, and master UI/button/command matrix.
- Generated MOCs/runtime-doc indexes changed because proof docs were indexed, not because runtime authority changed.
- The active Web/News/Reporting + UI/Commands proof lock remains open.
- Remaining gaps are still explicit: stale-cache/provider-failure fixtures, contradictory-reporting fixtures, source-credibility fixtures, malformed-widget proof, rapid-click/double-submit proof, Browser Use screenshot/click-path proof, and broader visual UI/button coverage.

## Boundary

Docs-only.
No runtime code changes.
No generated runtime truth hand-edits.
No capability changes.
No OpenClaw expansion.
No browser/computer-use expansion.
No external writes.
No automation expansion.