### PR TITLE
docs: sync current priority after runtime doc TODO

### DIFF
--- a/.agent_context/current_priority.md
+++ b/.agent_context/current_priority.md
@@ -3,16 +3,30 @@
 Current active task:
 
 ```text
-Post-audit continuity synchronization after PR #152-#156 — docs-only.
+Generated runtime-doc regeneration after PR #152-#158 — generated-output only.
 ```
 
 Branch:
 
 ```text
-docs/sync-post-openclaw-audit-hardening-status
+docs/regenerate-runtime-docs-post-openclaw-hardening
 ```
 
-This is a continuity/status synchronization task only. It does not authorize runtime implementation changes.
+Status:
+
+```text
+TODO tracked by PR #158. Generator has not yet been run.
+```
+
+Scope:
+
+```text
+generated runtime docs / fingerprints / MOC artifacts only
+no runtime code
+no manual continuity-doc rewrite beyond status synchronization
+no capability expansion
+no authority expansion
+```
 
 ## Recent merged truth
 
@@ -29,6 +43,8 @@ PR #152 — Full repo/doc/code alignment audit artifacts merged.
 PR #153 — PASS4 OpenClaw freeform goal inspection merged.
 PR #154 — OpenClaw PATCH A-D hardening merged.
 PR #156 — Search stopword cleanup merged.
+PR #157 — Post-audit continuity/status synchronization merged.
+PR #158 — Runtime-doc regeneration TODO tracking merged.
 ```
 
 ## Recent closed / not merged truth
@@ -38,7 +54,7 @@ PR #151 — Everyday UX continuity sync closed unmerged.
 PR #155 — Runtime docs regeneration closed unmerged.
 ```
 
-Therefore generated runtime docs may still need a fresh regeneration PR after PR #154/#156.
+Generated runtime docs still need a fresh regeneration PR because PR #155 did not merge and PR #158 only tracked the TODO.
 
 ## Historical branch note
 
@@ -83,15 +99,17 @@ Most other active capabilities — certification lock phases pending.
 #143 — "tell me more" with prior context needs session-state-aware test.
 ```
 
-#141 is likely the first runtime fix after continuity and generated runtime docs are synchronized, but it is not authorized by this docs-only continuity task.
+#141 is likely the first runtime fix after generated runtime docs are synchronized, but it is not authorized by this generated-doc task.
 
 ## Next correct sequence
 
 ```text
