### PR TITLE
docs: add web news ui proof lock closeout review

### DIFF
--- a/.agent_context/current_priority.md
+++ b/.agent_context/current_priority.md
@@ -1,18 +1,32 @@
 # Current Priority
 
-Current priority remains:
+Current priority:
 
 ```text
-Cap 16 web-search answer quality + conversation coherence proof
+Trust Review Card MVP / Visible Non-Action Receipt Surface
 ```
 
-Do not jump to Cap 64 P5, Shopify write work, OpenClaw browser automation, or broad advanced features until the conversation/search proof path is stable.
+Status:
+
+```text
+resumed after qualified closeout of the Web/News/Reporting + UI/Commands Proof + Stress Test lock
+```
+
+The Web/News/UI proof lock is qualified closed. Browser Use screenshot/click-path proof, high-frequency browser event replay, broader visual UI proof, deeper widget-specific fuzzing, and timeline-drift fixtures are carried forward as proof debt, not as approval for browser/computer-use expansion.
+
+Next branch:
+
+```text
+feature/trust-review-card-mvp
+```
 
 Near-term focus:
 
-1. Cap 16 CPU-budget/search reliability
-2. conversation/search proof re-run
-3. public demo capture
-4. then Cap 64 P5 live signoff
+1. Build the narrow Trust Review Card MVP as a visible non-action receipt surface.
+2. Show what Nova understood, what it can/cannot do, whether execution is authorized, whether confirmation is required, and why no action happened.
+3. Preserve no-authority boundaries: no new capability, no OpenClaw expansion, no browser/computer-use, no external writes, no autonomous workflows, no direct Cap 63 shortcut.
+4. Keep Browser Use screenshot/click-path proof as separate proof-infrastructure debt.
+
+Do not jump to Cap 64 P5, Shopify write work, OpenClaw browser automation, broad advanced features, scheduler/installer work, or external-write workflows until the Trust Review Card MVP branch is reviewed and merged.
 
 This file is a working agent context note. Exact runtime truth still comes from code and generated runtime docs.

--- a/docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_WEB_NEWS_PROOF_STRESS_TEST.md
+++ b/docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_WEB_NEWS_PROOF_STRESS_TEST.md
@@ -1,6 +1,10 @@
 # Active Priority Lock - 2026-05-06 Web / News / Reporting + UI Proof / Stress Test
 
-Status: active.
+Status: qualified closed as of 2026-05-07.
+
+Closeout review: `docs/status/WEB_NEWS_UI_PROOF_LOCK_CLOSEOUT_REVIEW_2026-05-07.md`
+
+Browser Use screenshot/click-path proof remains explicitly blocked by runtime asset setup and is carried forward as proof-infrastructure debt, not as runtime authority or hidden success.
 
 This is human-maintained priority guidance, not generated runtime truth.
 
@@ -197,7 +201,7 @@ Standard visible states for this lock:
 - no direct Cap 63 shortcut use
 - no Google connector runtime expansion
 - no capability registry expansion
-- no Trust Review Card implementation work while paused
+- no Trust Review Card implementation work under this completed proof/stress-test lock
 - no installer work
 
 ---
@@ -223,16 +227,16 @@ This lock is complete only if:
 
 ## Boundary Rule
 
-This lock exists to validate and pressure-test existing governed information/reporting and UI/command surfaces.
+This lock existed to validate and pressure-test existing governed information/reporting and UI/command surfaces.
 
-It does not authorize broader automation or OpenClaw execution expansion.
+It did not authorize broader automation or OpenClaw execution expansion.
 
 ## Next After This Lock
 
-After this proof/stress-test lock closes, the recommended next reviewed workstream is:
+After this proof/stress-test lock's qualified closeout, the recommended next reviewed workstream is:
 
 ```text
 Trust Review Card MVP / Visible Non-Action Receipt Surface
 ```
 
-Do not resume Trust Review Card implementation from this lock.
+Trust Review Card implementation should resume only from its own narrow MVP branch, not by expanding this completed proof/stress-test lock.

