### PR TITLE
docs: add UI simplification inventory

### DIFF
--- a/.agent_context/current_priority.md
+++ b/.agent_context/current_priority.md
@@ -3,13 +3,13 @@
 Current priority:
 
 ```text
-Proof infrastructure closeout review
+UI simplification inventory
 ```
 
 Status:
 
 ```text
-closeout review written / substantially reduced / visual proof blocked and carried forward
+inventory written / classify-only / no runtime changes
 ```
 
 Trust Review Card MVP is merged and closeout-reviewed as display-only, non-authorizing, and follow-ups tracked. It renders existing request-understanding review-card state as a visible non-action receipt surface; it does not authorize, confirm, dispatch, mutate state, call capabilities, call GovernorMediator, call OpenClaw, add browser/computer-use, add external writes, or create autonomous workflows.
@@ -21,12 +21,13 @@ Browser Use visual capture recovery was attempted and remains blocked/setup-requ
 Completed most recent branch:
 
 ```text
-docs/proof-infrastructure-closeout-review
+docs/ui-simplification-inventory
 ```
 
 Prior completed branches:
 
 ```text
+docs/proof-infrastructure-closeout-review
 test/non-search-widget-fuzzing
 test/dashboard-event-replay-harness
 ```
@@ -34,17 +35,16 @@ test/dashboard-event-replay-harness
 Next branch:
 
 ```text
-proof/browser-use-visual-capture-recovery (when Browser Use setup is repaired)
-or no new proof infrastructure until visual capture is unblocked
+ui/simplify-dashboard-default-experience
 ```
 
 Near-term focus:
 
-1. Proof infrastructure closeout is accepted as substantially reduced.
-2. Browser Use screenshot/click-path proof remains blocked/setup-required; carry forward as proof debt, not capability expansion approval.
-3. Deferred deeper fuzzing (policy, voice, workspace widgets) is low-urgency follow-up only.
+1. UI simplification inventory is complete. 86 buttons classified: ~55 KEEP / ~30 COLLAPSE / ~18 REMOVE.
+2. Next: implement inventory decisions in ui/simplify-dashboard-default-experience.
+3. After implementation: proof/live-manual-ui-verification — operator walks simplified UI and records results.
 4. Preserve no-authority boundaries: no new capability, no OpenClaw expansion, no browser/computer-use capability, no external writes, no autonomous workflows, no direct Cap 63 shortcut.
 
-Do not jump to Cap 64 P5, Shopify write work, OpenClaw browser automation, broad advanced features, scheduler/installer work, external-write workflows, richer receipt work, or browser/computer-use expansion based on this closeout.
+Do not jump to Cap 64 P5, Shopify write work, OpenClaw browser automation, broad advanced features, scheduler/installer work, external-write workflows, richer receipt work, or browser/computer-use expansion.
 
 This file is a working agent context note. Exact runtime truth still comes from code and generated runtime docs.

--- a/.agent_context/current_priority.md
+++ b/.agent_context/current_priority.md
@@ -3,52 +3,75 @@
 Current priority:
 
 ```text
-UI simplification inventory
+Cap 16 search reliability and conversation/search proof
 ```
 
 Status:
 
 ```text
-inventory written / classify-only / no runtime changes
+active / AGENTS.md governs this — do not override with UI simplification work
 ```
 
-Trust Review Card MVP is merged and closeout-reviewed as display-only, non-authorizing, and follow-ups tracked. It renders existing request-understanding review-card state as a visible non-action receipt surface; it does not authorize, confirm, dispatch, mutate state, call capabilities, call GovernorMediator, call OpenClaw, add browser/computer-use, add external writes, or create autonomous workflows.
+Cap 64 P5 remains paused until the Cap 16 proof path is stable. See AGENTS.md.
 
-The Web/News/UI proof lock is qualified closed. Browser Use screenshot/click-path proof, high-frequency browser event replay, broader visual UI proof, deeper widget-specific fuzzing, and timeline-drift fixtures are carried forward as proof debt, not as approval for browser/computer-use expansion.
+---
 
-Browser Use visual capture recovery was attempted and remains blocked/setup-required because the Browser Use / Node REPL path fails before JavaScript execution with `failed to write kernel assets: The system cannot find the path specified`. This is proof-infrastructure debt, not Nova runtime authority.
+## Queued / planned (not active)
 
-Completed most recent branch:
+UI simplification inventory is complete and queued for a future implementation branch.
+It does not become the active priority until Cap 16 search reliability proof is stable
+and a reviewed priority lock authorizes the switch.
 
 ```text
-docs/ui-simplification-inventory
+Inventory branch: docs/ui-simplification-inventory (merged via PR #133)
+Future implementation branch (queued): ui/simplify-dashboard-core-navigation
+Target: Start + Chat / News / CRM / Settings
 ```
 
-Prior completed branches:
+Do not begin ui/simplify-dashboard-core-navigation until the active Cap 16 priority
+lock is closed and a new reviewed priority lock is established.
+
+---
+
+## Completed recent branches
 
 ```text
+docs/ui-simplification-inventory      — docs-only / queued UI inventory
 docs/proof-infrastructure-closeout-review
 test/non-search-widget-fuzzing
 test/dashboard-event-replay-harness
 ```
 
-Next branch:
+---
 
-```text
-ui/simplify-dashboard-core-navigation
-```
+## Context carried forward
 
-Near-term focus:
+Trust Review Card MVP is merged and closeout-reviewed as display-only, non-authorizing,
+and follow-ups tracked. It renders existing request-understanding review-card state as a
+visible non-action receipt surface; it does not authorize, confirm, dispatch, mutate state,
+call capabilities, call GovernorMediator, call OpenClaw, add browser/computer-use, add
+external writes, or create autonomous workflows.
 
-1. UI simplification inventory is complete and product-direction corrected.
-2. Target: Start + Chat + News + CRM + Settings. Home/Memory/Workspace/Trust/Policy/Agent fold out of
-   top-level nav.
-3. CRM is future-facing/read-only/setup-required — no write actions.
-4. Next: implement in ui/simplify-dashboard-core-navigation.
-5. After implementation: proof/live-manual-ui-verification — operator walks simplified UI and records results.
-6. Preserve no-authority boundaries: no new capability, no OpenClaw expansion, no browser/computer-use
-   capability, no external writes, no autonomous workflows, no direct Cap 63 shortcut.
+The Web/News/UI proof lock is qualified closed. Browser Use screenshot/click-path proof,
+high-frequency browser event replay, broader visual UI proof, deeper widget-specific fuzzing,
+and timeline-drift fixtures are carried forward as proof debt, not as approval for
+browser/computer-use expansion.
 
-Do not jump to Cap 64 P5, Shopify write work, OpenClaw browser automation, broad advanced features, scheduler/installer work, external-write workflows, richer receipt work, or browser/computer-use expansion.
+Browser Use visual capture recovery was attempted and remains blocked/setup-required because
+the Browser Use / Node REPL path fails before JavaScript execution with
+`failed to write kernel assets: The system cannot find the path specified`.
+This is proof-infrastructure debt, not Nova runtime authority.
 
-This file is a working agent context note. Exact runtime truth still comes from code and generated runtime docs.
+---
+
+## Preserved no-authority boundaries
+
+Do not add capabilities, expand OpenClaw, add browser/computer-use, add external writes,
+add autonomous workflows, or use direct Cap 63 shortcuts based on any queued UI work.
+
+Do not jump to Cap 64 P5, Shopify write work, OpenClaw browser automation, broad advanced
+features, scheduler/installer work, external-write workflows, richer receipt work, or
+browser/computer-use expansion.
+
+This file is a working agent context note. Exact runtime truth still comes from code and
+generated runtime docs. AGENTS.md governs active priority.

--- a/.agent_context/current_priority.md
+++ b/.agent_context/current_priority.md
@@ -35,15 +35,19 @@ test/dashboard-event-replay-harness
 Next branch:
 
 ```text
-ui/simplify-dashboard-default-experience
+ui/simplify-dashboard-core-navigation
 ```
 
 Near-term focus:
 
-1. UI simplification inventory is complete. 86 buttons classified: ~55 KEEP / ~30 COLLAPSE / ~18 REMOVE.
-2. Next: implement inventory decisions in ui/simplify-dashboard-default-experience.
-3. After implementation: proof/live-manual-ui-verification — operator walks simplified UI and records results.
-4. Preserve no-authority boundaries: no new capability, no OpenClaw expansion, no browser/computer-use capability, no external writes, no autonomous workflows, no direct Cap 63 shortcut.
+1. UI simplification inventory is complete and product-direction corrected.
+2. Target: Start + Chat + News + CRM + Settings. Home/Memory/Workspace/Trust/Policy/Agent fold out of
+   top-level nav.
+3. CRM is future-facing/read-only/setup-required — no write actions.
+4. Next: implement in ui/simplify-dashboard-core-navigation.
+5. After implementation: proof/live-manual-ui-verification — operator walks simplified UI and records results.
+6. Preserve no-authority boundaries: no new capability, no OpenClaw expansion, no browser/computer-use
+   capability, no external writes, no autonomous workflows, no direct Cap 63 shortcut.
 
 Do not jump to Cap 64 P5, Shopify write work, OpenClaw browser automation, broad advanced features, scheduler/installer work, external-write workflows, richer receipt work, or browser/computer-use expansion.
 

--- a/docs/PROOFS/UI-Commands/LIVE_MANUAL_UI_VERIFICATION_PLAN_2026-05-09.md
+++ b/docs/PROOFS/UI-Commands/LIVE_MANUAL_UI_VERIFICATION_PLAN_2026-05-09.md
@@ -1,12 +1,32 @@
 # Live Manual UI Verification Plan - 2026-05-09
 
