### PR TITLE
docs: sync status after web news stress fixtures

### DIFF
--- a/docs/status/CURRENT_WORK_STATUS.md
+++ b/docs/status/CURRENT_WORK_STATUS.md
@@ -1,6 +1,6 @@
 # Nova Current Work Status
 
-Last reviewed: 2026-05-07 (proof library progress sync after PR #119)
+Last reviewed: 2026-05-07 (stress fixture progress sync after PR #121)
 
 This is a human-maintained continuity note for the current development slice.
 
@@ -32,7 +32,11 @@ The current active workstream is limited to validating and pressure-testing exis
 
 This is not an automation-expansion lock.
 
-PR #119 materially expanded the proof/evidence library, but it did not close the active lock.
+PR #119 materially expanded the proof/evidence library.
+
+PR #121 added deterministic stress fixtures for contradictory reporting, duplicate/prior-state topic
+mapping, and split-topic headline comparison. It reduced those proof gaps, but it did not close the
+active lock.
 
 ---
 
@@ -96,6 +100,12 @@ PR #119 materially expanded the proof/evidence library, but it did not close the
   regression recommendations, and evidence links. Generated MOCs/runtime-doc indexes were refreshed
   through the generator path because proof docs were added to the indexed documentation surface; runtime
   authority/capability behavior was not expanded.
+- **PR #121 deterministic stress fixtures:** added test-backed Web/News/Reporting stress fixtures for
+  contradictory multi-source reporting, duplicate/prior-state topic-map weighting, and split-topic
+  headline comparison. It recorded focused verification of `24 passed` for the news intelligence suite
+  and `23 passed` for the adjacent web search/search synthesis/story tracker slice. It did not add a
+  capability, OpenClaw expansion, browser/computer-use expansion, external writes, autonomous workflow
+  expansion, direct Cap 63 shortcut use, or live-network dependency in the fixture tests.
 - Cap 64 remains confirmation-bound local `mailto:` draft only. No SMTP, inbox access, or
   autonomous send.
 - Cap 65 remains read-only Shopify intelligence. No Shopify writes.
@@ -115,6 +125,8 @@ Current lock state:
 3. Trust Review Card MVP priority lock was selected in PR #112 and is now paused.
 4. Web/News/Reporting + UI/Commands proof/stress-test lock is active.
 5. PR #119 added the first evidence-backed proof library and UI verification matrix for the active lock.
-6. The active lock still remains open because stale-cache/provider-failure fixtures, contradictory-reporting fixtures, source-credibility fixtures, malformed-widget proof, rapid-click/double-submit proof, and Browser Use screenshot/click-path proof still need additional evidence.
-7. The active lock allows only proof scaffolding, proof artifacts, simulations, stress-test prompts, and audit work for existing surfaces.
-8. Broad OpenClaw automation, browser/computer-use expansion, external writes, email/calendar/Shopify/account actions, direct Cap 63 shortcut use, autonomous workflow execution, Google connector expansion, capability registry expansion, workflow automation expansion, scheduler expansion, installer work, and Trust Review Card implementation remain not approved.
+6. PR #121 reduced the contradiction and duplicate/split-topic proof gaps with deterministic fixtures.
+7. The active lock still remains open because stale-cache/provider-failure fixtures, source-credibility fixtures, malformed-widget proof, rapid-click/double-submit proof, broader visual UI/button proof, and Browser Use screenshot/click-path proof still need additional evidence.
+8. The next highest-ROI branch should focus on stale-cache/provider-failure plus source-credibility matrix fixtures.
+9. The active lock allows only proof scaffolding, proof artifacts, simulations, stress-test prompts, and audit work for existing surfaces.
+10. Broad OpenClaw automation, browser/computer-use expansion, external writes, email/calendar/Shopify/account actions, direct Cap 63 shortcut use, autonomous workflow execution, Google connector expansion, capability registry expansion, workflow automation expansion, scheduler expansion, installer work, and Trust Review Card implementation remain not approved.

--- a/docs/todo/ACTIVE_TODO.md
+++ b/docs/todo/ACTIVE_TODO.md
@@ -4,7 +4,7 @@
 
 Refer to: `docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_WEB_NEWS_PROOF_STRESS_TEST.md`
 
-Updated: 2026-05-07 after PR #119 added the Web/News proof library, case files, adversarial prompt suite, master UI verification matrix, and generator-consistent MOC/runtime-doc refresh.
+Updated: 2026-05-07 after PR #121 added deterministic Web/News stress fixtures for contradictory reporting, duplicate/prior-state topic maps, and split-topic headline comparison.
 
 Current active workstream:
 
@@ -16,24 +16,32 @@ This lock permits only proof scaffolding, proof artifacts, simulations, stress-t
 
 This is not an automation-expansion lock.
 
-PR #119 improved proof-library coverage, but it did not close the active proof/stress-test lock.
+PR #119 improved proof-library coverage.
+
+PR #121 reduced the contradiction and duplicate/split-topic proof gaps with deterministic tests and proof evidence, but it did not close the active proof/stress-test lock.
 
 ---
 
 ## Current Next TODO
 
-Build the next proof/stress-test pass for remaining governed web/news/reporting and visible UI/button/command gaps.
+Build the next proof/stress-test pass for remaining governed web/news/reporting truthfulness gaps.
 
 Highest-priority remaining proof gaps:
 
-- stale-cache fixtures
-- provider-failure fixtures
-- contradictory-reporting fixtures
-- source-credibility fixtures
+- stale-cache/provider-failure fixtures
+- source-credibility matrix fixtures
+- freshness labeling
+- confidence lowering under weak/old/untrusted sources
 - rapid-click / double-submit UI behavior
 - malformed-widget payload behavior
 - Browser Use screenshot/click-path proof after runtime asset setup is fixed
 - broader visual UI/button coverage beyond command-path evidence
+
+Recommended next branch:
+
+```text
+proof/stale-provider-credibility-fixtures
+```
 
 Expected proof outcome is truthful behavior, not guaranteed success.
 
@@ -86,6 +94,9 @@ Current completed audit/proof outcomes:
 - Web/News/Reporting + UI/Commands proof/stress-test lock created in PR #114
 - Web/News proof library, case-level proof files, adversarial prompt suite, and master UI/button/command matrix merged in PR #119
 - PR #119 organized already-captured raw evidence into reviewer-readable proof cases and refreshed generated MOCs/runtime-doc indexes through the generator path
+- PR #121 added deterministic stress fixtures for contradictory reporting, duplicate/prior-state topic-map behavior, and split-topic headline comparison
+- PR #121 recorded `24 passed` for `nova_backend/tests/executors/test_news_intelligence_executor.py`
+- PR #121 recorded `23 passed` for the adjacent web search / search synthesis / story tracker slice
 
 Do not broaden OpenClaw or start product/runtime expansion outside the active reviewed priority lock.
 
@@ -113,12 +124,16 @@ Completed under current lock:
 - seeded adversarial prompt suite created
 - master UI/button/command verification matrix created
 - generator-consistent MOC/runtime-doc refresh completed after proof docs were added
+- contradictory reporting fixture added and verified
+- duplicate/prior-state topic-map fixture added and verified
+- split-topic headline comparison fixture added and verified
 
 Still open under current lock:
 
 - stale-cache/provider-failure fixtures
-- contradictory reporting and timeline-drift fixtures
-- source credibility fixtures
+- source-credibility matrix fixtures
+- freshness labeling and confidence lowering under weak/old/untrusted sources
+- timeline-drift fixtures
 - rapid-click/double-submit proof
 - malformed-widget proof
 - Browser Use screenshot/click-path proof after asset setup is fixed


### PR DESCRIPTION
Updates the human-maintained continuity docs after PR #121.

Changes:
- records that PR #121 added deterministic Web/News stress fixtures
- notes contradiction and duplicate/split-topic proof gaps were reduced
- keeps the active proof/stress-test lock open
- points the next highest-ROI branch at stale-cache/provider-failure plus source-credibility matrix fixtures
- preserves the no-authority-expansion boundary

Docs-only. No runtime code, generated runtime truth, capability registry, OpenClaw, browser/computer-use, external-write, or workflow automation changes.