--- a/docs/status/CURRENT_WORK_STATUS.md
+++ b/docs/status/CURRENT_WORK_STATUS.md
@@ -1,6 +1,6 @@
 # Nova Current Work Status
 
-Last reviewed: 2026-05-07 (malformed widget / rapid-submit proof progress)
+Last reviewed: 2026-05-07 (Web/News/UI proof lock qualified closeout)
 
 This is a human-maintained continuity note for the current development slice.
 
@@ -12,7 +12,7 @@ Generated runtime docs and actual code win if they conflict with this note.
 
 ## Priority Lock Status (2026-05-06)
 
-Current active priority lock:
+Most recently active priority lock:
 
 ```text
 Governed Web / News / Reporting + UI / Commands Proof + Stress Test
@@ -20,38 +20,52 @@ Governed Web / News / Reporting + UI / Commands Proof + Stress Test
 
 Refer to: `docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_WEB_NEWS_PROOF_STRESS_TEST.md`
 
-Paused prior priority lock:
+Closeout review:
+
+```text
+docs/status/WEB_NEWS_UI_PROOF_LOCK_CLOSEOUT_REVIEW_2026-05-07.md
+```
+
+Closeout status:
+
+```text
+qualified closed / screenshot proof explicitly blocked
+```
+
+Current active priority lock may now resume:
 
 ```text
 Trust Review Card MVP / Visible Non-Action Receipt Surface
 ```
 
-The Trust Review Card MVP lock is paused by user request. No Trust Review Card implementation work should proceed until the active proof/stress-test lock is complete, closed, or explicitly superseded.
+The Trust Review Card MVP lock was paused by user request while the Web/News/Reporting + UI/Commands proof/stress-test lock ran. With the qualified closeout recorded, Trust Review Card MVP may resume through its own narrow branch.
 
-The current active workstream is limited to validating and pressure-testing existing governed information/reporting and visible UI/button/command surfaces.
+The completed proof/stress-test workstream was limited to validating and pressure-testing existing governed information/reporting and visible UI/button/command surfaces.
 
-This is not an automation-expansion lock.
+This closeout is not an automation-expansion approval.
 
 PR #119 materially expanded the proof/evidence library.
 
 PR #121 added deterministic stress fixtures for contradictory reporting, duplicate/prior-state topic
-mapping, and split-topic headline comparison. It reduced those proof gaps, but it did not close the
-active lock.
+mapping, and split-topic headline comparison. It reduced those proof gaps.
 
 The current stale/provider/credibility fixture pass adds deterministic search evidence coverage for
 stale timestamps, malformed/degraded provider output, and weak/untrusted source credibility signals.
-It further reduces proof gaps, but still does not close the active lock.
+It further reduced proof gaps.
 
 The dashboard stale/degraded rendering pass adds visible search-widget rendering for the new evidence
 metadata: provider status, freshness status, source credibility rows, and empty degraded search state.
-It further reduces UI truthfulness gaps, but still does not close the active lock because screenshot and
-rapid-click/double-submit proof remain open.
+It further reduced UI truthfulness gaps.
 
 The malformed widget / rapid-submit proof pass adds a visible unsupported dashboard-message fallback and
 contract proof for overlapping send blocks, single-use send binding, manual-turn filtering, assistant-text
 de-dupe, and pending confirmation isolation. It reduces the rapid-click/double-submit and malformed widget
-proof gaps, but still does not close the active lock because screenshot/click-path proof and broader
-widget-specific visual proof remain open.
+proof gaps.
+
+The closeout review classifies the lock as qualified closed. Browser Use screenshot/click-path proof,
+high-frequency browser event replay, broader visual UI proof, deeper widget-specific fuzzing, and
+timeline-drift fixtures remain carried-forward follow-up work rather than reasons to keep this lock
+indefinitely open.
 
 ---
 
@@ -103,9 +117,9 @@ widget-specific visual proof remain open.
   docs were regenerated through the generator path, runtime fingerprint/hash alignment updated, proof
   artifact over-indexing in generated MOCs corrected, and OpenClawMediator/read-only workflow proof
   remained documented as non-executing/non-authorizing.
-- **Paused Trust Review Card MVP lock:** selected in PR #112 and paused by the active Web/News/Reporting
-  + UI/Commands proof/stress-test lock. It should not be implemented while this proof lock is active.
-- **Active Web/News/Reporting + UI/Commands proof lock:** validates existing governed information,
+- **Trust Review Card MVP lock:** selected in PR #112 and paused by the Web/News/Reporting + UI/Commands
+  proof/stress-test lock. It may resume after the qualified closeout through a narrow feature branch.
+- **Qualified-closed Web/News/Reporting + UI/Commands proof lock:** validated existing governed information,
   reporting, dashboard, button, command, widget, confirmation, degraded-state, and blocked-action surfaces.
   It does not approve new capabilities, OpenClaw execution expansion, browser/computer-use expansion,
   external writes, autonomous workflow execution, Google connector runtime expansion, capability registry
@@ -139,6 +153,10 @@ widget-specific visual proof remain open.
   It records `25 passed` for the focused dashboard/session proof suite and JS syntax checks for served and
   mirrored dashboard files. It does not add runtime authority, capabilities, browser/computer-use, external
   writes, OpenClaw expansion, autonomous workflow expansion, or direct Cap 63 shortcut use.
+- **Web/News/UI proof lock closeout review:** classifies the proof/stress-test lock as qualified closed.
+  It explicitly carries Browser Use screenshot/click-path proof, high-frequency browser event replay,
+  broader visual UI proof, deeper non-search widget fuzzing, and timeline-drift fixtures forward as proof
+  follow-up work. It does not add runtime authority or approve browser/computer-use expansion.
 - Cap 64 remains confirmation-bound local `mailto:` draft only. No SMTP, inbox access, or
   autonomous send.
 - Cap 65 remains read-only Shopify intelligence. No Shopify writes.
@@ -147,7 +165,7 @@ widget-specific visual proof remain open.
 
 ## Planning-Only / Future Direction
 
-All future direction outside the active Web/News/Reporting + UI/Commands proof/stress-test lock requires a separate reviewed priority lock before work starts.
+All future direction outside the resumed Trust Review Card MVP scope requires a separate reviewed priority lock before work starts.
 
 Refer to: `docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_WEB_NEWS_PROOF_STRESS_TEST.md`
 
@@ -155,14 +173,14 @@ Current lock state:
 
 1. OpenClaw priority-lock sequence is complete and closed.
 2. Runtime truth regeneration / audit merged in PR #110 and is complete.
-3. Trust Review Card MVP priority lock was selected in PR #112 and is now paused.
-4. Web/News/Reporting + UI/Commands proof/stress-test lock is active.
+3. Trust Review Card MVP priority lock was selected in PR #112, paused during the proof/stress-test lock, and may now resume through a narrow MVP branch.
+4. Web/News/Reporting + UI/Commands proof/stress-test lock is qualified closed.
 5. PR #119 added the first evidence-backed proof library and UI verification matrix for the active lock.
 6. PR #121 reduced the contradiction and duplicate/split-topic proof gaps with deterministic fixtures.
 7. The stale-cache/provider-failure and source-credibility gaps now have deterministic backend fixture coverage.
 8. Dashboard-rendered stale/degraded search evidence state now has contract proof.
 9. Rapid-click/double-submit guard behavior and unsupported widget fallback now have contract proof.
-10. The active lock still remains open because Browser Use screenshot/click-path proof, broader visual UI/button proof, and deeper widget-specific malformed payload fixtures still need additional evidence.
-11. The next highest-ROI branch should focus on closeout review only after deciding whether screenshot/click-path proof remains a hard blocker, with screenshot proof still blocked until Browser Use runtime setup is fixed.
-12. The active lock allows only proof scaffolding, proof artifacts, simulations, stress-test prompts, and audit work for existing surfaces.
-13. Broad OpenClaw automation, browser/computer-use expansion, external writes, email/calendar/Shopify/account actions, direct Cap 63 shortcut use, autonomous workflow execution, Google connector expansion, capability registry expansion, workflow automation expansion, scheduler expansion, installer work, and Trust Review Card implementation remain not approved.
+10. Browser Use screenshot/click-path proof, broader visual UI/button proof, deeper widget-specific malformed payload fixtures, and timeline-drift fixtures are carried forward as follow-up proof debt.
+11. The next highest-ROI branch may resume Trust Review Card MVP as a visible non-action receipt surface.
+12. Trust Review Card MVP scope remains non-authorizing and must not expand execution, OpenClaw, browser/computer-use, capabilities, or external writes.
+13. Broad OpenClaw automation, browser/computer-use expansion, external writes, email/calendar/Shopify/account actions, direct Cap 63 shortcut use, autonomous workflow execution, Google connector expansion, capability registry expansion, workflow automation expansion, scheduler expansion, and installer work remain not approved.

--- a/docs/status/WEB_NEWS_UI_PROOF_LOCK_CLOSEOUT_REVIEW_2026-05-07.md
+++ b/docs/status/WEB_NEWS_UI_PROOF_LOCK_CLOSEOUT_REVIEW_2026-05-07.md
@@ -1,0 +1,174 @@
+# Web / News / UI Proof Lock Closeout Review - 2026-05-07
+
+Status: qualified closeout / screenshot proof explicitly blocked
+
+This is a human-maintained closeout review, not generated runtime truth.
+
+Generated runtime docs and actual code remain authoritative if they conflict with this review.
+
+## Reviewed Lock
+
+```text
+Governed Web / News / Reporting + UI / Commands Proof + Stress Test
+```
+
+Source lock:
+
+```text
+docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_WEB_NEWS_PROOF_STRESS_TEST.md
+```
+
+## Verdict
+
+The active proof/stress-test lock is closeout-ready for governed Web/News/Reporting behavior and dashboard contract behavior.
+
+The lock should close as a qualified closeout.
+
+Browser Use screenshot/click-path proof remains blocked by runtime asset setup. That blocker is carried forward as visual proof infrastructure debt, not treated as evidence of hidden Nova runtime failure and not treated as approval for browser/computer-use expansion.
+
+## Completed Proof Chain
+
+- PR #114 created the dedicated Web/News/Reporting + UI/Commands proof/stress-test lock.
+- PR #115 hardened the Truthful UI Rule and visible state language.
+- PR #116 added first raw UI/Web/News evidence and blockers.
+- PR #118 closed high-value command truthfulness follow-ups.
+- PR #119 organized the proof library and master UI matrix.
+- PR #121 added deterministic Web/News stress fixtures for contradiction, duplicate/prior-state topic maps, and split-topic headline comparison.
+- PR #123 added stale/provider/source-credibility evidence metadata and deterministic regression tests.
+- PR #124 rendered provider/freshness/source-credibility evidence visibly in the dashboard search widget.
+- PR #125 added malformed/unsupported widget fallback and rapid-click/double-submit contract proof.
+
+## Completed Areas
+
+### Governed Web / News / Reporting
+
+Closeout-ready for this lock:
+
+- governed web search proof
+- source labels, confidence, caveats, and evidence metadata
+- headline summary behavior with and without loaded headline context
+- multi-source reporting and intelligence brief proof
+- topic map and story tracker proof
+- quoted prompt-injection content treated as untrusted text
+- invalid website target rejection before confirmation
+- confirmation-bound valid website behavior
+- contradiction fixtures
+- duplicate/prior-state topic-map fixtures
+- split-topic headline comparison fixtures
+- stale-source freshness labeling
+- provider degraded/malformed behavior
+- conservative source credibility rows
+
+### UI / Commands
+
+Closeout-ready at command/contract level:
+
+- dashboard static load and visible button inventory
+- chat send command path
+- weather/news/calendar/memory/voice/email-draft/Shopify read-only or setup-dependent state proof
+- explicit OpenClaw/browser/external-write/Governor-bypass/Cap-63 refusal wording
+- pending confirmation isolation
+- dashboard search evidence rendering
+- empty degraded/malformed search widget visibility
+- unsupported dashboard/WebSocket message fallback
+- overlapping manual send block
+- single-use send button binding
+- manual-turn filtering
+- repeated assistant text de-dupe
+
+## Reduced Gaps
+
+The lock originally had major gaps in proof organization, raw evidence, contradiction handling, stale/provider behavior, source credibility, visible evidence state, malformed widget behavior, and rapid-click/double-submit behavior.
+
+Those are now reduced through case-level proof docs, raw evidence, deterministic tests, visible dashboard contract proof, and focused regression runs.
+
+## Still Open / Carried Forward
+
+These remain real, but they should not keep this lock open indefinitely:
+
+1. **Browser Use screenshot/click-path proof**
+   - Status: blocked.
+   - Reason: Browser Use runtime capture failed before page interaction with `failed to write kernel assets`.
+   - Carry forward as: `proof/browser-use-visual-capture-recovery`.
+
+2. **High-frequency browser event replay**
+   - Status: blocked by the same visual/browser automation setup.
+   - Carry forward as visual proof infrastructure, not runtime capability expansion.
+
+3. **Broader visual UI/button proof**
+   - Status: partial.
+   - Current proof is strong for command paths, contracts, and static matrix coverage.
+   - Full visual proof should resume after screenshot/click-path capture works.
+
+4. **Deeper non-search widget fuzzing**
+   - Status: follow-up hardening.
+   - Unsupported-message fallback and search widget malformed/degraded behavior are covered.
+   - Weather/calendar/memory/policy/system widget field fuzzing can be a later focused regression branch.
+
+5. **Timeline-drift fixtures**
+   - Status: follow-up hardening.
+   - Contradiction and split-topic fixtures are covered; timeline drift can be added later.
+
+## Closeout Classification
+
+```text
+Qualified closed.
+```
+
+Reason:
+
+- Core governed Web/News/Reporting behavior has concrete proof and deterministic stress fixtures.
+- Dashboard/search evidence state has visible contract proof.
+- High-risk command/governance boundaries have proof.
+- Rapid-submit and malformed/unsupported widget contract gaps have proof.
+- Remaining blockers are visual capture and deeper follow-up hardening, not proof of authority drift.
+
+## Boundaries Preserved
+
+This closeout does not approve:
+
+- broad OpenClaw automation
+- browser/computer-use expansion
+- external writes
+- email/calendar/Shopify/account actions beyond existing bounded read/draft/setup behavior
+- direct Cap 63 shortcut use
+- autonomous workflow execution
+- Google connector runtime expansion
+- capability registry expansion
+- workflow automation expansion
+- scheduler or installer work
+
+## Next Workstream
+
+With this qualified closeout accepted, the paused reviewed priority lock may resume:
+
+```text
+Trust Review Card MVP / Visible Non-Action Receipt Surface
+```
+
+Recommended next branch:
+
+```text
+feature/trust-review-card-mvp
+```
+
+Scope reminder:
+
+- visible non-action receipt card
+- planning/request-understanding display
+- confidence/boundary/status display
+- no execution authority
+- no OpenClaw expansion
+- no new capabilities
+
+## Carried-Forward Visual Proof Track
+
+Separate follow-up branch when ready:
+
+```text
+proof/browser-use-visual-capture-recovery
+```
+
+That branch should repair screenshot/click-path evidence capture and collect visual proof for existing surfaces only.
+
+It must not add browser/computer-use capability to Nova and must not create autonomous browsing or execution authority.

--- a/docs/todo/ACTIVE_TODO.md
+++ b/docs/todo/ACTIVE_TODO.md
@@ -4,35 +4,49 @@
 
 Refer to: `docs/status/ACTIVE_PRIORITY_LOCK_2026-05-06_WEB_NEWS_PROOF_STRESS_TEST.md`
 
-Updated: 2026-05-07 after the malformed widget / rapid-submit proof pass added unsupported widget fallback and rapid-submit contract coverage.
+Updated: 2026-05-07 after the Web/News/UI proof lock closeout review.
 
-Current active workstream:
+Most recently active workstream:
 
 ```text
 Governed Web / News / Reporting + UI / Commands Proof + Stress Test
 ```
 
-This lock permits only proof scaffolding, proof artifacts, simulations, stress-test prompts, and audit work for existing governed information/reporting and visible UI/command surfaces.
+Status:
+
+```text
+qualified closed / screenshot proof explicitly blocked
+```
+
+Closeout review:
+
+```text
+docs/status/WEB_NEWS_UI_PROOF_LOCK_CLOSEOUT_REVIEW_2026-05-07.md
+```
+
+This lock permitted only proof scaffolding, proof artifacts, simulations, stress-test prompts, and audit work for existing governed information/reporting and visible UI/command surfaces.
 
 This is not an automation-expansion lock.
 
 PR #119 improved proof-library coverage.
 
-PR #121 reduced the contradiction and duplicate/split-topic proof gaps with deterministic tests and proof evidence, but it did not close the active proof/stress-test lock.
+PR #121 reduced the contradiction and duplicate/split-topic proof gaps with deterministic tests and proof evidence.
 
-The stale/provider/credibility fixture pass reduces the stale-cache/provider-failure and source-credibility proof gaps, but it also does not close the active proof/stress-test lock.
+The stale/provider/credibility fixture pass reduced the stale-cache/provider-failure and source-credibility proof gaps.
 
-The dashboard stale/degraded rendering pass reduces the UI rendering gap for provider/freshness/source credibility metadata, but it also does not close the active proof/stress-test lock.
+The dashboard stale/degraded rendering pass reduced the UI rendering gap for provider/freshness/source credibility metadata.
 
-The malformed widget / rapid-submit proof pass reduces the rapid-click/double-submit and unsupported widget gaps, but it also does not close the active proof/stress-test lock.
+The malformed widget / rapid-submit proof pass reduced the rapid-click/double-submit and unsupported widget gaps.
+
+The closeout review carries Browser Use screenshot/click-path proof, high-frequency browser event replay, broader visual UI proof, deeper widget-specific malformed payload fixtures, and timeline-drift fixtures forward as follow-up proof debt.
 
 ---
 
 ## Current Next TODO
 
-Prepare the closeout review decision for the active proof/stress-test lock, while keeping screenshot/click-path and deeper visual UI proof gaps explicit.
+Resume the paused Trust Review Card MVP / Visible Non-Action Receipt Surface lock through a narrow non-authorizing implementation branch.
 
-Highest-priority remaining proof gaps:
+Carried-forward proof gaps:
 
 - Browser Use screenshot/click-path proof after runtime asset setup is fixed
 - broader visual UI/button coverage beyond command-path evidence
@@ -42,48 +56,22 @@ Highest-priority remaining proof gaps:
 Recommended next branch:
 
 ```text