-Status: planned / manual local verification only / results not yet recorded
+Status: **pre-simplification baseline / current UI only / results not yet recorded**
+
+## Framing
+
+```text
+PRE-SIMPLIFICATION BASELINE
+
+This plan tests the current 10-page dashboard as it exists before
+ui/simplify-dashboard-core-navigation is implemented.
+
+It is NOT a post-simplification proof plan.
+
+After the simplification implementation branch merges, a separate
+post-simplification verification plan must be created that tests:
+  Start / Chat / News / CRM / Settings
+and does NOT expect old standalone pages (page-trust, page-policy,
+page-home, page-workspace, page-agent) to exist at top-level navigation.
+
+Do not use this plan to validate the simplified UI. Create a new plan.
+```
 
 ## Classification
 
 ```text
 manual local proof
 operator-observed
+pre-simplification baseline only
 not Browser Use automation
 not automated browser proof
 not runtime authority expansion
@@ -14,13 +34,18 @@ not runtime authority expansion
 
 This plan covers direct local observation of the running dashboard after
 the deterministic proof infrastructure closeout. The operator starts Nova
-locally, opens the dashboard in a browser, and records observed behavior.
+locally, opens the dashboard in a browser, and records observed behavior
+against the **current** UI structure.
 
 No automated browser driver is used. No Browser Use capability is invoked.
 No new runtime authority is added. No features are changed to make checks pass.
 
 If a bug or discrepancy is found, it is logged as a finding in the results
 doc and addressed in a separate branch later.
+
+**Sections 5–10 of this plan test pages that will be folded into Settings or
+CRM by the simplification branch. Failures in those sections after simplification
+are expected, not regressions.**
 
 ## Prerequisites
 

--- a/docs/PROOFS/UI-Commands/LIVE_MANUAL_UI_VERIFICATION_PLAN_2026-05-09.md
+++ b/docs/PROOFS/UI-Commands/LIVE_MANUAL_UI_VERIFICATION_PLAN_2026-05-09.md
@@ -1,0 +1,273 @@
+# Live Manual UI Verification Plan - 2026-05-09
+
+Status: planned / manual local verification only / results not yet recorded
+
+## Classification
+
+```text
+manual local proof
+operator-observed
+not Browser Use automation
+not automated browser proof
+not runtime authority expansion
+```
+
+This plan covers direct local observation of the running dashboard after
+the deterministic proof infrastructure closeout. The operator starts Nova
+locally, opens the dashboard in a browser, and records observed behavior.
+
+No automated browser driver is used. No Browser Use capability is invoked.
+No new runtime authority is added. No features are changed to make checks pass.
+
+If a bug or discrepancy is found, it is logged as a finding in the results
+doc and addressed in a separate branch later.
+
+## Prerequisites
+
+```text
+1. Start Nova: python scripts/start_daemon.py --no-browser
+2. Open dashboard: http://127.0.0.1:8000
+3. Open browser devtools console (to observe JS errors)
+4. Record observations in: proof/record-live-manual-ui-verification-results
+```
+
+## Out of Scope
+
+- Browser Use screenshot/click-path automation (blocked/setup-required)
+- autonomous workflows
+- external write actions
+- capability expansion
+- OpenClaw expansion
+- installer or scheduler work
+- fixing bugs inline (log findings, fix separately)
+
+---
+
+## Section 1 — Dashboard Load and WebSocket
+
+| # | Action | Expected | Observed | Pass/Fail | Notes |
+|---|---|---|---|---|---|
+| 1.1 | Open `http://127.0.0.1:8000` | Dashboard loads, no console-visible JS error | TBD | TBD | |
+| 1.2 | Observe orb / status indicator on load | Status reflects connected or setup-required state, not fake-ready | TBD | TBD | |
+| 1.3 | Observe WebSocket connection in devtools Network tab | `/ws` connection establishes | TBD | TBD | |
+| 1.4 | Stop backend, observe dashboard | Dashboard shows degraded/disconnected state, does not hang silently | TBD | TBD | |
+| 1.5 | Restart backend, reload dashboard | Dashboard reconnects or requires manual reload; no false-ready claim | TBD | TBD | |
+
+---
+
+## Section 2 — Chat Send and Guard Behavior
+
+| # | Action | Expected | Observed | Pass/Fail | Notes |
+|---|---|---|---|---|---|
+| 2.1 | Type a message and press send | One assistant response, no duplicate | TBD | TBD | |
+| 2.2 | Click send twice rapidly | Second send blocked; loading hint visible | TBD | TBD | |
+| 2.3 | Hold Enter key | No duplicate payloads enqueued | TBD | TBD | |
+| 2.4 | Send blank/whitespace message | No send occurs, no payload enqueued | TBD | TBD | |
+| 2.5 | Send very long message (500+ chars) | Handled gracefully, no crash | TBD | TBD | |
+| 2.6 | Send during pending response | Loading hint visible; second send blocked | TBD | TBD | |
+| 2.7 | Switch to another page during pending response | No crash; response still arrives on return | TBD | TBD | |
+| 2.8 | Reload page during pending response | State resets cleanly; no stuck pending state | TBD | TBD | |
+
+---
+
+## Section 3 — Trust Review Card
+
+| # | Action | Expected | Observed | Pass/Fail | Notes |
+|---|---|---|---|---|---|
+| 3.1 | Ask a non-action planning question | Trust Review Card renders as display-only receipt | TBD | TBD | |
+| 3.2 | Inspect card for action buttons | No dispatch/confirm/execute buttons present | TBD | TBD | |
+| 3.3 | Click anywhere on card | No action triggered, no state change | TBD | TBD | |
+| 3.4 | Ask a blocked-action question | Explicit refusal; card shows boundary, not fake success | TBD | TBD | |
+
+---
+
+## Section 4 — News / Search / Reporting Widgets
+
+| # | Action | Expected | Observed | Pass/Fail | Notes |
+|---|---|---|---|---|---|
+| 4.1 | Click `btn-news` | News widget loads or shows setup/degraded state | TBD | TBD | |
+| 4.2 | Click `btn-news-refresh` | Refresh triggers without duplicate send | TBD | TBD | |
+| 4.3 | Click `btn-news-summary` | Summary widget renders or shows no-context message | TBD | TBD | |
+| 4.4 | Use `btn-news-search` to search a term | Search result renders with source labels and confidence | TBD | TBD | |
+| 4.5 | Use `btn-news-expand` | Expands news list without crash | TBD | TBD | |
+| 4.6 | Ask for intelligence brief via chat | Intelligence brief widget renders | TBD | TBD | |
+| 4.7 | Ask for topic map | Topic map widget renders | TBD | TBD | |
+
+---
+
+## Section 5 — Weather / Calendar / Morning Panel
+
+| # | Action | Expected | Observed | Pass/Fail | Notes |
+|---|---|---|---|---|---|
+| 5.1 | Click `btn-morning-toggle` | Morning panel toggles open/closed | TBD | TBD | |
+| 5.2 | Observe weather in morning panel | Weather summary shown, or "Weather unavailable." fallback | TBD | TBD | |
+| 5.3 | Observe calendar in morning panel | Calendar shows events, setup-required, or no-events default | TBD | TBD | |
+| 5.4 | Click `btn-morning-calendar-connect` | Opens calendar connection flow or setup-required state | TBD | TBD | |
+
+---
+
+## Section 6 — Memory Panel
+
+| # | Action | Expected | Observed | Pass/Fail | Notes |
+|---|---|---|---|---|---|
+| 6.1 | Click `btn-memory-overview` | Memory overview renders or shows empty state | TBD | TBD | |
+| 6.2 | Click `btn-memory-list` | Memory list renders | TBD | TBD | |
+| 6.3 | Click `btn-memory-list-all` | All memories listed | TBD | TBD | |
+| 6.4 | Click `btn-memory-recent` | Recent memories listed | TBD | TBD | |
+| 6.5 | Click `btn-memory-list-active` / `locked` / `deferred` | Filtered memory lists render | TBD | TBD | |
+| 6.6 | Click `btn-memory-refresh` | Refresh triggers without duplicate | TBD | TBD | |
+| 6.7 | Click `btn-memory-export` | Export triggers or shows not-ready state | TBD | TBD | |
+| 6.8 | Click `btn-memory-threads` | Thread-scoped memory view renders | TBD | TBD | |
+
+---
+
+## Section 7 — Trust Center Panel
+
+| # | Action | Expected | Observed | Pass/Fail | Notes |
+|---|---|---|---|---|---|
+| 7.1 | Navigate to page-trust | Trust center page renders | TBD | TBD | |
+| 7.2 | Click `btn-trust-center-refresh` | Refresh triggers, data updates | TBD | TBD | |
+| 7.3 | Click `btn-trust-center-system` | System status section visible | TBD | TBD | |
+| 7.4 | Click `btn-trust-center-memory` | Memory section visible | TBD | TBD | |
+| 7.5 | Click `btn-trust-center-policy-map` | Policy readiness section visible | TBD | TBD | |
+| 7.6 | Click `btn-trust-center-voice-check` | Voice status shown or setup-required | TBD | TBD | |
+| 7.7 | Click `btn-trust-center-bridge-status` | Bridge/connection status visible | TBD | TBD | |
+| 7.8 | Click `btn-trust-center-workspace` | Workspace section visible | TBD | TBD | |
+| 7.9 | Click `btn-trust-center-agent` | Agent section visible | TBD | TBD | |
+| 7.10 | Click `btn-trust-center-settings` | Navigates to settings | TBD | TBD | |
+
+---
+
+## Section 8 — Policy Center Panel
+
+| # | Action | Expected | Observed | Pass/Fail | Notes |
+|---|---|---|---|---|---|
+| 8.1 | Navigate to page-policy | Policy center renders | TBD | TBD | |
+| 8.2 | Click `btn-policy-refresh` | Refresh triggers without crash | TBD | TBD | |
+| 8.3 | Click `btn-policy-capability-map` | Capability readiness visible | TBD | TBD | |
+| 8.4 | Click `btn-policy-create-weather` / `calendar` / `status` | Policy creation flow or setup-required state | TBD | TBD | |
+| 8.5 | Click `btn-policy-open-trust` / `settings` | Navigates correctly | TBD | TBD | |
+
+---
+
+## Section 9 — Settings Panel
+
+| # | Action | Expected | Observed | Pass/Fail | Notes |
+|---|---|---|---|---|---|
+| 9.1 | Navigate to page-settings | Settings page renders | TBD | TBD | |
+| 9.2 | Click `btn-settings-refresh-runtime` | Runtime status refreshes | TBD | TBD | |
+| 9.3 | Click `btn-settings-voice-status` | Voice status shown or setup-required | TBD | TBD | |
+| 9.4 | Click `btn-settings-voice-check` | Voice check runs or shows not-available | TBD | TBD | |
+| 9.5 | Click `btn-settings-open-connections` | Navigates to connections | TBD | TBD | |
+| 9.6 | Click `btn-settings-open-trust` | Navigates to trust center | TBD | TBD | |
+| 9.7 | Click `btn-settings-open-accessibility` | Accessibility settings visible | TBD | TBD | |
+| 9.8 | Click `btn-settings-open-privacy` | Privacy settings visible | TBD | TBD | |
+| 9.9 | Click `btn-settings-reset-defaults` | Prompts for confirmation, does not auto-reset | TBD | TBD | |
+| 9.10 | Click `btn-reset-confirm` then `btn-reset-cancel` | Cancel aborts reset; confirm triggers reset flow | TBD | TBD | |
+
+---
+
+## Section 10 — Home / Workspace / Agent Panels
+
+| # | Action | Expected | Observed | Pass/Fail | Notes |
+|---|---|---|---|---|---|
+| 10.1 | Navigate to page-home | Home launch widget renders | TBD | TBD | |
+| 10.2 | Click `btn-home-threads` | Thread list visible | TBD | TBD | |
+| 10.3 | Navigate to page-workspace | Workspace board renders | TBD | TBD | |
+| 10.4 | Click `btn-workspace-home-refresh` | Refresh triggers | TBD | TBD | |
+| 10.5 | Click `btn-workspace-board-refresh` | Board refresh triggers | TBD | TBD | |
+| 10.6 | Click `btn-workspace-board-threads` / `architecture` / `visual` | Board views switch | TBD | TBD | |
+| 10.7 | Navigate to page-agent | Agent panel renders | TBD | TBD | |
+| 10.8 | Click `btn-agent-refresh` | Agent status refreshes | TBD | TBD | |
+| 10.9 | Click `btn-agent-open-home` / `settings` / `trust` | Navigates correctly | TBD | TBD | |
+
+---
+
+## Section 11 — Degraded / Unsupported / Blocked States
+
+| # | Action | Expected | Observed | Pass/Fail | Notes |
+|---|---|---|---|---|---|
+| 11.1 | Ask for an OpenClaw browser automation action | Explicit refusal, no execution | TBD | TBD | |
+| 11.2 | Ask for an external write action | Explicit refusal, no execution | TBD | TBD | |
+| 11.3 | Ask for a direct Cap 63 / Governor bypass | Explicit refusal, no bypass | TBD | TBD | |
+| 11.4 | Send `open website notaurl` | Invalid-input rejection before confirmation | TBD | TBD | |
+| 11.5 | Send `open website example.com`, then send unrelated command | Stale confirmation canceled; new command handled | TBD | TBD | |
+| 11.6 | Send quoted prompt-injection text | Treated as untrusted content; no execution | TBD | TBD | |
+| 11.7 | Observe any widget that returns no data | Widget shows setup-required or degraded state, not crash | TBD | TBD | |
+
+---
+
+## Section 12 — Workflow Focus / Operational Context
+
+| # | Action | Expected | Observed | Pass/Fail | Notes |
+|---|---|---|---|---|---|
+| 12.1 | Click `btn-workflow-show-steps` | Workflow steps panel renders | TBD | TBD | |
+| 12.2 | Click `btn-workflow-refine` | Refine action triggers without crash | TBD | TBD | |
+| 12.3 | Click `btn-workflow-reset` | Workflow state resets, no stuck pending | TBD | TBD | |
+| 12.4 | Click `btn-operational-context-refresh` | Operational context refreshes | TBD | TBD | |
+| 12.5 | Click `btn-operational-context-reset` | Context resets without crash | TBD | TBD | |
+
+---
+
+## Section 13 — Short Workflow Sequences
+
+Record complete user-facing flows end to end.
+
+| # | Workflow | Steps | Expected | Observed | Pass/Fail |
+|---|---|---|---|---|---|
+| 13.1 | Basic chat | Load → send message → receive response | One response, no duplicate, Trust Review Card if applicable | TBD | TBD |
+| 13.2 | Rapid submit stress | Load → send → immediately send again | Second blocked; loading hint visible | TBD | TBD |
+| 13.3 | News + search | Load → news → search term → review results | Source labels, confidence shown | TBD | TBD |
+| 13.4 | Memory overview | Load → memory overview → list memories | Lists render without crash | TBD | TBD |
+| 13.5 | Backend disconnect | Start → send message → kill backend → observe | Degraded state shown, no crash | TBD | TBD |
+| 13.6 | Backend reconnect | After disconnect → restart backend → reload | Reconnects or requires manual reload cleanly | TBD | TBD |
+| 13.7 | Panel switching mid-turn | Send → immediately switch to settings | No crash; response visible on return | TBD | TBD |
+| 13.8 | Reset flow | Settings → reset → cancel | Cancel aborts; no state change | TBD | TBD |
+| 13.9 | Blocked action refusal | Send browser automation request | Explicit refusal, no execution claim | TBD | TBD |
+| 13.10 | Trust center full view | Navigate to trust center → review all subsections | All sections render, no crash | TBD | TBD |
+
+---
+
+## Findings Log
+
+Record any discrepancies observed during the pass here. Do not fix inline.
+
+| # | Section | Finding | Severity | Recommended follow-up branch |
+|---|---|---|---|---|
+| — | — | None yet | — | — |
+
+---
+
+## Evidence
+
+Results should be recorded in a separate doc:
+
+```text
+docs/PROOFS/UI-Commands/cases/LIVE_MANUAL_UI_VERIFICATION_RESULTS_2026-05-09.md
+```
+
+Raw notes / screenshots (if any):
+
+```text
+docs/PROOFS/UI-Commands/evidence/2026-05-09/manual/
+```
+
+---
+
+## Boundary Statement
+
+This verification plan does not add:
+
+- Browser Use capability
+- computer-use capability
+- OpenClaw expansion
+- new runtime authority
+- external write workflows
+- autonomous workflows
+- direct Cap 63 shortcuts
+- new dashboard features
+- new widget types
+- new capabilities
+
+It is observe-and-record only. All findings go to a separate results doc and
+are addressed in separate fix branches after review.

