### PR TITLE
fix: everyday UX friction slice 9 — RC-7 normalization, dead code, pipeline tests

### DIFF
--- a/nova_backend/src/conversation/response_style_router.py
+++ b/nova_backend/src/conversation/response_style_router.py
@@ -95,14 +95,16 @@ class InputNormalizer:
         (r"^\s*what are you good at\s*[.?!]*$", "what can you do"),
         (r"^\s*what do you know(?: how to do)?\s*[.?!]*$", "what can you do"),
         (r"^\s*what do you do\s*[.?!]*$", "what can you do"),
-        (r"^\s*(?:can|could) you help(?: me)?\s*[.?!]*$", "what can you do"),
-        (r"^\s*(?:i need|i want)\s+(?:some\s+)?help\s*[.?!]*$", "what can you do"),
-        (r"^\s*help me\s*[.?!]*$", "what can you do"),
         # Note: "who are you", "what is nova" are handled by the identity intent — not normalized here
+        # Note: "help me", "i need help", "can you help me", "where do i start" are intentionally
+        # NOT normalized here. They route to HELP_ORIENT_RE (RC-7 warm orienting question), not to
+        # the capability list. Normalizing them to "what can you do" would bypass that handler.
         (r"^\s*(?:show|list|tell me)\s+(?:your\s+)?(?:skills|features|options|commands|menu)\s*[.?!]*$", "what can you do"),
         (r"^\s*what(?:'s| is)\s+(?:available|possible)\s*[.?!]*$", "what can you do"),
         (r"^\s*(?:how do i|how can i)\s+use\s+(?:you|nova|this)\s*[.?!]*$", "what can you do"),
-        (r"^\s*(?:get started|where do i start|how do i start)\s*[.?!]*$", "what can you do"),
+        # "get started" and "how do i start" are explicit capability-discovery onboarding → list.
+        # "where do i start" is an orienting-help phrase → routes to HELP_ORIENT_RE instead.
+        (r"^\s*(?:get started|how do i start)\s*[.?!]*$", "what can you do"),
         (r"^\s*what(?:'s| is)\s+(?:the\s+)?time\s*$", "what time is it"),
         (r"^\s*time now\s*$", "what time is it"),
         (r"\bmake it louder\b", "volume up"),

--- a/nova_backend/src/governor/governor_mediator.py
+++ b/nova_backend/src/governor/governor_mediator.py
@@ -1161,8 +1161,7 @@ class GovernorMediator:
         if INTEL_BRIEF_RE.match(t):
             return _invocation_if_enabled(50, {})
 
-        if TODAY_NEWS_RE.match(t):
-            return _invocation_if_enabled(50, {"read_sources": True})
+        # TODAY_NEWS_RE check removed: unreachable — early pre-check at L902 returns first.
 
         m = EXPAND_STORY_INDEX_RE.match(t)
         if m:
@@ -1260,12 +1259,7 @@ class GovernorMediator:
                 candidate = ""
             return _invocation_if_enabled(62, {"text": candidate})
 
-        vm = VERIFY_RE.match(t)
-        if vm:
-            candidate = (vm.group("text") or "").strip()
-            if candidate.lower() in {"this", "that", "it"}:
-                candidate = ""
-            return _invocation_if_enabled(31, {"text": candidate})
+        # VERIFY_RE check removed: unreachable — early pre-check at L986 returns first.
 
         m = DOC_CREATE_RE.match(t)
         if m:
@@ -1409,9 +1403,7 @@ class GovernorMediator:
         if MEMORY_RECENT_RE.match(t):
             return _invocation_if_enabled(61, {"action": "recent"})
 
-        m = MEMORY_SEARCH_RE.match(t)
-        if m:
-            return _invocation_if_enabled(61, {"action": "search", "query": m.group("query").strip()})
+        # MEMORY_SEARCH_RE check removed: unreachable — early pre-check at L1014 returns first.
 
         if MEMORY_RECALL_FRIENDLY_RE.match(t):
             return _invocation_if_enabled(61, {"action": "overview"})

