### PR TITLE
docs: clarify Nova two-domain product direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,23 @@ Nova focuses on what the system is allowed to do, how actions are routed, and ho
 ## Why Nova
 Most AI tools optimize for capability expansion. Nova emphasizes bounded execution, reviewable actions, local ownership, and user-visible control.
 
+Nova is intended to evolve into:
+
+```text
+A governed personal operational intelligence platform.
+```
+
+The long-term direction has two connected domains:
+
+```text
+1. Everyday home / voice / local assistant platform
+2. Creator-business operational intelligence platform
+```
+
+See:
+- [Nova Two-Domain Direction](docs/future/NOVA_TWO_DOMAIN_DIRECTION_2026-05-11.md)
+- [Nova Creator-Led Shopify POD Model](docs/future/NOVA_CREATOR_LED_SHOPIFY_POD_MODEL_2026-05-11.md)
+
 ## Start Here
 1. [Start Here](START_HERE.md)
 2. [Quickstart](QUICKSTART.md)
@@ -68,6 +85,8 @@ For current human-readable work continuity, including what is committed versus l
 For the 2026-05-01 branch/workstream alignment map, use [Repo Branch and Workstream Status](docs/status/REPO_BRANCH_AND_WORKSTREAM_STATUS_2026-05-01.md).
 
 ## Future Directions
+- [Nova Two-Domain Direction](docs/future/NOVA_TWO_DOMAIN_DIRECTION_2026-05-11.md)
+- [Nova Creator-Led Shopify POD Model](docs/future/NOVA_CREATOR_LED_SHOPIFY_POD_MODEL_2026-05-11.md)
 - [Realistic Scope and Priorities](docs/future/REALISTIC_SCOPE_AND_PRIORITIES.md)
 - [Google Connector Model](docs/future/NOVA_GOOGLE_CONNECTOR_MODEL.md)
 - [Google Connector Implementation Roadmap](docs/future/GOOGLE_CONNECTOR_IMPLEMENTATION_ROADMAP.md)

--- a/docs/future/NOVA_TWO_DOMAIN_DIRECTION_2026-05-11.md
+++ b/docs/future/NOVA_TWO_DOMAIN_DIRECTION_2026-05-11.md
@@ -1,7 +1,7 @@
 # Nova Two-Domain Direction
 
 Date: 2026-05-11
-Status: planning lock / future direction / non-runtime-authority
+Status: future direction / planning record / non-runtime-authority
 
 ## Purpose
 