--- a/docs/status/UI_SIMPLIFICATION_INVENTORY_2026-05-09.md
+++ b/docs/status/UI_SIMPLIFICATION_INVENTORY_2026-05-09.md
@@ -124,6 +124,72 @@ user goals.
 | Policy (`page-policy`) | Not top-level; fold into Settings / Governance / Advanced |
 | Agent (`page-agent`) | Not top-level; fold into Settings / Advanced |
 
+### Folded Page Destination Map
+
+Where each non-top-level page's content and buttons go:
+
+| Current page | New destination | Button fate |
+|---|---|---|
+| Home (`page-home`) | Chat sidebar / Settings | Morning/weather/calendar status → Chat contextual or Settings status section; diagnostic widgets → Settings / Diagnostics; shortcut chips → see Section 12 |
+| Memory (`page-memory`) | Settings / Memory | All memory action buttons (list, filter, edit, lock, defer, delete) move into Settings / Memory sub-section |
+| Workspace (`page-workspace`) | CRM (business-facing) + Settings / Workspace (diagnostic) | Board thread/architecture views → Settings / Workspace; business project context → CRM |
+| Trust (`page-trust`) | Settings / Governance | All trust subsection buttons become Settings / Governance accordions; no separate nav page |
+| Policy (`page-policy`) | Settings / Policy | Policy overview → Settings / Policy; policy create shortcuts → REMOVE |
+| Agent (`page-agent`) | Settings / Agent / Advanced | Agent refresh and status → Settings / Agent section; agent-to-trust/home nav links → obsolete |
+| Intro (`page-intro`) | Start screen | Becomes entry point; buttons reduced to Start + Settings link only |
+
+---
+
+### Settings Structure Map
+
+Settings absorbs six folded pages. New Settings sub-section structure:
+
+| Sub-section | Content | Source pages / buttons |
+|---|---|---|
+| General | Profile, identity, preferences, rules, accessibility, privacy, reset | Existing Settings buttons: profile-save-*, reset-defaults, accessibility, privacy |
+| Connections | External connections, calendar setup, API status | btn-connections-refresh, btn-settings-open-connections, btn-morning-calendar-connect |
+| Voice | Voice status, voice check | btn-settings-voice-status, btn-settings-voice-check |
+| Memory | Memory list, filter, edit, lock, defer, delete, export | All btn-memory-* from current Memory page |
+| Governance / Trust | Trust status summary, authority boundary, system/memory/bridge status | btn-trust-center-refresh + trust subsections (all as accordions) |
+| Policy | Policy overview, capability readiness | btn-policy-refresh, btn-policy-capability-map; no creation shortcuts |
+| Agent / OpenClaw | Agent and bridge status | btn-agent-refresh; read-only status only |
+| Workspace / Project context | Thread structure, board views | btn-workspace-board-* views; diagnostic only |
+| Diagnostics | Workflow steps, operational context, assistive notices, runtime refresh | btn-workflow-*, btn-operational-context-*, btn-assistive-*, btn-settings-refresh-runtime |
+| Advanced / Proof | Proof surfaces, capability surface widget, operator health, bridge reasoning grids | Collapsed by default; operator/developer view only |
+
+---
+
+### CRM Stub (current-state definition)
+
+CRM is future-facing. The stub page renders what exists today:
+
+```text
+CRM page (current state):
+
+Title: CRM
+
+Default state (no integrations configured):
+  - "Business integrations coming soon."
+  - One link: Settings / Connections (to configure)
+
+Shopify (if configured):
+  - Read-only store status / revenue summary from Cap 65
+  - No write actions. No create/update/delete product or order.
+
+Email (always):
+  - Email draft creation through Chat only, user-initiated, confirmation-bound
+  - User sends manually. No inbox access. No autonomous send.
+
+Calendar / business context:
+  - Read-only event list if calendar connected
+  - Setup-required state if not connected
+```
+
+No buttons: "Add lead", "Send follow-up", "Create deal", "Sync customer",
+"Assign task", or any CRM write action.
+
+---
+
 ### Intro / Start screen buttons (corrected from Section 10)
 
 The intro page is **KEEP** — it becomes the Start screen, not a page to remove.
@@ -144,19 +210,30 @@ Its buttons are reduced:
 
 ## Section 4 — Buttons: Chat Page
 
+### Chat vs News: resolved decision
+
+News has its own top-level page. Chat renders news widgets inline when the user
+asks, but Chat should not duplicate the full News control cluster as persistent
+shortcut buttons. Five news-specific buttons on the Chat page implies News is a
+Chat sub-feature, not a peer page.
+
+Decision: move persistent News controls to the News page. Remove them from the
+Chat default view. The user navigates to News to browse; news results appear in
+Chat when requested via natural language or a single chip ("Today's news").
+
 | Button ID | Label | Current behavior | Backend-backed? | Classification | Rationale |
 |---|---|---|---|---|---|
-| `btn-news` | News | Requests news widget | Yes | **KEEP** | Core |
-| `btn-news-summary` | Summary | Requests news summary | Yes | **KEEP** | Core |
-| `btn-news-refresh` | Refresh | Refreshes news | Yes | **KEEP** | Core |
-| `btn-news-expand` | Expand | Expands news list | Yes | **KEEP** | Useful |
-| `btn-news-search` | Search | Opens search input | Yes | **KEEP** | Core |
-| `btn-morning-toggle` | Morning | Toggles morning panel | Yes | **KEEP** | Useful summary |
-| `btn-morning-calendar-connect` | Connect calendar | Opens calendar setup | Partial — setup-required | **COLLAPSE** | Only relevant pre-setup; show inline in calendar widget when setup-required |
-| `btn-hints-toggle` | Hints | Toggles hint panel | No direct backend | **REMOVE** | Adds noise; hints are low-value in current form |
-| `btn-live-help-start` | Live help start | Starts live help session | Unclear / limited | **REMOVE** | Implies autonomy; unclear governed path |
-| `btn-live-help-stop` | Live help stop | Stops live help | Same | **REMOVE** | Same as above |
-| `btn-live-help-explain` | Explain | Explain via live help | Same | **REMOVE** | Same as above |
+| `btn-news` | News | Requests news widget | Yes | **REMOVE from Chat** | News page owns this; one nav chip in Chat is enough |
+| `btn-news-summary` | Summary | Requests news summary | Yes | **REMOVE from Chat** | Same |
+| `btn-news-refresh` | Refresh | Refreshes news | Yes | **REMOVE from Chat** | Same |
+| `btn-news-expand` | Expand | Expands news list | Yes | **REMOVE from Chat** | Same |
+| `btn-news-search` | Search | Opens search input | Yes | **REMOVE from Chat** | Same; search chip in Chat covers this |
+| `btn-morning-toggle` | Morning | Toggles morning panel | Yes | **KEEP** | Status/calendar/weather summary before Chat; stays in Chat |
+| `btn-morning-calendar-connect` | Connect calendar | Opens calendar setup | Partial — setup-required | **COLLAPSE** → **Settings / Connections** | Show as Settings link when setup-required; not a Chat button |
+| `btn-hints-toggle` | Hints | Toggles hint panel | No direct backend | **REMOVE** | Low-value in current form |
+| `btn-live-help-start` | Live help start | Starts live help session | Unclear / limited | **REMOVE** | No clear governed path |
+| `btn-live-help-stop` | Live help stop | Stops live help | Same | **REMOVE** | Same |
+| `btn-live-help-explain` | Explain | Explain via live help | Same | **REMOVE** | Same |
 
 ---
 
@@ -225,12 +302,12 @@ Its buttons are reduced:
 | `btn-settings-voice-status` | Voice status | Shows voice status | Yes | **KEEP** | Core |
 | `btn-settings-voice-check` | Voice check | Runs voice check | Partial | **COLLAPSE** | Only useful post-setup |
 | `btn-settings-open-connections` | Connections | Navigates to connections | Yes | **KEEP** | Core navigation |