-1. Merge docs/sync-post-openclaw-audit-hardening-status.
-2. Create a separate generated-runtime-docs sync PR from current main.
-3. Run targeted OpenClaw freeform-goal governance regression tests.
-4. Then select one scoped runtime follow-up, likely #141.
+1. Run scripts/generate_runtime_docs.py on the runtime-doc regeneration branch in a real repo working tree.
+2. Run scripts/check_runtime_doc_drift.py.
+3. Inspect that changed files are generated runtime/MOC/fingerprint artifacts only.
+4. Open/merge a generated-docs-only PR.
+5. Run targeted OpenClaw freeform-goal governance regression tests.
+6. Then select one scoped runtime follow-up, likely #141.
 ```
 
 ## Safety boundary

--- a/docs/audits/PATCH_ROADMAP_2026-05-11.md
+++ b/docs/audits/PATCH_ROADMAP_2026-05-11.md
@@ -1,15 +1,32 @@
 # Audit Patch Roadmap
 
+Status update after PR #158:
+
+```text
+P1-GOV was addressed by PR #153 and PR #154.
+P1-CI / runtime-doc regeneration remains open because PR #155 closed unmerged and PR #158 only tracked the TODO.
+This roadmap is historical unless explicitly referenced by current priority docs.
+```
+
 **Date:** 2026-05-11
 **Source:** PASS1_RUNTIME_AND_OPENCLAW_AUDIT_2026-05-11.md + PASS3_FULL_ALIGNMENT_AUDIT_2026-05-11.md
-**Branch this roadmap targets:** audit/full-repo-doc-code-alignment
+**Historical branch targeted by this roadmap:** audit/full-repo-doc-code-alignment
 
-Each item below is a proposed narrow patch. None are authorized to begin without a separate
+Each item below was a proposed narrow patch at the time of the audit. None are authorized to begin without a separate
 reviewed priority lock unless the item is docs-only and explicitly scoped below.
 
 ---
 
-## P1-GOV — OpenClaw freeform goal governance inspection (HIGHEST GOVERNANCE PRIORITY)
+## P1-GOV — OpenClaw freeform goal governance inspection (HIGHEST GOVERNANCE PRIORITY AT TIME OF AUDIT)
+
+Historical outcome:
+
+```text
+PASS4 inspection merged in PR #153.
+PATCH A-D hardening merged in PR #154.
+```
+
+Original audit scope retained below for historical traceability.
 
 **Type:** governance inspection → likely fix
 **Branch:** `audit/openclaw-freeform-goal-inspection`
@@ -37,22 +54,22 @@ reviewed priority lock unless the item is docs-only and explicitly scoped below.
 - Assert each is rejected, or confirm which governance layer mediates it
 - Document the exact traversal path with line references
 
-**Merge gate:** Either (a) inspection confirms path is already hard-blocked with evidence,
+**Merge gate at time of audit:** Either (a) inspection confirms path is already hard-blocked with evidence,
 or (b) a hard-block patch is implemented and tested.
-**Note:** No strong governance-safety claim about OpenClaw can be made until this lands.
 
 ---
 
-## P1-CI — Runtime docs regeneration (BLOCKS CI)
+## P1-CI — Runtime docs regeneration (CURRENTLY STILL OPEN)
 
 **Type:** generator/docs
-**Branch:** `docs/regenerate-runtime-docs`
-**Scope:** Run `scripts/generate_runtime_docs.py`, commit the 10 stale files.
+**Current task branch:** `docs/regenerate-runtime-docs-post-openclaw-hardening`
+**Historical branch in original roadmap:** `docs/regenerate-runtime-docs`
+**Scope:** Run `scripts/generate_runtime_docs.py`, commit the stale generated files.
 **Files:** `docs/current_runtime/CURRENT_RUNTIME_STATE.md`,
-`docs/current_runtime/RUNTIME_FINGERPRINT.md`, all 8 `_MOCs/*.md`
+`docs/current_runtime/RUNTIME_FINGERPRINT.md`, all generated `_MOCs/*.md`
 **Blocked:** No capability changes. No code changes. Generator run only.
 **Merge gate:** `runtime-docs` CI passes.
-**Note:** This must land before any next implementation PR can pass CI cleanly.
+**Current status:** TODO tracked by PR #158. Generator has not yet been run.
 
 ---
 
@@ -137,22 +154,18 @@ audit branch itself.
 
 ---
 
-## Ordering Recommendation
+## Historical ordering recommendation
 
 ```text
-1. P1-GOV (openclaw freeform goal inspection) — highest governance priority; no strong
-   safety claim can be made until this is resolved
-2. P1-CI (docs/regenerate-runtime-docs) — blocks CI on all future pushes; can run in
-   parallel with P1-GOV if it stays docs-only
-3. P3 (docs/stale-status-doc-labels) — small, safe; can be batched with P1-CI
-4. P2a (fix/cap16-authority-scope-registry) — one-line registry addition; low risk
-5. P4 (docs/google-connector-planning-labels) — labeling pass; low priority
-6. P5 (test verification) — run before next implementation PR
+1. P1-GOV (openclaw freeform goal inspection)
+2. P1-CI (docs/regenerate-runtime-docs)
+3. P3 (docs/stale-status-doc-labels)
+4. P2a (fix/cap16-authority-scope-registry)
+5. P4 (docs/google-connector-planning-labels)
+6. P5 (test verification)
 ```
 
-**Note on P1-GOV vs P1-CI ordering:** P1-CI is faster to execute. Run it in parallel or
-immediately after P1-GOV inspection is scoped. Do not let CI cleanup be used to signal
-the repo is governance-clean — CI passing is a necessary but not sufficient condition.
+P1-GOV is now historically complete via PR #153/#154. P1-CI remains the current open item.
 
 ---
 

--- a/docs/status/CURRENT_WORK_STATUS.md
+++ b/docs/status/CURRENT_WORK_STATUS.md
@@ -13,16 +13,23 @@ Generated runtime docs and actual code win if they conflict with this note.
 ## Current Active Task
 
 ```text
-Post-audit continuity synchronization after PR #152-#156.
+Generated runtime-doc regeneration after PR #152-#158.
 ```
 
-This is a docs-only continuity synchronization task.
+Status:
+
+```text
+TODO tracked by PR #158.
+Generator has not yet been run.
+```
+
+This is a generated-output synchronization task only.
 
 No runtime implementation priority is selected until:
 
 ```text
-1. continuity docs are synchronized
-2. generated runtime docs are regenerated from current main
+1. generated runtime docs are regenerated from current main
+2. runtime-doc drift verification is complete
 ```
 
 ---
@@ -118,6 +125,33 @@ merged — PR #156
 
 Search phrase cleanup landed without runtime authority expansion.
 
+### Post-audit continuity synchronization
+
+Status:
+
+```text
+merged — PR #157
+```
+
+Main continuity/status docs synchronized after PR #152-#156.
+
+### Runtime-doc regeneration TODO tracking
+
+Status:
+
+```text
+merged — PR #158
+```
+
+Records:
+
+```text
+- PR #155 closed unmerged
+- runtime docs still require generator run
+- exact regeneration commands
+- generated-files-only scope
+```
+
 ---
 
 ## Closed / Unmerged Follow-Through
@@ -127,7 +161,7 @@ PR #151 — continuity sync branch closed unmerged.
 PR #155 — runtime docs regeneration closed unmerged.
 ```
 
-Generated runtime docs therefore still likely require a dedicated regeneration/synchronization PR.
+Generated runtime docs therefore still require a dedicated regeneration/synchronization PR.
 
 ---
 
@@ -145,7 +179,7 @@ The likely first runtime implementation follow-up remains:
 #141 — live WebSocket search-widget render investigation.
 ```
 
-but only after continuity/runtime-doc synchronization is complete.
+but only after generated runtime-doc synchronization is complete.
 
 ---
 
@@ -203,8 +237,10 @@ No recent merge authorizes:
 ## Next Correct Step
 
 ```text
-1. Merge this continuity sync.
-2. Regenerate runtime docs from current main in a separate PR.
-3. Run targeted OpenClaw governance regression verification.
-4. Then select one scoped runtime follow-up.
+1. Run scripts/generate_runtime_docs.py on current main-derived branch.
+2. Run scripts/check_runtime_doc_drift.py.
+3. Inspect generated diffs.
+4. Open generated-docs-only PR.
+5. Then run targeted OpenClaw governance regression verification.
+6. Then select one scoped runtime follow-up.
 ```

--- a/docs/status/WORKFLOW_STAGE_ROADMAP_2026-05-02.md
+++ b/docs/status/WORKFLOW_STAGE_ROADMAP_2026-05-02.md
@@ -1,14 +1,18 @@
 # Workflow Stage Roadmap - 2026-05-02
 
-Status: operational planning snapshot.
+Status: historical operational planning snapshot.
 
-This document summarizes the current stage of the active Nova workflow sequence and the Auralis manual validation track.
+> Historical snapshot. Do not use this file to select current work. Current priority lives in `.agent_context/current_priority.md` and `docs/todo/ACTIVE_TODO.md`.
+>
+> This document reflects the repo/workflow state as of 2026-05-02 through the 2026-05-04 OpenClaw hardening priority lock. Later PRs supersede its active-priority wording.
+
+This document summarizes the 2026-05-02 stage of the Nova workflow sequence and the Auralis manual validation track.
 
 It is not runtime truth. Exact runtime truth still comes from code and generated runtime docs.
 
 ---
 
-## Current overall stage
+## Historical overall stage
 
 ```text
 Stage 6: Routine surfaces — PARTIAL (RoutineGraph v0 + Plan My Week + cost posture step 1 done)
@@ -19,12 +23,12 @@ Stages 1, 2, 3, 4, and 5 completed 2026-05-02.
 Stage 6 partial: RoutineGraph v0 and Plan My Week done 2026-05-03. Cost posture metadata (step 1
 of free-first) done 2026-05-03.
 
-Active priority lock (2026-05-04): all remaining Stage 6 work (business workflow demo, governed
-workspace shell, workflow object model) is paused. Active sequence is OpenClaw hardening —
+Active priority lock as of 2026-05-04: all remaining Stage 6 work (business workflow demo, governed
+workspace shell, workflow object model) was paused. Active sequence was OpenClaw hardening —
 RequestUnderstanding review card → capability signoff matrix → OpenClawMediator skeleton →
 read-only workflow proof. See `docs/status/ACTIVE_PRIORITY_LOCK_2026-05-04.md`.
 
-The current repo sequence is:
+The repo sequence at that time was:
 
 ```text
 Proof closeout
@@ -139,7 +143,7 @@ Merged: PRs #85, #87, #88, #89 on 2026-05-02.
 
 ## Stage 6 - Routine surfaces
 
-State: **active** 2026-05-03.
+State as of 2026-05-03: **active**.
 
 ### Completed in Stage 6
 
@@ -153,14 +157,14 @@ State: **active** 2026-05-03.
   caps; validation; governance matrix column; runtime state summary; 24 tests. Metadata + visibility
   only; no enforcement.
 
-### Remaining in Stage 6
+### Remaining in Stage 6 as of this historical snapshot
 
 - Business workflow demo: find 5 local businesses, draft improvement notes, create reviewable
   outreach drafts.
 - Governed workflow workspace shell: WorkflowObject model, workflow template schema.
 - Google read-only connector foundation planning (design-only; no runtime connector).
 
-### Proof criteria (still required before Stage 6 exit)
+### Proof criteria at the time of this snapshot
 
 - Daily Brief remains non-authorizing through RoutineGraph — PASS (60 tests, PR #93)
 - Routines do not execute hidden actions — PASS (approval_required enforced, run/receipt
@@ -190,13 +194,12 @@ Blocked from runtime until:
 
 ---
 
-## Current recommended action
+## Historical recommended action
 
-Stage 6 is active. RoutineGraph v0, Plan My Week, and cost posture metadata (step 1) are done.
+As of this snapshot, Stage 6 was active. RoutineGraph v0, Plan My Week, and cost posture metadata (step 1) were done.
 
 ```text
-Next: business workflow demo → governed workspace shell → Google connector planning (design only).
+Next at the time: business workflow demo → governed workspace shell → Google connector planning (design only).
 ```
 
-Do not start write/action capabilities in this sprint.
-Cost posture enforcement is a future step — metadata exists; no runtime blocking is implemented yet.
+Do not use this historical recommendation as current priority. Cost posture enforcement was a future step at this point — metadata existed; no runtime blocking was implemented yet.


### PR DESCRIPTION
## Summary

Synchronizes the active priority/status layer after PR #158 tracked the pending runtime-doc regeneration task.

This PR corrects stale continuity wording that still pointed to the completed post-audit sync and labels older roadmap/audit-roadmap docs as historical.

## Files changed

- `.agent_context/current_priority.md`
- `docs/status/CURRENT_WORK_STATUS.md`
- `docs/status/WORKFLOW_STAGE_ROADMAP_2026-05-02.md`
- `docs/audits/PATCH_ROADMAP_2026-05-11.md`

## Current truth recorded

```text
Generated runtime-doc regeneration after PR #152-#158 — generated-output only.
```

Also records:

```text
PR #157 — post-audit continuity sync merged
PR #158 — runtime-doc regeneration TODO tracking merged
PR #155 — runtime-doc regeneration closed unmerged
generator has not yet been run
```

## Historical labels added

- `WORKFLOW_STAGE_ROADMAP_2026-05-02.md` is labeled historical and not current-priority truth.
- `PATCH_ROADMAP_2026-05-11.md` now says P1-GOV was addressed by PR #153/#154 and P1-CI remains open.

## Explicit non-goals

No runtime code.
No generated runtime docs.
No capability changes.
No authority expansion.
No OpenClaw expansion.
No browser/computer-use expansion.
No external writes.
No autonomous workflow authorization.

## Next step after merge

Run generated runtime-doc regeneration in a real repo working tree:

```bash
python scripts/generate_runtime_docs.py
python scripts/check_runtime_doc_drift.py
git status
git diff
```

Then open a generated-docs-only PR.