-docs/web-news-ui-proof-lock-closeout-review
+feature/trust-review-card-mvp
 ```
 
-Expected proof outcome is truthful behavior, not guaranteed success.
+Scope for the next branch:
 
-Required proof focus retained from the active lock:
-
-- governed web search
-- browser/article open behavior
-- headline summaries
-- headline cluster comparison
-- multi-source reports
-- intelligence briefs
-- topic maps
-- story tracking
-- dashboard buttons/widgets
-- command entry flows
-- degraded/error states
-- confirmation prompts
-- blocked-action behavior
-- setup-required states
-- truthful UI state labels: working, blocked, setup-required, degraded, offline, unsupported
-- voice/media/system controls
-- analysis/memory/document surfaces
-
-Required stress-test focus retained from the active lock:
-
-- malformed feeds
-- conflicting narratives
-- stale caches
-- duplicate stories
-- fake/low-credibility sources
-- governance bypass attempts
-- hallucinated attribution
-- topic-map instability
-- network failure paths
-- rapid repeated button presses
-- stale WebSocket state
-- malformed widget payloads
-- blocked-action coercion attempts
-- degraded-state rendering
-- prompt injection from article content
+- visible non-action receipt card
+- planning/request-understanding display
+- confidence/boundary/status display
+- what Nova understood / can do / cannot do
+- whether execution is authorized
+- whether user confirmation is required
+- why no action happened
+- evidence/state if relevant
+- no execution authority
+- no OpenClaw expansion
+- no new capabilities
 
 Current completed audit/proof outcomes:
 
@@ -105,6 +93,7 @@ Current completed audit/proof outcomes:
 - the dashboard stale/degraded rendering pass recorded `4 passed`, `24 passed`, `2 passed`, and JS syntax checks for the focused rendering branch
 - the malformed widget / rapid-submit proof pass added an unsupported dashboard-message fallback and contract proof for overlapping send blocks, single-use send binding, turn-id filtering, assistant-text de-dupe, and pending confirmation isolation
 - the malformed widget / rapid-submit proof pass recorded `25 passed` and JS syntax checks for served/mirrored dashboard files
+- the Web/News/UI proof lock closeout review classified the lock as qualified closed and carried Browser Use screenshot/click-path proof forward as visual proof infrastructure debt
 
 Do not broaden OpenClaw or start product/runtime expansion outside the active reviewed priority lock.
 
@@ -122,9 +111,13 @@ References:
 
 Current active lock:
 
-- Governed Web / News / Reporting + UI / Commands Proof + Stress Test
+- Trust Review Card MVP / Visible Non-Action Receipt Surface
 
-Completed under current lock:
+Most recently completed lock:
+
+- Governed Web / News / Reporting + UI / Commands Proof + Stress Test: qualified closed
+
+Completed under the qualified-closed Web/News/UI proof lock:
 
 - proof package scaffolds created
 - Web/News proof library index created
@@ -143,15 +136,15 @@ Completed under current lock:
 - unsupported dashboard/WebSocket message fallback added and verified
 - rapid-click/double-submit contract guard coverage added and verified
 
-Still open under current lock:
+Carried-forward proof debt:
 
 - timeline-drift fixtures
 - Browser Use screenshot/click-path proof after asset setup is fixed
 - broader visual UI/button proof beyond command-path evidence
 - deeper widget-specific malformed payload fixtures beyond search/unsupported-message coverage
-- final lock closeout review
+- final lock closeout review added
 
-Paused prior lock:
+Resumed prior lock:
 
 - Trust Review Card MVP / Visible Non-Action Receipt Surface
 
@@ -187,8 +180,8 @@ Completed previous lock:
 - workflow automation expansion
 - scheduler expansion
 - installer work
-- Trust Review Card implementation while paused
+- Trust Review Card implementation outside the narrow resumed MVP/non-action receipt scope
 
 ---
 
-**Historical baseline below is retained for completed-context only. Work outside the active Web/News/Reporting + UI/Commands proof/stress-test lock requires a new reviewed priority lock.**
+**Historical baseline below is retained for completed-context only. Work outside the resumed Trust Review Card MVP / Visible Non-Action Receipt Surface scope requires a new reviewed priority lock.**


### PR DESCRIPTION
Adds a docs-only closeout review for the completed Web/News/Reporting + UI/Commands proof/stress-test lock.

Verdict:
- qualified closeout / screenshot proof explicitly blocked

Records:
- completed proof chain from PR #114 through PR #125
- completed governed Web/News/Reporting proof areas
- completed dashboard/search evidence and command contract proof areas
- reduced proof gaps
- carried-forward blockers for Browser Use screenshot/click-path proof, high-frequency browser event replay, broader visual UI proof, deeper widget-specific fuzzing, and timeline-drift fixtures

Updates:
- active proof lock status to qualified closed
- CURRENT_WORK_STATUS.md continuity
- ACTIVE_TODO.md next branch guidance

Next recommended workstream:
- Trust Review Card MVP / Visible Non-Action Receipt Surface

Boundaries preserved:
- no runtime behavior changes
- no generated runtime truth hand edits
- no new capabilities
- no OpenClaw expansion
- no browser/computer-use expansion
- no external writes
- no autonomous workflow expansion
- no direct Cap 63 shortcut use

Docs-only. No tests run because no runtime/code files changed.