-| `btn-settings-open-trust` | Trust center | Navigates to trust | Yes | **KEEP** | Core navigation |
-| `btn-settings-open-home` | Home | Navigates to home | Yes | **KEEP** | Navigation |
-| `btn-settings-open-agent` | Agent | Navigates to agent | Yes | **COLLAPSE** | Low-value if agent page collapses |
+| `btn-settings-open-trust` | Trust center | Navigates to trust | Yes | **RECLASSIFY** → scroll to Governance sub-section | Trust folds into Settings; this becomes a same-page scroll link, not cross-page nav |
+| `btn-settings-open-home` | Home | Navigates to home | Yes | **REMOVE** | Home is not top-level; no destination |
+| `btn-settings-open-agent` | Agent | Navigates to agent | Yes | **RECLASSIFY** → scroll to Agent / Advanced sub-section | Agent folds into Settings; same-page scroll |
 | `btn-settings-open-accessibility` | Accessibility | Opens accessibility settings | Yes | **KEEP** | Useful |
 | `btn-settings-open-privacy` | Privacy | Opens privacy settings | Yes | **KEEP** | Useful |
-| `btn-settings-open-intro` | Intro | Navigates to intro | Low | **REMOVE** | Intro page is low-value for ongoing sessions |
+| `btn-settings-open-intro` | Intro / Return to Start | Navigates to Start screen | Yes | **KEEP** | Intro is now the Start screen; return path is valid |
 | `btn-settings-reset-defaults` | Reset defaults | Resets settings | Yes | **KEEP** | Core — requires confirmation |
 | `btn-reset-confirm` | Confirm reset | Executes reset | Yes | **KEEP** | Required by reset flow |
 | `btn-reset-cancel` | Cancel reset | Aborts reset | Yes | **KEEP** | Required by reset flow |
@@ -240,20 +317,36 @@ Its buttons are reduced:
 
 ---
 
-## Section 9 — Buttons: Home, Workspace, Agent Pages
+## Section 9 — Buttons: Home, Workspace, Agent Pages (folded)
 
-| Button ID | Label | Current behavior | Backend-backed? | Classification | Rationale |
-|---|---|---|---|---|---|
-| `btn-home-threads` | Threads | Shows threads | Yes | **KEEP** | Core |
-| `btn-workspace-home-refresh` | Refresh | Refreshes workspace home | Yes | **KEEP** | Core |
-| `btn-workspace-board-refresh` | Refresh board | Refreshes board | Yes | **KEEP** | Core |
-| `btn-workspace-board-threads` | Threads view | Switches board view | Yes | **KEEP** | Core |
-| `btn-workspace-board-architecture` | Architecture view | Switches board view | Yes | **KEEP** | Useful |
-| `btn-workspace-board-visual` | Visual view | Switches board view | Yes | **KEEP** | Useful |
-| `btn-agent-refresh` | Refresh agent | Refreshes agent/bridge status | Yes | **KEEP** (if page kept) | Core for agent page |
-| `btn-agent-open-home` | Home | Navigates to home | Yes | **KEEP** | Navigation |
-| `btn-agent-open-settings` | Settings | Navigates to settings | Yes | **KEEP** | Navigation |
-| `btn-agent-open-trust` | Trust | Navigates to trust | Yes | **KEEP** | Navigation |
+Home, Workspace, and Agent are no longer standalone top-level pages. Their buttons
+do not KEEP on standalone pages — they fold into Settings sub-sections or CRM, as
+defined in the Section 3 Folded Page Destination Map.
+
+### Home page buttons
+
+| Button ID | Label | New destination | Classification |
+|---|---|---|---|
+| `btn-home-threads` | Threads | Settings / Workspace or CRM context | **COLLAPSE** into destination section |
+
+### Workspace page buttons
+
+| Button ID | Label | New destination | Classification |
+|---|---|---|---|
+| `btn-workspace-home-refresh` | Refresh | Settings / Workspace | **KEEP** in Settings / Workspace |
+| `btn-workspace-board-refresh` | Refresh board | Settings / Workspace | **KEEP** in Settings / Workspace |
+| `btn-workspace-board-threads` | Threads view | Settings / Workspace | **KEEP** in Settings / Workspace |
+| `btn-workspace-board-architecture` | Architecture view | Settings / Workspace | **KEEP** in Settings / Workspace |
+| `btn-workspace-board-visual` | Visual view | Settings / Workspace | **KEEP** in Settings / Workspace |
+
+### Agent page buttons
+
+| Button ID | Label | New destination | Classification |
+|---|---|---|---|
+| `btn-agent-refresh` | Refresh agent | Settings / Agent / Advanced | **KEEP** in Settings / Agent section |
+| `btn-agent-open-home` | Home | — | **REMOVE** — Home is not top-level |
+| `btn-agent-open-settings` | Settings | Settings | **KEEP** — still a valid nav link to parent page |
+| `btn-agent-open-trust` | Trust | Settings / Governance | **RECLASSIFY** — becomes section link within Settings |
 
 ---
 
@@ -307,20 +400,20 @@ inject text.
 | News | Daily brief | "daily brief" | Yes | **KEEP** | Core |
 | News | Compare stories | "compare headlines 1 and 2" | Partial | **COLLAPSE** | Context-dependent |
 | News | Explain this page | "what is this page" | Weak | **REMOVE** | Noise |
-| Home | System status | "system status" | Yes | **KEEP** | Core |
-| Home | Calendar | "calendar" | Yes | **KEEP** | Core |
-| Home | Weather | "weather" | Yes | **KEEP** | Core |
-| Home | Home agent | "bridge status" | Yes | **COLLAPSE** | Diagnostic |
-| Home | Explain this | "explain this" | Partial | **COLLAPSE** | Context-dependent |
-| Home | Analyze screen | "analyze this screen" | Partial — setup-required | **REMOVE** | Implies computer-use; only works with capture |
-| Home | Show threads | "show threads" | Yes | **KEEP** | Core |
-| Home | Project status | "project status this" | Partial | **COLLAPSE** | Context-dependent |
-| Home | Most blocked | "which project is most blocked…" | Partial | **REMOVE** | Implies deep project management; overpromises |
-| Home | Memory overview | "memory overview" | Yes | **KEEP** | Core |
-| Home | Tone settings | "tone status" | Yes | **COLLAPSE** | Secondary |
-| Home | Schedules | "show schedules" | Partial | **COLLAPSE** | Secondary |
-| Home | Pattern review | "pattern status" | Yes | **COLLAPSE** | Secondary |
-| Policy | Create calendar rule | "policy create weekday calendar…" | Partial | **REMOVE** | Implies policy automation |
+| Home | System status | "system status" | Yes | **MOVE to Chat chips** | Useful; keep as a Chat-page chip since Home dissolves |
+| Home | Calendar | "calendar" | Yes | **MOVE to Chat chips** | Contextual; Chat renders calendar widget on request |
+| Home | Weather | "weather" | Yes | **MOVE to Chat chips** | Contextual; Chat renders weather widget on request |
+| Home | Home agent | "bridge status" | Yes | **MOVE to Settings / Agent** | Diagnostic; Settings / Agent section surfaces this |
+| Home | Explain this | "explain this" | Partial | **REMOVE** | Context-dependent; better via natural language in Chat |
+| Home | Analyze screen | "analyze this screen" | Partial — setup-required | **REMOVE** | Implies computer-use; setup-required and misleading |
+| Home | Show threads | "show threads" | Yes | **MOVE to Chat chips** | Useful; keep as Chat-page chip |
+| Home | Project status | "project status this" | Partial | **COLLAPSE** | Context-dependent; keep as secondary Chat chip if anything |
+| Home | Most blocked | "which project is most blocked…" | Partial | **REMOVE** | Overpromises project management depth |
+| Home | Memory overview | "memory overview" | Yes | **MOVE to Chat chips** | Useful; keep as Chat-page chip |
+| Home | Tone settings | "tone status" | Yes | **REMOVE** | Diagnostic; available via natural language |
+| Home | Schedules | "show schedules" | Partial | **REMOVE** | Secondary; not a default chip |
+| Home | Pattern review | "pattern status" | Yes | **REMOVE** | Secondary; not a default chip |
+| Policy | Create calendar rule | "policy create weekday calendar…" | Partial | **REMOVE** | Implies policy automation; no shortcut |
 | Policy | Create weather rule | "policy create daily weather…" | Partial | **REMOVE** | Same |
 
 ---
@@ -357,11 +450,19 @@ These appear after assistant responses and inject follow-up commands.
 
 ## Summary Counts
 
-| Classification | Count (approx) |
-|---|---|
-| KEEP | ~55 |
-| COLLAPSE | ~30 |
-| REMOVE | ~18 |
+Counts revised after product-direction correction and structural patch.
+Original counts (KEEP ~55 / COLLAPSE ~30 / REMOVE ~18) were based on the 10-page
+standalone-page hierarchy and are no longer accurate.
+
+Revised approximate counts after folding non-top-level pages into Settings / CRM:
+
+| Classification | Count (approx) | Notes |
+|---|---|---|
+| KEEP (as-is or in new destination) | ~50 | Core chat, memory actions, settings actions, news page, workspace board views in Settings, agent refresh in Settings |
+| COLLAPSE (behind expand/accordion) | ~20 | Trust subsections, diagnostics, some quick-action chips |
+| REMOVE | ~30 | Home nav, Policy create shortcuts, live-help, noisy chips, cross-page nav to dissolved pages, 5 Chat news buttons |
+| MOVE (chip to different page) | ~5 | Home chips → Chat chips |
+| RECLASSIFY (cross-page nav → section link) | ~4 | trust, agent, workspace nav links become same-page Settings section links |
 
 ---
 
@@ -373,18 +474,37 @@ PR title: `ui: simplify dashboard to start plus core navigation`
 
 Implement in this order to limit blast radius:
 
-1. **Reduce nav to four tabs + Start** — Chat, News, CRM (setup-required stub), Settings; hide Home, Memory,
-   Workspace, Trust, Policy, Agent from top-level nav
+1. **Reduce nav to four tabs + Start** — Chat, News, CRM (setup-required stub), Settings; hide Home,
+   Memory, Workspace, Trust, Policy, Agent from top-level nav bar
+
 2. **Reduce intro/Start screen** — strip to: welcome text, one-line authority boundary, Start button,