--- a/docs/future/NOVA_TWO_DOMAIN_DIRECTION_2026-05-11.md
+++ b/docs/future/NOVA_TWO_DOMAIN_DIRECTION_2026-05-11.md
@@ -1,0 +1,307 @@
+# Nova Two-Domain Direction
+
+Date: 2026-05-11
+Status: planning lock / future direction / non-runtime-authority
+
+## Purpose
+
+Record the intended long-term direction for Nova as a governed personal operational intelligence platform with two connected domains:
+
+1. Everyday home / voice / local assistant platform
+2. Creator-business operational intelligence platform
+
+This document is planning truth only. It does not add runtime authority, capabilities, external writes, autonomous workflows, browser/computer-use, or OpenClaw expansion.
+
+The core rule remains:
+
+```text
+Intelligence is not authority.
+```
+
+---
+
+## Direction Statement
+
+Nova is not only a chatbot and not only a business tool.
+
+The intended direction is:
+
+```text
+Nova = governed personal operational intelligence platform
+```
+
+Nova should become useful in two real-world domains:
+
+```text
+Everyday life / home / local voice assistant
++
+Creator-led business operations / Shopify / marketing / analytics / finance visibility
+```
+
+These domains share the same governed execution model.
+
+---
+
+## Domain 1: Everyday Home / Voice / Local Assistant Platform
+
+### Goal
+
+Build Nova first as an everyday local-first assistant platform that can help with real tasks under bounded, visible authority.
+
+This is the first platform layer.
+
+Nova should be able to help with ordinary daily interaction through voice, chat, and dashboard controls, then route real actions through governed capability paths.
+
+### Intended capabilities over time
+
+- voice interaction
+- local dashboard interaction
+- system status and diagnostics
+- local search and governed web search where explicitly requested
+- reminders and schedules
+- file/folder opening where governed
+- screen capture and screen explanation where governed
+- news/weather/current-information snapshots
+- memory review and recall under memory governance
+- local device and desktop workflows where explicitly invoked
+- home/desktop operational assistance
+- visible degraded/setup-required states
+- confirmation-gated actions where required
+
+### What “actual things” means
+
+Actual things means Nova may operate approved local capabilities and governed integrations that the user explicitly invokes.
+
+Examples of intended future usefulness:
+
+- open a folder
+- check system status
+- capture/explain the screen
+- read the news/weather snapshot
+- draft an email without sending it
+- help organize local work
+- run bounded local routines
+- prepare task plans
+- surface reminders
+- eventually control approved home/desktop actions through explicit governed capabilities
+
+Actual things does not mean hidden autonomy or silent computer use.
+
+### Boundary
+
+Nova may eventually do practical work for the user, but those actions must remain:
+
+```text
+explicit
+bounded
+visible
+logged
+reviewable
+confirmation-gated where required
+```
+
+Nova must not become a hidden background actor, unbounded autonomous agent, or silent computer-use system.
+
+---
+
+## Domain 2: Creator-Business Operational Intelligence Platform
+
+### Goal
+
+Use Nova as the governed operating intelligence layer for creator-led businesses, starting with Christopher's Shopify + print-on-demand / art / clothing direction.
+
+This is the second platform layer.
+
+It exists because Nova should be useful against real business pressure, not only demo prompts.
+
+### Intended model
+
+```text
+Christopher creates.
+Shopify sells.
+Printful fulfills.
+Nova analyzes, drafts, reports, and recommends.
+Christopher approves actions.
+```
+
+### Intended responsibilities for Nova
+
+- marketing planning
+- campaign drafting
+- product-performance analytics
+- Shopify reporting
+- finance visibility
+- margin tracking
+- KPI summaries
+- customer/order summaries
+- design backlog organization
+- content calendar planning
+- trend detection
+- recommended next actions
+- business-risk warnings
+- weekly/monthly performance reviews
+
+### Marketing manager meaning
+
+Nova may help manage marketing visibility and planning:
+
+- identify what products to promote
+- draft campaigns
+- draft captions and product descriptions
+- compare platform performance
+- recommend content themes
+- summarize campaign results
+- prepare launch checklists
+
+Nova does not autonomously publish, spend, boost, or message customers.
+
+### Data analytics manager meaning
+
+Nova may help manage analytics visibility:
+
+- Shopify metrics
+- product views
+- conversion rates
+- order volume
+- revenue
+- traffic source summaries
+- customer/order patterns
+- campaign performance
+- trend detection
+
+Nova reports and recommends. It does not falsify certainty or hide source gaps.
+
+### Finance manager meaning
+
+Nova may help manage financial visibility:
+
+- revenue summaries
+- cost of goods visibility
+- Printful cost estimates
+- Shopify/payment fee estimates
+- ad spend summaries where data is provided
+- gross margin
+- estimated net profit
+- cash-flow warnings
+- pricing recommendations
+
+Nova does not move money, file taxes, make payments, spend ad budget, alter bank settings, or perform autonomous financial transactions.
+
+### Boundary
+
+Nova should manage business visibility and recommendations, not autonomous business authority.
+
+Nova must not autonomously:
+
+- spend money
+- publish products
+- change prices
+- send marketing emails
+- post on social media
+- issue refunds
+- change Shopify settings
+- perform financial transactions
+- create external writes without approval
+
+---
+
+## Shared Governance Model
+
+Both domains use the same Nova rule:
+
+```text
+Nova prepares intelligence.
+Christopher authorizes execution.
+```
+
+Even when Nova gains stronger practical usefulness, execution must stay behind the governed path:
+
+```text
+User -> GovernorMediator -> CapabilityRegistry -> ExecuteBoundary -> NetworkMediator where needed -> LedgerWriter
+```
+
+No future domain should create a bypass around the governance spine.
+
+---
+
+## Why Both Domains Matter
+
+The everyday/home assistant domain proves Nova can be useful as a daily personal system.
+
+The creator-business domain proves Nova can operate against real business pressure:
+
+- real metrics
+- real products
+- real customers
+- real campaigns
+- real finances
+- real operational decisions
+
+Together, they make Nova more than an assistant UI.
+
+They define Nova as:
+
+```text
+personal operational intelligence infrastructure
+```
+
+---
+
+## Product Direction in One Sentence
+
+```text
+Nova is a governed local-first operational intelligence platform for everyday life and creator-business operations.
+```
+
+---
+
+## Priority Warning
+
+This document does not change the active work priority.
+
+Implementation must still follow the current priority lock and continuity files.
+
+Do not use this direction document to start:
+
+- Shopify writes
+- Cap 64 P5
+- Google connector runtime work
+- UI simplification
+- OpenClaw expansion
+- browser/computer-use expansion
+- autonomous workflow execution
+- social posting automation
+- finance automation
+
+without a separate reviewed priority lock.
+
+---
+
+## First Practical Sequence
+
+The safest sequence remains:
+
+1. Make Nova useful daily as a local-first voice/dashboard assistant.
+2. Keep governed execution boundaries visible and reliable.
+3. Use one real creator-business workflow as a proving ground.
+4. Start with read-only Shopify/business intelligence.
+5. Add drafting and recommendation surfaces.
+6. Add approval-gated execution only after proof and lock review.
+
+---
+
+## Final Direction Lock
+
+The intended long-term direction is:
+
+```text
+Everyday governed local assistant platform
++
+Creator-business operational intelligence layer
+```
+
+Nova should become useful enough to help with real daily life and real business operations, while preserving the core invariant:
+
+```text
+Intelligence is not authority.
+```