--- a/nova_backend/src/websocket/intent_patterns.py
+++ b/nova_backend/src/websocket/intent_patterns.py
@@ -60,7 +60,7 @@ EMAIL_INBOX_RESPONSE = (
 HELP_ORIENT_RE = re.compile(
     r"^\s*(?:"
     r"help\s+me"
-    r"|i\s+need\s+(?:some\s+)?help"
+    r"|i\s+(?:need|want)\s+(?:some\s+)?help"
     r"|can\s+you\s+help(?:\s+me)?"
     r"|could\s+you\s+help(?:\s+me)?"
     r"|i\s+(?:could\s+)?use\s+(?:some\s+)?help"

--- a/nova_backend/tests/websocket/test_session_layer_pipeline.py
+++ b/nova_backend/tests/websocket/test_session_layer_pipeline.py
@@ -1,0 +1,309 @@
+# tests/websocket/test_session_layer_pipeline.py
+"""
+Full-pipeline routing tests: InputNormalizer → session-layer patterns → governor.
+
+These tests simulate the production path that a raw user phrase travels through:
+
+  1. InputNormalizer.normalize()        (SessionRouter.normalize_and_route)
+  2. command_text strip [.?!]+$        (session_handler line 971)
+  3. Session-layer pattern checks       (HELP_ORIENT_RE, EMAIL_INBOX_RE, etc.)
+  4. GovernorMediator fallback          (if no session-layer match)
+
+Tests that skip InputNormalizer will miss bugs like the RC-7/PHRASE_NORMALIZATION
+collision, where phrases are transformed before session-layer patterns ever fire.
+"""
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from src.conversation.response_style_router import InputNormalizer
+from src.governor.governor_mediator import GovernorMediator
+from src.websocket.intent_patterns import (
+    AMBIENT_CLARIFICATION_PATTERNS,
+    CAPABILITY_HELP_RE,
+    EMAIL_INBOX_RE,
+    HELP_ORIENT_RE,
+    REMIND_ME_TIMELESS_RE,
+    TIME_QUERY_RE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _pipeline(raw: str) -> str | int | None:
+    """
+    Simulate the full production routing path for a raw user phrase.
+    Returns a string label (session-layer) or int capability_id (governor)
+    or None (LLM fallthrough).
+    """
+    # Step 1: normalize (InputNormalizer runs in SessionRouter.normalize_and_route)
+    normalized = InputNormalizer.normalize(raw)
+
+    # Step 2: strip trailing punctuation (session_handler line 971)
+    command_text = re.sub(r"[.?!]+$", "", normalized).strip()
+
+    # Step 3: session-layer checks (order matches session_handler)
+    if TIME_QUERY_RE.match(command_text):
+        return "TIME_QUERY"
+    if EMAIL_INBOX_RE.match(command_text):
+        return "EMAIL_INBOX"
+    if HELP_ORIENT_RE.match(command_text):
+        return "HELP_ORIENT"
+    if CAPABILITY_HELP_RE.match(command_text):
+        return "CAPABILITY_HELP"
+    if REMIND_ME_TIMELESS_RE.match(command_text):
+        return "REMIND_TIMELESS"
+    for pat, _ in AMBIENT_CLARIFICATION_PATTERNS:
+        if pat.match(command_text):
+            return "AMBIENT_CLARIFICATION"
+
+    # Step 4: governor
+    result = GovernorMediator.parse_governed_invocation(command_text)
+    if result is None:
+        return None
+    return getattr(result, "capability_id", None)
+
+
+# ---------------------------------------------------------------------------
+# RC-7: "help me" forms → HELP_ORIENT (warm orienting question)
+# These were previously broken: PHRASE_NORMALIZATION mapped them to
+# "what can you do", causing CAPABILITY_HELP to fire instead.
+# ---------------------------------------------------------------------------
+
+class TestRC7HelpOrient:
+    """Verify RC-7 routes to HELP_ORIENT through the full pipeline."""
+
+    @pytest.mark.parametrize("raw", [
+        "help me",
+        "Help me",
+        "HELP ME",
+        "help me!",           # trailing punct stripped
+        "i need help",
+        "i need some help",
+        "can you help me",
+        "could you help me",
+        "i could use some help",
+        "not sure what to ask",
+        "not sure what to do",
+        "where do i start",
+        "where do i begin",
+        # nova-prefix stripped by POLITE_PREFIX_RE in InputNormalizer
+        "nova help me",
+        "nova i need help",
+        "nova where do i start",
+        "hey nova help me",
+        "ok nova help me",
+    ])
+    def test_routes_to_help_orient(self, raw: str):
+        assert _pipeline(raw) == "HELP_ORIENT", (
+            f"{repr(raw)} should route to HELP_ORIENT; "
+            f"got {_pipeline(raw)!r}. "
+            f"Check PHRASE_NORMALIZATION in response_style_router.py — "
+            f"normalizing these phrases to 'what can you do' bypasses RC-7."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Capability list → CAPABILITY_HELP (explicit list requests, not "I'm lost")
+# ---------------------------------------------------------------------------
+
+class TestCapabilityHelp:
+    """Verify explicit capability-list requests stay in CAPABILITY_HELP."""
+
+    @pytest.mark.parametrize("raw", [
+        "what can you do",
+        "what can u do",
+        "what are you good at",
+        "what do you do",
+        "tell me what you can do",
+        "show me what you can do",
+        "show capabilities",
+        "show me your capabilities",
+        "what capabilities do you have",
+        "get started",
+        "how do i start",
+        "how do i use you",
+        "how can i use nova",
+        "what's available",
+        # nova-prefix
+        "nova what can you do",
+    ])
+    def test_routes_to_capability_help(self, raw: str):
+        assert _pipeline(raw) == "CAPABILITY_HELP", (
+            f"{repr(raw)} should route to CAPABILITY_HELP; got {_pipeline(raw)!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Email inbox boundary
+# ---------------------------------------------------------------------------
+
+class TestEmailInbox:
+    """RC-1: email inbox phrases → EMAIL_INBOX (not Cap 17 or LLM)."""
+
+    @pytest.mark.parametrize("raw", [
+        "open my email",
+        "check my email",
+        "check email",
+        "my inbox",
+        "show me my emails",
+        "nova open my email",
+        "hey nova check my email",
+    ])
+    def test_inbox_routes_correctly(self, raw: str):
+        assert _pipeline(raw) == "EMAIL_INBOX", (
+            f"{repr(raw)} should route to EMAIL_INBOX; got {_pipeline(raw)!r}"
+        )
+
+    @pytest.mark.parametrize("raw", [
+        "email John about the meeting",
+        "write an email to Sarah",
+        "draft an email",
+        "send an email to mom",
+    ])
+    def test_email_draft_does_not_hit_inbox(self, raw: str):
+        result = _pipeline(raw)
+        assert result != "EMAIL_INBOX", (
+            f"{repr(raw)} should NOT route to EMAIL_INBOX (it's a draft request); "
+            f"got {result!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Time / date queries
+# ---------------------------------------------------------------------------
+
+class TestTimeQuery:
+    """Time and date queries handled by session layer."""
+
+    @pytest.mark.parametrize("raw", [
+        "what time is it",
+        "what time is it?",
+        "what day is it",
+        "what's today's date",
+        "what's the date",
+        "current time",
+        "nova what time is it",
+        "hey nova what time is it",
+    ])
+    def test_routes_to_time_query(self, raw: str):
+        assert _pipeline(raw) == "TIME_QUERY", (
+            f"{repr(raw)} should route to TIME_QUERY; got {_pipeline(raw)!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Timeless reminder boundary
+# ---------------------------------------------------------------------------
+
+class TestRemindMeTimeless:
+    """Timeless remind-me forms → clarification; full form passes through."""
+
+    @pytest.mark.parametrize("raw", [
+        "remind me to call mom",
+        "remind me to exercise",
+        "set a reminder",
+        "nova remind me to call mom",
+    ])
+    def test_timeless_routes_to_clarification(self, raw: str):
+        assert _pipeline(raw) == "REMIND_TIMELESS", (
+            f"{repr(raw)} should route to REMIND_TIMELESS; got {_pipeline(raw)!r}"
+        )
+
+    @pytest.mark.parametrize("raw", [
+        "remind me at 3pm to call mom",
+        "remind me daily at 9am to check email",
+    ])
+    def test_full_form_does_not_hit_timeless(self, raw: str):
+        result = _pipeline(raw)
+        assert result != "REMIND_TIMELESS", (
+            f"{repr(raw)} has a time spec — should NOT route to REMIND_TIMELESS; "
+            f"got {result!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Core governor routing through full pipeline
+# ---------------------------------------------------------------------------
+
+class TestGovernorRoutingPipeline:
+    """Key governor routes verified through the full InputNormalizer pipeline."""
+
+    @pytest.mark.parametrize("raw,expected_cap", [
+        ("what's the news", 56),
+        ("show me the news", 56),
+        ("morning news", 56),
+        ("catch me up", 56),
+        ("what did i miss", 56),
+        ("today's news", 50),
+        ("what's the weather", 55),
+        ("check weather", 55),
+        ("will it snow tomorrow", 55),
+        ("should i bring an umbrella", 55),
+        ("search for AI news", 16),
+        ("look up quantum computing", 16),
+        ("find me a recipe for pasta", 16),
+        ("verify this", 31),
+        ("fact check the moon has an atmosphere", 31),
+        ("what have you saved for me", 61),
+        ("what have i saved", 61),
+        ("how is the AI story doing", 52),
+        ("send an email", 64),
+        ("can you help me write an email", 64),
+    ])
+    def test_governor_cap(self, raw: str, expected_cap: int):
+        assert _pipeline(raw) == expected_cap, (
+            f"{repr(raw)} should route to Cap {expected_cap}; got {_pipeline(raw)!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Ambient clarification — only fires without prior context
+# (context guard tested at the handler level; here we test pattern matching)
+# ---------------------------------------------------------------------------
+
+class TestAmbientClarificationPatterns:
+    """Ambient patterns match correctly (context guard tested separately)."""
+
+    @pytest.mark.parametrize("raw", [
+        "tell me more",
+        "tell me more about that",
+        "go deeper",
+        "elaborate",
+        "what went wrong",
+        "why didn't that work",
+        "idk what to do",
+        "i'm lost",
+        "i'm stuck",
+        "why did that fail",
+        "what should i do today",
+    ])
+    def test_matches_ambient_pattern(self, raw: str):
+        # These should match AMBIENT_CLARIFICATION_PATTERNS directly
+        # (pipeline may or may not fire depending on session state in production)
+        normalized = InputNormalizer.normalize(raw)
+        command_text = re.sub(r"[.?!]+$", "", normalized).strip()
+        matched = any(pat.match(command_text) for pat, _ in AMBIENT_CLARIFICATION_PATTERNS)
+        assert matched, (
+            f"{repr(raw)} (normalized to {repr(command_text)!r}) "
+            f"should match an AMBIENT_CLARIFICATION_PATTERNS entry"
+        )
+
+    @pytest.mark.parametrize("raw", [
+        # These have prior-context intent but should NOT be in ambient patterns
+        "what's the weather",
+        "search for AI news",
+        "what can you do",
+    ])
+    def test_does_not_match_ambient_pattern(self, raw: str):
+        normalized = InputNormalizer.normalize(raw)
+        command_text = re.sub(r"[.?!]+$", "", normalized).strip()
+        matched = any(pat.match(command_text) for pat, _ in AMBIENT_CLARIFICATION_PATTERNS)
+        assert not matched, (
+            f"{repr(raw)} should NOT match AMBIENT_CLARIFICATION_PATTERNS; "
+            f"got a match on {repr(command_text)}"
+        )

--- a/nova_backend/tests/websocket/test_session_layer_pipeline.py
+++ b/nova_backend/tests/websocket/test_session_layer_pipeline.py
@@ -97,6 +97,10 @@ class TestRC7HelpOrient:
         "nova where do i start",
         "hey nova help me",
         "ok nova help me",
+        # "i want help" forms — distinct from "i need help", same intent
+        "i want help",
+        "i want some help",
+        "nova i want help",
     ])
     def test_routes_to_help_orient(self, raw: str):
         assert _pipeline(raw) == "HELP_ORIENT", (
@@ -104,6 +108,20 @@ class TestRC7HelpOrient:
             f"got {_pipeline(raw)!r}. "
             f"Check PHRASE_NORMALIZATION in response_style_router.py — "
             f"normalizing these phrases to 'what can you do' bypasses RC-7."
+        )
+
+    @pytest.mark.parametrize("raw", [
+        # These start with "help me" but have a task suffix — should fall through to
+        # governor or LLM, not fire the short orienting question.
+        "help me write a letter",
+        "help me draft an email",
+        "help me plan my day",
+    ])
+    def test_help_with_task_does_not_route_to_help_orient(self, raw: str):
+        result = _pipeline(raw)
+        assert result != "HELP_ORIENT", (
+            f"{repr(raw)} has a task suffix — should NOT route to HELP_ORIENT; "
+            f"got {result!r}"
         )
 
 


### PR DESCRIPTION
## Summary

Three targeted fixes found by running the full `InputNormalizer → session-layer → governor`
production pipeline in analysis, not just testing patterns in isolation.

## Changes

### 1. RC-7 normalization conflict fixed (`response_style_router.py`)

`PHRASE_NORMALIZATION` was silently mapping `"help me"`, `"i need help"`, `"can you help me"`,
and `"where do i start"` to `"what can you do"` before the session loop ran. This caused
`CAPABILITY_HELP_RE` to fire instead of `HELP_ORIENT_RE`, making the RC-7 warm orienting
response **unreachable in production** for its four most natural trigger phrases.

Removed three conflicting entries; narrowed one. Added inline comment marking the RC-7
boundary for future editors.

**Before:** `"help me"` → normalized to `"what can you do"` → capability list
**After:** `"help me"` → stays as `"Help me."` → `HELP_ORIENT_RE` → warm orienting question

### 2. `HELP_ORIENT_RE` extended (`intent_patterns.py`)

Added `"i want (some) help"` alongside `"i need (some) help"` — same intent, missing variant.
Pattern: `i\s+(?:need|want)\s+(?:some\s+)?help`

### 3. Dead downstream pattern checks removed (`governor_mediator.py`)

Three patterns gained unconditional early pre-checks during slices 6-7. Their original
downstream locations became unreachable. Removed:
- `TODAY_NEWS_RE` at L1164 (active at L902)
- `VERIFY_RE` at L1263 (active at L986)
- `MEMORY_SEARCH_RE` at L1412 (active at L1014)

### 4. Full-pipeline routing tests added (`tests/websocket/test_session_layer_pipeline.py`)

98 new assertions covering the full production path: `InputNormalizer.normalize()` →
`command_text` strip → session-layer patterns → governor. Previous verification tests
bypassed `InputNormalizer` and would have missed the RC-7 bug entirely.

Key classes: `TestRC7HelpOrient` (21 cases including `"i want help"` forms + 3 negative
task-suffix cases), `TestCapabilityHelp` (15), `TestEmailInbox`, `TestTimeQuery`,
`TestRemindMeTimeless`, `TestGovernorRoutingPipeline` (20 caps), `TestAmbientClarificationPatterns`.

## Test results

**536 passed** — websocket + conversation suites (6.8s local)
**98 passed** — new pipeline tests only (0.3s local)

## CI note

The failing CI checks (`lint-and-test`, `runtime-docs`, `verify-phase35`, adversarial urllib)
are **pre-existing on main** — same workflows fail on the merge target. The lint errors are in
`action_request.py`, `action_types.py`, and `agents/__init__.py` (untouched by this PR).
The adversarial failure is `search_synthesis.py` importing `urllib` (also untouched).
The `verify-phase35` failure is a missing `pytest` install in that CI environment.

None of the failing checks touch the files changed in this PR.

## Scope

- No new capabilities
- No authority changes
- `response_style_router.py` change is pure normalization routing — does not affect any capability executor
- `intent_patterns.py` change extends HELP_ORIENT_RE only — no new handler code
- Governor change is dead code removal only — no routing behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)