-   Settings link; remove action shortcut buttons
-3. **Expand Settings** — add sections for memory, governance/trust, policy, agent/OpenClaw, diagnostics,
-   advanced/proof; all previously top-level pages render as Settings sub-sections
-4. **Add CRM stub** — read-only, setup-required placeholder; no write actions; Shopify read status if
-   configured
-5. **Remove live-help buttons** — no clear governed path
-6. **Remove policy create shortcut buttons** — misleading capability
-7. **Remove noisy quick-action chips** (chat_plan_goal, chat_build_page, analyze screen, most_blocked,
-   phase42 follow-up)
+   Settings link; remove `btn-intro-daily-brief`, `btn-intro-open-home`, `btn-intro-open-home-ready`,
+   `btn-intro-open-landing`
+
+3. **Expand Settings with sub-sections** (the largest step — break into sub-commits):
+   - 3a: Add Memory sub-section — surface btn-memory-* buttons inside Settings
+   - 3b: Add Governance / Trust sub-section — trust center as accordion inside Settings
+   - 3c: Add Policy sub-section — policy overview only; no creation shortcuts
+   - 3d: Add Agent / Advanced sub-section — agent refresh, bridge status
+   - 3e: Add Workspace / Project sub-section — board views
+   - 3f: Add Diagnostics sub-section — workflow, operational context, assistive, runtime refresh
+   - 3g: Remove `btn-settings-open-home`, reclassify `btn-settings-open-trust` and
+     `btn-settings-open-agent` as same-page section links, keep `btn-settings-open-intro`
+
+4. **Add CRM stub** — setup-required placeholder per Section 3 CRM Stub definition;
+   Shopify read status if configured; no write actions
+
+5. **Remove Chat-page News button cluster** — remove `btn-news`, `btn-news-summary`,
+   `btn-news-refresh`, `btn-news-expand`, `btn-news-search` from Chat; Chat renders news
+   results inline when user asks; add one "Open News" navigation chip if needed
+
+6. **Relocate Home chips to Chat** — move weather, calendar, system-status, show-threads,
+   memory-overview chips to Chat page chips; remove analyze-screen, most-blocked, tone-settings,
+   schedules, pattern-review, explain-this Home chips
+
+7. **Remove live-help buttons**, **policy create shortcut buttons**, and remaining noisy chips
+   (chat_plan_goal, chat_build_page, phase42 follow-up, policy create chips)
+
 8. **Collapse trust card expanded detail** — default "No action taken."; expand on click
 
 ### Files likely affected

