### PR TITLE
fix: remove "nonexistent" from _QUERY_STOPWORDS in search_synthesis

### DIFF
--- a/nova_backend/src/brain/search_synthesis.py
+++ b/nova_backend/src/brain/search_synthesis.py
@@ -90,7 +90,6 @@ _QUERY_STOPWORDS = {
     "latest",
     "look",
     "news",
-    "nonexistent",
     "report",
     "result",
     "results",


### PR DESCRIPTION
## Summary

- Removes `"nonexistent"` from `_QUERY_STOPWORDS` in `search_synthesis.py`
- It leaked into the stopword list as a test artifact — stopwords should only be query-framing/meta words like `search`, `show`, `latest`, `news` that carry no topical signal
- `"nonexistent"` is a real English word that could appear in legitimate user queries and should contribute to weak-query detection, not be discarded as noise

## Why it doesn't break the weak-query test

The test query `"qzxqzxqzx nonexistent topic with 1000 sources"` is still correctly flagged as a weak match: result texts contain `kafka`, `configuration`, `connector`, etc. — none of the meaningful tokens regardless of whether `"nonexistent"` is filtered. Overlap is 0/2 < 25% → weak match stays `True`.

## Scope

Single-line deletion. No behaviour changes beyond correctly treating `"nonexistent"` as a meaningful query token.

## Test plan

- [x] 235 brain tests pass
- [x] `test_search_synthesis_downgrades_weak_query_match` passes (confirmed logic still correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)