### PR TITLE
docs: lock audit-first safety boundary

### DIFF
--- a/.agent_context/current_priority.md
+++ b/.agent_context/current_priority.md
@@ -3,10 +3,16 @@
 Current active task:
 
 ```text
-Status / continuity synchronization after PR #144-#148.
+Full repo/doc/code alignment audit — safety-bounded, audit-only.
 ```
 
-No runtime implementation priority is selected until the continuity synchronization lands.
+Branch:
+
+```text
+audit/full-repo-doc-code-alignment
+```
+
+This is an audit-first priority. It does not authorize runtime implementation changes.
 
 ## Recent merged truth
 
@@ -17,6 +23,45 @@ PR #145 — Work Style Enforcement Lock merged.
 PR #146 — Creator-led Shopify/POD future direction merged.
 PR #147 — Nova two-domain product direction merged.
 PR #148 — Piper-first voice direction merged.
+PR #149 — Current status / continuity synchronization merged.
+```
+
+## Audit scope
+
+```text
+1. Runtime/generated truth reconciliation
+2. Capability registry ↔ docs alignment
+3. Governance authority/bypass audit
+4. UI/WebSocket/routing audit
+5. Future docs/planning-only labeling audit
+6. Proof/test/CI claims audit
+7. Stale/duplicate docs cleanup map
+8. Final patch roadmap
+```
+
+## Safety boundary
+
+The audit may identify gaps and propose patches.
+
+The audit must not directly implement runtime fixes unless a separate reviewed priority lock is created.
+
+Do not start or include:
+
+```text
+runtime behavior changes
+capability expansion
+authority expansion
+OpenClaw expansion
+browser/computer-use expansion
+external writes
+Shopify writes
+email sending
+finance automation
+social posting automation
+ElevenLabs implementation
+Google connector runtime implementation
+UI simplification implementation
+autonomous workflow execution
 ```
 
 ## Open carried-forward follow-ups
@@ -27,25 +72,15 @@ PR #148 — Piper-first voice direction merged.
 #143 — "tell me more" with prior context needs session-state-aware test.
 ```
 
-## Queued / not active
-
-```text
-UI simplification
-Cap 64 P5
-Google connector runtime implementation
-Shopify writes
-ElevenLabs implementation
-OpenClaw expansion
-browser/computer-use expansion
-external writes
-finance automation
-social posting automation
-autonomous workflow execution
-```
+#141 is likely the first runtime fix after the audit, but it is not authorized by this audit lock.
 
 ## Preserved boundaries
 
+```text
+Intelligence is not authority.
+```
+
 Do not add capabilities, expand OpenClaw, add browser/computer-use, add external writes,
-add autonomous workflows, or bypass GovernorMediator during continuity synchronization.
+add autonomous workflows, or bypass GovernorMediator during the audit.
 
 This file is an agent continuity note. Runtime truth still comes from code and generated runtime docs.


### PR DESCRIPTION
## Summary

Locks the next priority to a safety-bounded full repo/doc/code alignment audit.

The active task is now:

```text
Full repo/doc/code alignment audit — safety-bounded, audit-only.
```

## Files changed

- `.agent_context/current_priority.md`

## Audit scope

- Runtime/generated truth reconciliation
- Capability registry ↔ docs alignment
- Governance authority/bypass audit
- UI/WebSocket/routing audit
- Future docs/planning-only labeling audit
- Proof/test/CI claims audit
- Stale/duplicate docs cleanup map
- Final patch roadmap

## Safety boundary

Audit may identify gaps and propose patches, but it must not directly implement runtime fixes without a separate reviewed priority lock.

Blocked by this lock:

- runtime behavior changes
- capability expansion
- authority expansion
- OpenClaw expansion
- browser/computer-use expansion
- external writes
- Shopify writes
- email sending
- finance automation
- social posting automation
- ElevenLabs implementation
- Google connector runtime implementation
- UI simplification implementation
- autonomous workflow execution

## Follow-ups carried forward

- #141 — Search widget not surfacing in live WebSocket sessions
- #142 — RS-2 capability list truncation needs reproduction
- #143 — `"tell me more"` with prior context needs session-state-aware test

#141 is likely the first runtime fix after the audit, but it is not authorized by this audit lock.

## Governance

Preserves:

```text
Intelligence is not authority.
```

Docs-only. No runtime changes.