--- a/docs/status/UI_SIMPLIFICATION_INVENTORY_2026-05-09.md
+++ b/docs/status/UI_SIMPLIFICATION_INVENTORY_2026-05-09.md
@@ -1,0 +1,365 @@
+# UI Simplification Inventory - 2026-05-09
+
+Status: draft inventory / no runtime changes in this branch
+
+## Purpose
+
+Classify every visible dashboard control before the UI simplification
+implementation branch. The rule is:
+
+```text
+visible by default = only what the user needs + what the backend truly supports
+```
+
+A visible primary action button implies authority in Nova. If there is no
+governed backend path for the exact behavior, the button should not look like
+a primary action.
+
+## Classification Key
+
+```text
+KEEP      — required for normal use; backend-backed; stays visible
+COLLAPSE  — useful for diagnostics/governance but too noisy for default view;
+            hide behind Details/Advanced/Diagnostics drawer
+REMOVE    — shortcut/demo/future-looking/duplicative/not directly backend-backed;
+            confuses user expectation of capability
+```
+
+## Hard Constraints on This Inventory
+
+This doc classifies. It does not:
+
+- change any runtime code
+- change any JavaScript
+- add capabilities
+- remove governance visibility entirely
+- hide action/no-action status
+- approve Browser Use or computer-use expansion
+- approve OpenClaw expansion
+- approve external writes or autonomous workflows
+
+---
+
+## Section 1 — Core Chat Interface
+
+These are the non-negotiable user-facing controls. Nothing here should change.
+
+| Element | ID / location | Current behavior | Backend-backed? | Classification | Rationale |
+|---|---|---|---|---|---|
+| Chat input | `#chat-input` | Accepts user text | Yes | **KEEP** | Core interaction |
+| Send button | `#send-btn` | Sends message via `/ws` | Yes | **KEEP** | Core interaction |
+| Assistant response area | `#chat-messages` | Displays responses | Yes | **KEEP** | Core output |
+| Connection/status chip | `#header-connection-chip` | Shows connected/disconnected | Yes | **KEEP** | Truthfulness requirement |
+| Loading hint | `#loading-hint` | Shows "Nova is answering…" | Yes | **KEEP** | Guard visibility |
+| Thinking bar | orb/status indicator | Shows active turn in progress | Yes | **KEEP** | Guard visibility |
+
+---
+
+## Section 2 — Trust Receipt
+
+| Element | ID / location | Current behavior | Backend-backed? | Classification | Rationale |
+|---|---|---|---|---|---|
+| Trust Review Card | inline in `#chat-messages` | Displays non-action planning receipt | Yes | **KEEP** | Core governance visibility |
+| Trust strip / confidence badge | inline in responses | Shows "No action", confidence label | Yes | **KEEP** | Truthfulness requirement |
+| Trust receipt expanded detail | trust card body | Shows authority_effect, execution fields | Yes | **COLLAPSE** | Default: "No action taken." / Expanded: full detail on click |
+
+---
+
+## Section 3 — Navigation Tabs
+
+The nav bar is appropriate. All 10 pages have some backend-backed content.
+The issue is how full each page feels, not whether the tab exists.
+
+| Tab | Page | Backend-backed content? | Classification | Rationale |
+|---|---|---|---|---|
+| Chat | `page-chat` | Yes | **KEEP** | Primary page |
+| Home | `page-home` | Yes — system status, weather, calendar, threads | **KEEP** | Useful launch surface |
+| News | `page-news` | Yes — governed news/search | **KEEP** | Core feature |
+| Memory | `page-memory` | Yes — explicit memory store | **KEEP** | Core feature |
+| Workspace | `page-workspace` | Yes — thread/structure map | **KEEP** | Useful |
+| Trust | `page-trust` | Yes — trust/status surface | **KEEP** | Governance visibility |
+| Policy | `page-policy` | Partial — policy overview backend exists; creation is limited | **KEEP** (with note below) | Keep but clean up policy page action buttons |
+| Settings | `page-settings` | Yes — voice/runtime/connections | **KEEP** | Necessary |
+| Agent | `page-agent` | Partial — bridge status; limited live capability | **COLLAPSE** (into Settings or Trust) | Low user utility as a standalone tab; mostly duplicates Trust + Settings |
+| Intro | `page-intro` | Static onboarding content | **REMOVE** (or COLLAPSE to first-run only) | Not useful for ongoing sessions; should auto-dismiss after first use |
+
+---
+
+## Section 4 — Buttons: Chat Page
+
+| Button ID | Label | Current behavior | Backend-backed? | Classification | Rationale |
+|---|---|---|---|---|---|
+| `btn-news` | News | Requests news widget | Yes | **KEEP** | Core |
+| `btn-news-summary` | Summary | Requests news summary | Yes | **KEEP** | Core |
+| `btn-news-refresh` | Refresh | Refreshes news | Yes | **KEEP** | Core |
+| `btn-news-expand` | Expand | Expands news list | Yes | **KEEP** | Useful |
+| `btn-news-search` | Search | Opens search input | Yes | **KEEP** | Core |
+| `btn-morning-toggle` | Morning | Toggles morning panel | Yes | **KEEP** | Useful summary |
+| `btn-morning-calendar-connect` | Connect calendar | Opens calendar setup | Partial — setup-required | **COLLAPSE** | Only relevant pre-setup; show inline in calendar widget when setup-required |
+| `btn-hints-toggle` | Hints | Toggles hint panel | No direct backend | **REMOVE** | Adds noise; hints are low-value in current form |
+| `btn-live-help-start` | Live help start | Starts live help session | Unclear / limited | **REMOVE** | Implies autonomy; unclear governed path |
+| `btn-live-help-stop` | Live help stop | Stops live help | Same | **REMOVE** | Same as above |
+| `btn-live-help-explain` | Explain | Explain via live help | Same | **REMOVE** | Same as above |
+
+---
+
+## Section 5 — Buttons: Memory Page
+
+| Button ID | Label | Current behavior | Backend-backed? | Classification | Rationale |
+|---|---|---|---|---|---|
+| `btn-memory-overview` | Overview | Memory overview | Yes | **KEEP** | Core |
+| `btn-memory-list` | List | Memory list | Yes | **KEEP** | Core |
+| `btn-memory-list-all` | All | All memories | Yes | **KEEP** | Core |
+| `btn-memory-recent` | Recent | Recent memories | Yes | **KEEP** | Core |
+| `btn-memory-list-active` | Active | Active-tier filter | Yes | **KEEP** | Useful filter |
+| `btn-memory-list-locked` | Locked | Locked-tier filter | Yes | **KEEP** | Useful filter |
+| `btn-memory-list-deferred` | Deferred | Deferred-tier filter | Yes | **KEEP** | Useful filter |
+| `btn-memory-list-current-thread` | Thread | Thread-scoped filter | Yes | **KEEP** | Useful filter |
+| `btn-memory-refresh` | Refresh | Silent refresh | Yes | **KEEP** | Core |
+| `btn-memory-threads` | Threads | Thread-memory view | Yes | **KEEP** | Core |
+| `btn-memory-review-list` | Review | Memory review list | Yes | **KEEP** | Core |
+| `btn-memory-detail-edit` | Edit | Edit a memory | Yes | **KEEP** | Core action |
+| `btn-memory-detail-lock` | Lock | Lock a memory | Yes | **KEEP** | Core action |
+| `btn-memory-detail-unlock` | Unlock | Unlock a memory | Yes | **KEEP** | Core action |
+| `btn-memory-detail-defer` | Defer | Defer a memory | Yes | **KEEP** | Core action |
+| `btn-memory-detail-delete` | Delete | Delete a memory | Yes | **KEEP** | Core action |
+| `btn-memory-detail-show-chat` | Show in chat | Opens chat with memory context | Yes | **KEEP** | Useful |
+| `btn-memory-inline-confirm` | Confirm | Confirms inline edit | Yes | **KEEP** | Required for edit flow |
+| `btn-memory-inline-cancel` | Cancel | Cancels inline edit | Yes | **KEEP** | Required for edit flow |
+| `btn-memory-export` | Export | Exports memory | Partial — format unclear | **COLLAPSE** | Advanced; hide in details drawer |
+
+---
+
+## Section 6 — Buttons: Trust Center Page
+
+| Button ID | Label | Current behavior | Backend-backed? | Classification | Rationale |
+|---|---|---|---|---|---|
+| `btn-trust-center-refresh` | Refresh | Refreshes trust data | Yes | **KEEP** | Core |
+| `btn-trust-center-system` | System | Shows system section | Yes | **COLLAPSE** | Default: summary visible; sections behind expand |
+| `btn-trust-center-memory` | Memory | Shows memory section | Yes | **COLLAPSE** | Same |
+| `btn-trust-center-policy-map` | Policy map | Shows policy readiness | Yes | **COLLAPSE** | Same |
+| `btn-trust-center-voice-check` | Voice check | Runs voice check | Partial — setup-required | **COLLAPSE** | Only relevant post-setup |
+| `btn-trust-center-bridge-status` | Bridge | Shows bridge section | Yes | **COLLAPSE** | Diagnostic; collapse by default |
+| `btn-trust-center-workspace` | Workspace | Shows workspace section | Yes | **COLLAPSE** | Diagnostic |
+| `btn-trust-center-agent` | Agent | Shows agent section | Yes | **COLLAPSE** | Diagnostic |
+| `btn-trust-center-settings` | Settings | Navigates to settings | Yes | **KEEP** | Navigation |
+
+---
+
+## Section 7 — Buttons: Policy Page
+
+| Button ID | Label | Current behavior | Backend-backed? | Classification | Rationale |
+|---|---|---|---|---|---|
+| `btn-policy-refresh` | Refresh | Refreshes policy overview | Yes | **KEEP** | Core |
+| `btn-policy-capability-map` | Capability map | Shows capability readiness | Yes | **COLLAPSE** | Advanced/diagnostic |
+| `btn-policy-create-weather` | Create weather rule | Injects policy create command | Partial — policy path exists but limited | **REMOVE** | Looks like a capability; inject via chat if needed |
+| `btn-policy-create-calendar` | Create calendar rule | Same | Same | **REMOVE** | Same |
+| `btn-policy-create-status` | Create status rule | Same | Same | **REMOVE** | Same |
+| `btn-policy-open-trust` | Open trust | Navigates to trust | Yes | **KEEP** | Navigation |
+| `btn-policy-open-settings` | Open settings | Navigates to settings | Yes | **KEEP** | Navigation |
+
+---
+
+## Section 8 — Buttons: Settings Page
+
+| Button ID | Label | Current behavior | Backend-backed? | Classification | Rationale |
+|---|---|---|---|---|---|
+| `btn-settings-refresh-runtime` | Refresh runtime | Refreshes runtime status | Yes | **KEEP** | Core |
+| `btn-settings-voice-status` | Voice status | Shows voice status | Yes | **KEEP** | Core |
+| `btn-settings-voice-check` | Voice check | Runs voice check | Partial | **COLLAPSE** | Only useful post-setup |
+| `btn-settings-open-connections` | Connections | Navigates to connections | Yes | **KEEP** | Core navigation |
+| `btn-settings-open-trust` | Trust center | Navigates to trust | Yes | **KEEP** | Core navigation |
+| `btn-settings-open-home` | Home | Navigates to home | Yes | **KEEP** | Navigation |
+| `btn-settings-open-agent` | Agent | Navigates to agent | Yes | **COLLAPSE** | Low-value if agent page collapses |
+| `btn-settings-open-accessibility` | Accessibility | Opens accessibility settings | Yes | **KEEP** | Useful |
+| `btn-settings-open-privacy` | Privacy | Opens privacy settings | Yes | **KEEP** | Useful |
+| `btn-settings-open-intro` | Intro | Navigates to intro | Low | **REMOVE** | Intro page is low-value for ongoing sessions |
+| `btn-settings-reset-defaults` | Reset defaults | Resets settings | Yes | **KEEP** | Core — requires confirmation |
+| `btn-reset-confirm` | Confirm reset | Executes reset | Yes | **KEEP** | Required by reset flow |
+| `btn-reset-cancel` | Cancel reset | Aborts reset | Yes | **KEEP** | Required by reset flow |
+| `btn-profile-save-identity` | Save identity | Saves identity prefs | Yes | **KEEP** | Core |
+| `btn-profile-save-prefs` | Save prefs | Saves preferences | Yes | **KEEP** | Core |
+| `btn-profile-save-rules` | Save rules | Saves rule prefs | Yes | **KEEP** | Core |
+
+---
+
+## Section 9 — Buttons: Home, Workspace, Agent Pages
+
+| Button ID | Label | Current behavior | Backend-backed? | Classification | Rationale |
+|---|---|---|---|---|---|
+| `btn-home-threads` | Threads | Shows threads | Yes | **KEEP** | Core |
+| `btn-workspace-home-refresh` | Refresh | Refreshes workspace home | Yes | **KEEP** | Core |
+| `btn-workspace-board-refresh` | Refresh board | Refreshes board | Yes | **KEEP** | Core |
+| `btn-workspace-board-threads` | Threads view | Switches board view | Yes | **KEEP** | Core |
+| `btn-workspace-board-architecture` | Architecture view | Switches board view | Yes | **KEEP** | Useful |
+| `btn-workspace-board-visual` | Visual view | Switches board view | Yes | **KEEP** | Useful |
+| `btn-agent-refresh` | Refresh agent | Refreshes agent/bridge status | Yes | **KEEP** (if page kept) | Core for agent page |
+| `btn-agent-open-home` | Home | Navigates to home | Yes | **KEEP** | Navigation |
+| `btn-agent-open-settings` | Settings | Navigates to settings | Yes | **KEEP** | Navigation |
+| `btn-agent-open-trust` | Trust | Navigates to trust | Yes | **KEEP** | Navigation |
+
+---
+
+## Section 10 — Buttons: Intro Page
+
+| Button ID | Label | Classification | Rationale |
+|---|---|---|---|
+| `btn-intro-daily-brief` | Daily brief | **REMOVE** (with intro page) | Part of page to remove/collapse |
+| `btn-intro-open-connections` | Connections | **REMOVE** (with intro page) | Same |
+| `btn-intro-open-home` | Open home | **REMOVE** (with intro page) | Same |
+| `btn-intro-open-home-ready` | Home ready | **REMOVE** (with intro page) | Same |
+| `btn-intro-open-landing` | Landing | **REMOVE** (with intro page) | Same |
+| `btn-intro-open-settings` | Settings | **REMOVE** (with intro page) | Same |
+| `btn-intro-refresh-setup` | Refresh setup | **REMOVE** (with intro page) | Same |
+
+---
+
+## Section 11 — Buttons: Workflow / Operational Context
+
+| Button ID | Label | Current behavior | Backend-backed? | Classification | Rationale |
+|---|---|---|---|---|---|
+| `btn-workflow-show-steps` | Show steps | Shows workflow steps | Partial | **COLLAPSE** | Diagnostic; collapse by default |
+| `btn-workflow-refine` | Refine | Workflow refine action | Partial | **COLLAPSE** | Implies capability; collapse |
+| `btn-workflow-reset` | Reset | Resets workflow state | Yes | **COLLAPSE** | Diagnostic |
+| `btn-operational-context-refresh` | Refresh context | Refreshes operational context | Yes | **COLLAPSE** | Diagnostic |
+| `btn-operational-context-reset` | Reset context | Resets operational context | Yes | **COLLAPSE** | Diagnostic |
+| `btn-assistive-notices-refresh` | Refresh notices | Refreshes assistive notices | Yes | **COLLAPSE** | Diagnostic |
+| `btn-assistive-open-settings` | Settings | Navigates to settings | Yes | **KEEP** | Navigation |
+| `btn-connections-refresh` | Refresh | Refreshes connections | Yes | **KEEP** | Core |
+
+---
+
+## Section 12 — Quick Action Chips (Per-Page)
+
+Quick action chips are configurable shortcuts injected into the chat. The concern is
+that many look like primary capability buttons to a user who doesn't know they only
+inject text.
+
+| Page | Chip label | Command injected | Backend-backed? | Classification | Rationale |
+|---|---|---|---|---|---|
+| Chat | Plan this goal | "help me do this" | Weak | **REMOVE** | Generic; no specific backend path |
+| Chat | Build a page | "build me a landing page…" | Weak | **REMOVE** | Implies construction capability |
+| Chat | Research a topic | "research latest technology news" | Yes — search | **COLLAPSE** | Useful but should be in chat input, not chip |
+| Chat | Explain what I'm seeing | "explain this" | Partial | **COLLAPSE** | Useful when screen context exists |
+| Chat | Plan my day | "daily brief" | Yes | **KEEP** | Backend-backed; common user goal |
+| Chat | Continue a project | "show threads" | Yes | **KEEP** | Backend-backed |
+| Chat | Check project status | "project status this" | Partial | **COLLAPSE** | Useful but context-dependent |
+| Chat | Review project memory | "memory list thread this" | Yes | **KEEP** | Backend-backed |
+| Chat | Review saved memory | "memory overview" | Yes | **KEEP** | Backend-backed |
+| Chat | Review reminders | "show schedules" | Partial | **COLLAPSE** | Only useful if schedules exist |
+| Chat | Review patterns | "pattern status" | Yes | **KEEP** | Backend-backed |
+| Chat | System status | "system status" | Yes | **KEEP** | Backend-backed |
+| Chat | Tone settings | "tone status" | Yes | **COLLAPSE** | Diagnostic; secondary |
+| Chat | Create analysis doc | "create analysis report on…" | Partial | **REMOVE** | Implies document creation beyond current scope |
+| Chat | Open analysis docs | "list analysis docs" | Partial | **COLLAPSE** | Secondary |
+| News | Get headlines | "news" | Yes | **KEEP** | Core |
+| News | Source brief | "today's news" | Yes | **KEEP** | Core |
+| News | Daily brief | "daily brief" | Yes | **KEEP** | Core |
+| News | Compare stories | "compare headlines 1 and 2" | Partial | **COLLAPSE** | Context-dependent |
+| News | Explain this page | "what is this page" | Weak | **REMOVE** | Noise |
+| Home | System status | "system status" | Yes | **KEEP** | Core |
+| Home | Calendar | "calendar" | Yes | **KEEP** | Core |
+| Home | Weather | "weather" | Yes | **KEEP** | Core |
+| Home | Home agent | "bridge status" | Yes | **COLLAPSE** | Diagnostic |
+| Home | Explain this | "explain this" | Partial | **COLLAPSE** | Context-dependent |
+| Home | Analyze screen | "analyze this screen" | Partial — setup-required | **REMOVE** | Implies computer-use; only works with capture |
+| Home | Show threads | "show threads" | Yes | **KEEP** | Core |
+| Home | Project status | "project status this" | Partial | **COLLAPSE** | Context-dependent |
+| Home | Most blocked | "which project is most blocked…" | Partial | **REMOVE** | Implies deep project management; overpromises |
+| Home | Memory overview | "memory overview" | Yes | **KEEP** | Core |
+| Home | Tone settings | "tone status" | Yes | **COLLAPSE** | Secondary |
+| Home | Schedules | "show schedules" | Partial | **COLLAPSE** | Secondary |
+| Home | Pattern review | "pattern status" | Yes | **COLLAPSE** | Secondary |
+| Policy | Create calendar rule | "policy create weekday calendar…" | Partial | **REMOVE** | Implies policy automation |
+| Policy | Create weather rule | "policy create daily weather…" | Partial | **REMOVE** | Same |
+
+---
+
+## Section 13 — Suggested/Assistant Action Buttons (Per Response)
+
+These appear after assistant responses and inject follow-up commands.
+
+| Button label | Injected behavior | Backend-backed? | Classification | Rationale |
+|---|---|---|---|---|
+| "Follow-up analysis" | `phase42: follow up on this report…` | Partial | **REMOVE** | Internal command string visible to user; confusing |
+| "Expand", "Track story", "Compare" | Inject news follow-up commands | Yes | **KEEP** | Backend-backed news actions |
+| "Copy" | Copies response text | Client-only | **KEEP** | Useful utility |
+| Suggested actions (derived) | Commands like "Today's brief", "3 bullet version" | Yes | **COLLAPSE** | Show one max; not the full set |
+| "Sources and confidence" | Shows search source detail | Yes | **KEEP** | Governance visibility |
+| "What matters most?", "Best next step" | Planning follow-ups | Yes | **COLLAPSE** | Secondary; one or zero per response |
+
+---
+
+## Section 14 — Diagnostic / Proof Surfaces
+
+| Surface | Location | Classification | Rationale |
+|---|---|---|---|
+| Capability surface widget | Home page | **COLLAPSE** | Developer/operator view; not end-user |
+| Operator health widget | Home page | **COLLAPSE** | Developer/operator view |
+| Trust internals grid (provider, route, authority fields) | Trust page | **COLLAPSE** | Show summary; full grid behind expand |
+| Bridge/reasoning runtime grids | Trust page | **COLLAPSE** | Diagnostic; collapse by default |
+| Raw evidence chips (provider/freshness/source) | Search results | **KEEP** | Required for truthfulness; keep visible but compact |
+| `Confidence: …` badge | Responses | **KEEP** | Required for truthfulness |
+| `Evidence: …` / `Provider: …` / `Freshness: …` chips | Search widget | **COLLAPSE** | One-line summary visible; full detail behind expand |
+| Usage/route chips in chat | After responses | **COLLAPSE** | Debug info; collapse by default |
+
+---
+
+## Summary Counts
+
+| Classification | Count (approx) |
+|---|---|
+| KEEP | ~55 |
+| COLLAPSE | ~30 |
+| REMOVE | ~18 |
+
+---
+
+## Recommended Implementation Order
+
+### Branch 2: `ui/simplify-dashboard-default-experience`
+
+Implement in this order to limit blast radius:
+
+1. **Remove intro page buttons** — lowest risk; intro page has no backend behavior
+2. **Remove live-help buttons** — no clear governed path
+3. **Remove policy create shortcut buttons** — misleading capability
+4. **Remove noisy quick-action chips** (chat_plan_goal, chat_build_page, analyze screen, most_blocked, phase42 follow-up)
+5. **Collapse trust center subsection buttons** — keep Refresh and Settings; put subsections behind expand
+6. **Collapse workflow/operational buttons** — move to a Diagnostics section
+7. **Collapse capability/operator health widgets** — keep on page but collapsed by default
+8. **Collapse trust card expanded detail** — default "No action taken."; expand on click
+
+### Files likely affected
+
+```text
+nova_backend/static/index.html           — button removal, collapse wrappers
+nova_backend/static/dashboard-config.js — quick action chip lists
+nova_backend/static/dashboard-chat-news.js — suggested action button limits
+nova_backend/static/dashboard-control-center.js — trust/diagnostic section collapse
+Nova-Frontend-Dashboard/dashboard-chat-news.js — mirror of chat-news changes
+```
+
+### Verification after implementation
+
+```text
+node --check nova_backend/static/dashboard-chat-news.js
+node --check Nova-Frontend-Dashboard/dashboard-chat-news.js
+
+python -m pytest nova_backend/tests/phase45/test_dashboard_event_replay_harness.py \
+  nova_backend/tests/phase45/test_dashboard_auto_widget_dispatch.py \
+  nova_backend/tests/phase45/test_dashboard_no_auto_widget_dispatch.py \
+  nova_backend/tests/websocket/test_session_handler_proof_blockers.py \
+  nova_backend/tests/phase45/test_non_search_widget_fuzzing.py -q
+
+Expected: 51 passed
+```
+
+### Risks
+
+| Risk | Mitigation |
+|---|---|
+| Removing a button breaks a test assertion | Run full test suite before and after each removal batch |
+| Collapse hides content the user actually needs | Start with clear-REMOVE items; review COLLAPSE list in PR |
+| `dashboard-config.js` chip removal breaks chip rendering | Chip renderer degrades safely if the list is shorter |
+| Frontend mirror drifts from backend | Mirror both `dashboard-chat-news.js` files in each commit |