--- a/docs/future/NOVA_TWO_DOMAIN_DIRECTION_2026-05-11.md
+++ b/docs/future/NOVA_TWO_DOMAIN_DIRECTION_2026-05-11.md
@@ -5,7 +5,7 @@ Status: future direction / planning record / non-runtime-authority
 
 ## Purpose
 
-Record the intended long-term direction for Nova as a governed personal operational intelligence platform with two connected domains:
+Record what Nova is intended to be and the long-term direction for Nova as a governed personal operational intelligence platform with two connected domains:
 
 1. Everyday home / voice / local assistant platform
 2. Creator-business operational intelligence platform
@@ -16,6 +16,46 @@ The core rule remains:
 
 ```text
 Intelligence is not authority.
+```
+
+---
+
+## What Nova Is / What Nova Will Be
+
+Nova is intended to be a governed local-first operational intelligence platform.
+
+Nova is not just:
+
+- a chatbot
+- a voice UI
+- a dashboard
+- a business analytics tool
+- a home assistant clone
+- an automation script runner
+- an autonomous agent
+
+Nova is the governed intelligence and execution-control layer that can help with real life and real work while keeping authority bounded, visible, and reviewable.
+
+In practical terms:
+
+```text
+Nova understands, organizes, reports, drafts, recommends, and routes approved actions.
+```
+
+Nova should eventually support both:
+
+```text
+Everyday personal/home operation
++
+Creator-business operation
+```
+
+without turning into hidden autonomy.
+
+The product identity is:
+
+```text
+Governed local-first operational intelligence for everyday life and creator-business operations.
 ```
 
 ---


### PR DESCRIPTION
## Summary

Adds and surfaces Nova’s two-domain long-term direction:

1. Everyday home / voice / local assistant platform
2. Creator-business operational intelligence platform

Clarifies what Nova is / will be:

```text
Governed local-first operational intelligence for everyday life and creator-business operations.
```

## Files changed

- `README.md`
- `docs/future/NOVA_TWO_DOMAIN_DIRECTION_2026-05-11.md`

## Boundaries

Docs-only.

No runtime changes.
No capability expansion.
No authority expansion.
No OpenClaw expansion.
No browser/computer-use expansion.
No external writes.
No autonomous workflow approval.

## Governance

Preserves the core invariant:

```text
Intelligence is not authority.
```

This document is a future-direction planning record and does not change the active priority lock.