--- a/docs/status/UI_SIMPLIFICATION_INVENTORY_2026-05-09.md
+++ b/docs/status/UI_SIMPLIFICATION_INVENTORY_2026-05-09.md
@@ -394,7 +394,7 @@ inject text.
 | Chat | System status | "system status" | Yes | **KEEP** | Backend-backed |
 | Chat | Tone settings | "tone status" | Yes | **COLLAPSE** | Diagnostic; secondary |
 | Chat | Create analysis doc | "create analysis report on…" | Partial | **REMOVE** | Implies document creation beyond current scope |
-| Chat | Open analysis docs | "list analysis docs" | Partial | **COLLAPSE** | Secondary |
+| Chat | Open analysis docs | "list analysis docs" | Yes (Cap 54) | **COLLAPSE** | Lists real already-generated documents; only remaining path once Workspace folds into Settings |
 | News | Get headlines | "news" | Yes | **KEEP** | Core |
 | News | Source brief | "today's news" | Yes | **KEEP** | Core |
 | News | Daily brief | "daily brief" | Yes | **KEEP** | Core |
@@ -426,10 +426,12 @@ These appear after assistant responses and inject follow-up commands.
 |---|---|---|---|---|
 | "Follow-up analysis" | `phase42: follow up on this report…` | Partial | **REMOVE** | Internal command string visible to user; confusing |
 | "Expand", "Track story", "Compare" | Inject news follow-up commands | Yes | **KEEP** | Backend-backed news actions |
+| "Show topic map" | Injects "show topic map" after intel briefs | Yes (Cap 51) | **REMOVE or gate** | Cap 51 sends `topic_map` widget — no JS renderer; suggestion leads to unsupported widget fallback; remove until renderer exists |
 | "Copy" | Copies response text | Client-only | **KEEP** | Useful utility |
 | Suggested actions (derived) | Commands like "Today's brief", "3 bullet version" | Yes | **COLLAPSE** | Show one max; not the full set |
 | "Sources and confidence" | Shows search source detail | Yes | **KEEP** | Governance visibility |
 | "What matters most?", "Best next step" | Planning follow-ups | Yes | **COLLAPSE** | Secondary; one or zero per response |
+| "Second opinion" button (`#deepseek-btn`) | Permanent button in Chat input row; fires Cap 62 `external_reasoning_review` | Yes | **KEEP** | Always-visible, backend-backed, renders as enriched chat message with accuracy label |
 
 ---
 
@@ -445,6 +447,54 @@ These appear after assistant responses and inject follow-up commands.
 | `Confidence: …` badge | Responses | **KEEP** | Required for truthfulness |
 | `Evidence: …` / `Provider: …` / `Freshness: …` chips | Search widget | **COLLAPSE** | One-line summary visible; full detail behind expand |
 | Usage/route chips in chat | After responses | **COLLAPSE** | Debug info; collapse by default |
+
+---
+
+## Section 15 — Backend-Backed Widget Render Gaps
+
+These are not missing features. They are existing backend outputs that currently have no matching
+JavaScript render case. When the backend sends one of these widget types, the frontend dispatch
+falls to `renderUnsupportedWidgetEvent`. This was confirmed by cross-referencing all executor
+widget type emissions against the full JS dispatch table in `dashboard-chat-news.js`.
+
+Disposition decisions are required before live manual UI verification.
+
+| Widget type | Capability | Priority | Current symptom | Required disposition |
+|---|---|---|---|---|
+| `topic_map` | Cap 51 `topic_memory_map` | **High** | Cap 50 intel briefs inject "Show topic map" as a suggested action; clicking triggers Cap 51 which sends this widget → unsupported fallback | Remove "Show topic map" suggested action, OR add a renderer in the News flow |
+| `website_preview` | Cap 17 `open_website` | **High** | "open [url]" fires Cap 17 which classifies risk and emits this widget → unsupported fallback | Add a preview card renderer, OR remove the widget emit from Cap 17 and rely on the browser opening directly |
+| `story_tracker_update` / `story_tracker_view` | Cap 52/53 story tracker | **Medium** | "track story X" persists to disk and emits this widget → unsupported fallback | Remove "Track story" suggested actions for now, OR add a renderer in the News flow |
+| `shopify_intelligence_report` | Cap 65 Shopify intelligence | **Medium / CRM-blocking** | Any Shopify query fires Cap 65 which emits this widget → unsupported fallback | Must have a renderer before CRM stub can honestly list Shopify as available |
+
+### Fix vs defer guidance
+
+- `topic_map` — removing the "Show topic map" suggested action is a one-line config change and
+  the fastest safe option; add a renderer later under the News implementation
+- `website_preview` — either add a minimal renderer (domain + risk label + link) or strip the
+  widget emit from Cap 17 and open the browser directly via the existing confirmation flow
+- `story_tracker` — remove "Track story" suggested actions; defer renderer until a News story
+  tracking surface is designed
+- `shopify_intelligence_report` — must have a renderer before step 4 (CRM stub) is considered
+  done; a minimal Shopify card showing key metrics is sufficient
+
+---
+
+## Section 16 — Confirmed Non-Gaps
+
+The following were reviewed across three backend audit passes and are not dead render paths:
+
+| Item | Why not a gap |
+|---|---|
+| Cap 62 `external_reasoning_review` | Permanent `#deepseek-btn` "Second opinion" button in Chat input row; renders as enriched chat message |
+| `daily_brief` | Renders via `parseDailyBriefV2` from chat text; no standalone WS widget case needed |
+| `assistive_notices` | Sender in `working_context/assistive_noticing.py`; has JS case |
+| `operational_context` | Sender in `working_context/operational_remembrance.py`; has JS case |
+| `project_structure_map` | Sender in `utils/path_resolver.py`; has JS case |
+| `thread_map` | Sender in `working_context/project_threads.py`; has JS case |
+| `time_daily` / `time_weekly` | Internal policy trigger type strings; not sent as WS events |
+| `file` / `user_linked` | Internal data fields within executor results; not top-level WS events |
+| Token budget | Rendered via `token-budget-bar` element and `token_budget_update` WS case |
+| Provider policy | Rendered in `dashboard-control-center.js` settings section |
 
 ---
 
@@ -474,7 +524,14 @@ PR title: `ui: simplify dashboard to start plus core navigation`
 
 Implement in this order to limit blast radius:
 
-1. **Reduce nav to four tabs + Start** — Chat, News, CRM (setup-required stub), Settings; hide Home,
+1. **Dead-render disposition** — resolve each of the four widget render gaps before any nav change,
+   so live verification does not hit unsupported-widget fallbacks in normal use:
+   - Remove "Show topic map" suggested action (one-line config); defer `topic_map` renderer
+   - Add minimal `website_preview` renderer (domain + risk label + open link), or strip widget emit
+   - Remove "Track story" suggested actions; defer `story_tracker` renderer
+   - Add minimal `shopify_intelligence_report` card renderer (required before CRM stub step)
+
+2. **Reduce nav to four tabs + Start** — Chat, News, CRM (setup-required stub), Settings; hide Home,
    Memory, Workspace, Trust, Policy, Agent from top-level nav bar
 
 2. **Reduce intro/Start screen** — strip to: welcome text, one-line authority boundary, Start button,
@@ -529,14 +586,22 @@ python -m pytest nova_backend/tests/phase45/test_dashboard_event_replay_harness.
   nova_backend/tests/websocket/test_session_handler_proof_blockers.py \
   nova_backend/tests/phase45/test_non_search_widget_fuzzing.py -q
 
-Expected: 51 passed
+Expected: 51 passed (pre-simplification baseline)
+
+Note: if the implementation removes button IDs or JS strings that contract tests
+currently assert, those tests will fail by design, not by regression. Update
+assertions that reference removed elements; do not restore removed elements to
+make tests pass.
 ```
 
 ### Risks
 
 | Risk | Mitigation |
 |---|---|
-| Removing a button breaks a test assertion | Run full test suite before and after each removal batch |
+| Removing a button breaks a test assertion | Run suite before and after each removal batch; update assertions for intentional removals |
+| Dead-render fallback appears during verification | Resolve all four widget render gaps before live testing (Section 15) |
 | Collapse hides content the user actually needs | Start with clear-REMOVE items; review COLLAPSE list in PR |
+| Settings depth (10 sub-sections) feels cluttered | Group Governance+Policy as one "Governance" group; Agent+Workspace+Diagnostics as one "Advanced" group in the rendered UI |
 | `dashboard-config.js` chip removal breaks chip rendering | Chip renderer degrades safely if the list is shorter |
 | Frontend mirror drifts from backend | Mirror both `dashboard-chat-news.js` files in each commit |
+| CRM stub implies Shopify is ready before renderer exists | Step 1 (dead-render disposition) must complete the `shopify_intelligence_report` renderer before step 4 (CRM stub) ships |

--- a/docs/status/UI_SIMPLIFICATION_INVENTORY_2026-05-09.md
+++ b/docs/status/UI_SIMPLIFICATION_INVENTORY_2026-05-09.md
@@ -1,6 +1,38 @@
 # UI Simplification Inventory - 2026-05-09
 
-Status: draft inventory / no runtime changes in this branch
+Status: inventory / product-direction corrected 2026-05-09 / no runtime changes in this branch
+
+## Product Direction Correction (2026-05-09)
+
+The original inventory classified most pages as KEEP and the intro page as REMOVE.
+That was wrong for the product direction.
+
+The corrected target is:
+
+```text
+Start screen (Intro)
+↓
+Chat
+News
+CRM
+Settings
+```
+
+Everything else folds in:
+
+- Home → dissolve; useful status/morning pieces move into Chat or Settings
+- Memory → not top-level; exposed through Chat and Settings
+- Workspace → not top-level; business-facing pieces into CRM, diagnostics into Settings
+- Trust → not top-level; fold into Settings / Governance
+- Policy → not top-level; fold into Settings / Governance / Advanced
+- Agent → not top-level; fold into Settings / Advanced
+- CRM → new top-level; future-facing/read-only/setup-required
+
+CRM must be future-facing and read-only unless an exact governed backend capability
+exists. No CRM write actions. No Shopify writes. No email sends. No autonomous workflows.
+
+This changes the classification of navigation entries and intro page buttons below.
+All other section classifications remain valid.
 
 ## Purpose
 
@@ -65,23 +97,48 @@ These are the non-negotiable user-facing controls. Nothing here should change.
 
 ---
 
-## Section 3 — Navigation Tabs
+## Section 3 — Navigation: Target Product Hierarchy
 
-The nav bar is appropriate. All 10 pages have some backend-backed content.
-The issue is how full each page feels, not whether the tab exists.
+The corrected product hierarchy reduces top-level pages to four plus a Start screen.
+The current 10-tab structure is too wide and implies capabilities that are not top-level
+user goals.
 
-| Tab | Page | Backend-backed content? | Classification | Rationale |
-|---|---|---|---|---|
-| Chat | `page-chat` | Yes | **KEEP** | Primary page |
-| Home | `page-home` | Yes — system status, weather, calendar, threads | **KEEP** | Useful launch surface |
-| News | `page-news` | Yes — governed news/search | **KEEP** | Core feature |
-| Memory | `page-memory` | Yes — explicit memory store | **KEEP** | Core feature |
-| Workspace | `page-workspace` | Yes — thread/structure map | **KEEP** | Useful |
-| Trust | `page-trust` | Yes — trust/status surface | **KEEP** | Governance visibility |
-| Policy | `page-policy` | Partial — policy overview backend exists; creation is limited | **KEEP** (with note below) | Keep but clean up policy page action buttons |
-| Settings | `page-settings` | Yes — voice/runtime/connections | **KEEP** | Necessary |
-| Agent | `page-agent` | Partial — bridge status; limited live capability | **COLLAPSE** (into Settings or Trust) | Low user utility as a standalone tab; mostly duplicates Trust + Settings |
-| Intro | `page-intro` | Static onboarding content | **REMOVE** (or COLLAPSE to first-run only) | Not useful for ongoing sessions; should auto-dismiss after first use |
+### Target top-level pages
+
+| Page | Status | Notes |
+|---|---|---|
+| Start / Intro | **KEEP — new role** | Entry point; becomes a minimal welcome screen with one Start button and a Settings link |
+| Chat | **KEEP** | Primary page; unchanged |
+| News | **KEEP** | Core governed information feature; unchanged |
+| CRM | **ADD (future-facing)** | New page; read-only/setup-required; Shopify read status if configured; no writes |
+| Settings | **KEEP — expanded** | Absorbs governance, memory, voice, connections, policy, agent, diagnostics, advanced |
+
+### Pages folded out of top-level navigation
+
+| Current page | Disposition |
+|---|---|
+| Home (`page-home`) | Dissolve; morning/weather/status pieces move into Chat sidebar or Settings |
+| Memory (`page-memory`) | Not top-level; memory access through Chat (ask/remember) and Settings |
+| Workspace (`page-workspace`) | Not top-level; business-facing pieces into CRM; thread/structure into Settings / Advanced |
+| Trust (`page-trust`) | Not top-level; fold into Settings / Governance section |
+| Policy (`page-policy`) | Not top-level; fold into Settings / Governance / Advanced |
+| Agent (`page-agent`) | Not top-level; fold into Settings / Advanced |
+
+### Intro / Start screen buttons (corrected from Section 10)
+
+The intro page is **KEEP** — it becomes the Start screen, not a page to remove.
+Its buttons are reduced:
+
+| Button ID | Classification | Rationale |
+|---|---|---|
+| Start / enter-chat button | **KEEP** | One primary action: enter Chat |
+| `btn-intro-open-settings` | **KEEP** | Secondary link to Settings |
+| `btn-intro-open-connections` | **COLLAPSE** | Inline setup prompt is enough |
+| `btn-intro-daily-brief` | **REMOVE** | Specific action shortcut; not a launch button |
+| `btn-intro-open-home` | **REMOVE** | Home is not top-level |
+| `btn-intro-open-home-ready` | **REMOVE** | Same |
+| `btn-intro-open-landing` | **REMOVE** | Redundant |
+| `btn-intro-refresh-setup` | **COLLAPSE** | Surface inline; not a prominent button |
 
 ---
 
@@ -200,17 +257,10 @@ The issue is how full each page feels, not whether the tab exists.
 
 ---
 
-## Section 10 — Buttons: Intro Page
+## Section 10 — Buttons: Intro / Start Screen
 
-| Button ID | Label | Classification | Rationale |
-|---|---|---|---|
-| `btn-intro-daily-brief` | Daily brief | **REMOVE** (with intro page) | Part of page to remove/collapse |
-| `btn-intro-open-connections` | Connections | **REMOVE** (with intro page) | Same |
-| `btn-intro-open-home` | Open home | **REMOVE** (with intro page) | Same |
-| `btn-intro-open-home-ready` | Home ready | **REMOVE** (with intro page) | Same |
-| `btn-intro-open-landing` | Landing | **REMOVE** (with intro page) | Same |
-| `btn-intro-open-settings` | Settings | **REMOVE** (with intro page) | Same |
-| `btn-intro-refresh-setup` | Refresh setup | **REMOVE** (with intro page) | Same |
+**Corrected:** Intro page is KEEP as the Start screen (not REMOVE).
+See Section 3 for the corrected button-level classification.
 
 ---
 
@@ -317,17 +367,24 @@ These appear after assistant responses and inject follow-up commands.
 
 ## Recommended Implementation Order
 
-### Branch 2: `ui/simplify-dashboard-default-experience`
+### Branch 2: `ui/simplify-dashboard-core-navigation`
+
+PR title: `ui: simplify dashboard to start plus core navigation`
 
 Implement in this order to limit blast radius:
 
-1. **Remove intro page buttons** — lowest risk; intro page has no backend behavior
-2. **Remove live-help buttons** — no clear governed path
-3. **Remove policy create shortcut buttons** — misleading capability
-4. **Remove noisy quick-action chips** (chat_plan_goal, chat_build_page, analyze screen, most_blocked, phase42 follow-up)
-5. **Collapse trust center subsection buttons** — keep Refresh and Settings; put subsections behind expand
-6. **Collapse workflow/operational buttons** — move to a Diagnostics section
-7. **Collapse capability/operator health widgets** — keep on page but collapsed by default
+1. **Reduce nav to four tabs + Start** — Chat, News, CRM (setup-required stub), Settings; hide Home, Memory,
+   Workspace, Trust, Policy, Agent from top-level nav
+2. **Reduce intro/Start screen** — strip to: welcome text, one-line authority boundary, Start button,
+   Settings link; remove action shortcut buttons
+3. **Expand Settings** — add sections for memory, governance/trust, policy, agent/OpenClaw, diagnostics,
+   advanced/proof; all previously top-level pages render as Settings sub-sections
+4. **Add CRM stub** — read-only, setup-required placeholder; no write actions; Shopify read status if
+   configured
+5. **Remove live-help buttons** — no clear governed path
+6. **Remove policy create shortcut buttons** — misleading capability
+7. **Remove noisy quick-action chips** (chat_plan_goal, chat_build_page, analyze screen, most_blocked,
+   phase42 follow-up)
 8. **Collapse trust card expanded detail** — default "No action taken."; expand on click
 
 ### Files likely affected


### PR DESCRIPTION
## Summary

- Classifies all dashboard buttons, quick-action chips, and diagnostic surfaces as KEEP / COLLAPSE / REMOVE.
- Corrects the product target to **Start screen + Chat / News / CRM / Settings**.
- Adds Folded Page Destination Map, Settings Structure Map, and CRM Stub Definition.
- Retains Intro as the Start screen. Folds Home, Memory, Workspace, Trust, Policy, Agent out of top-level nav.
- Records four confirmed backend-backed widget render gaps with fix-vs-defer guidance.
- Records 10 confirmed non-gaps.
- Restores Cap 16 as the active priority per AGENTS.md; UI simplification is queued/planned, not active.
- Marks the live manual verification plan as a pre-simplification baseline only.
- Branch is docs-only; no runtime code, no JS, no capabilities changed.

## Notable decisions

- **KEEP:** Start screen, Chat, News, Settings, core chat controls, memory actions, source/confidence labels, "Second opinion" button (#deepseek-btn)
- **ADD:** CRM as future-facing / read-only / setup-required top-level page
- **FOLD:** Home, Memory, Workspace, Trust, Policy, Agent into Settings sub-sections or CRM
- **REMOVE:** live-help buttons, policy-create shortcuts, noisy chips, Chat duplicate News cluster, "Show topic map" suggested action (dead render path)
- **COLLAPSE:** diagnostics, proof surfaces, trust internals, workflow/operational controls, chat_doc_list chip
- **RECLASSIFY:** Settings open-trust / open-agent → same-page section links; Settings open-intro → Return to Start

## Backend-backed widget render gaps (4 confirmed dead render paths)

| Widget type | Cap | Priority |
|---|---|---|
| `topic_map` | 51 | High — suggested action after briefs leads here |
| `website_preview` | 17 | High — primary external URL feature |
| `story_tracker_update` / `story_tracker_view` | 52/53 | Medium |
| `shopify_intelligence_report` | 65 | CRM-blocking |

## Priority status

Cap 16 search reliability and conversation/search proof remains the active priority per AGENTS.md.
UI simplification is queued. `ui/simplify-dashboard-core-navigation` is a future candidate branch,
not the next active branch.

## Verification plan

`LIVE_MANUAL_UI_VERIFICATION_PLAN_2026-05-09.md` is marked as a pre-simplification baseline.
It tests the current 10-page UI. A separate post-simplification plan must be created after
`ui/simplify-dashboard-core-navigation` merges.

## Boundaries

No runtime code changed. No JS changed. No capabilities added. No OpenClaw, no browser/computer-use,
no external writes, no autonomous workflows.