### PR TITLE
docs: close trust panel MVP status sync

### DIFF
--- a/.agent_context/current_priority.md
+++ b/.agent_context/current_priority.md
@@ -3,10 +3,10 @@
 Current active task:
 
 ```text
-Trust Panel MVP — priority lock only.
+Trust Panel MVP — COMPLETE.
 ```
 
-Priority lock:
+Most recent completed lock:
 
 ```text
 docs/status/ACTIVE_PRIORITY_LOCK_2026-05-14_TRUST_PANEL_MVP.md
@@ -15,16 +15,16 @@ docs/status/ACTIVE_PRIORITY_LOCK_2026-05-14_TRUST_PANEL_MVP.md
 Status:
 
 ```text
-#141 live proof is complete.
-Trust Panel MVP should now proceed as a separate scoped visibility lane.
-Approval gate wiring follows the Trust Panel MVP rather than being bundled into it.
+PR #167 merged.
+Live visual proof recorded.
+Approval gate wiring follows the Trust Panel MVP under a separate scoped priority lock.
 ```
 
 Scope:
 
 ```text
-priority lock / continuity synchronization only
-no runtime implementation in this task
+closeout / continuity synchronization only
+no approval-gate runtime implementation in this task
 no capability expansion
 no authority expansion
 ```
@@ -46,6 +46,7 @@ PR #154 — OpenClaw PATCH A-D hardening merged.
 PR #156 — Search stopword cleanup merged.
 PR #157 — Post-audit continuity/status synchronization merged.
 PR #158 — Runtime-doc regeneration TODO tracking merged.
+PR #167 — Trust Panel MVP receipt surface merged.
 ```
 
 ## Recent closed / not merged truth
@@ -116,14 +117,14 @@ Most other active capabilities — certification lock phases pending.
 #143 — "tell me more" with prior context needs session-state-aware test.
 ```
 
-#141 is no longer the active follow-up. The next strategic lane is Trust Panel MVP under its own lock.
+#141 is no longer the active follow-up. The next strategic lane is approval gate wiring under its own lock.
 
 ## Next correct sequence
 
 ```text
-1. Trust Panel MVP lock review.
-2. Trust Panel MVP implementation in a separate scoped branch.
-3. Approval gate wiring after visible receipt/governance surfaces exist.
+1. Close Trust Panel MVP continuity/status synchronization.
+2. Create an approval gate wiring priority lock.
+3. Implement approval gate wiring after the reviewed lock exists.
 ```
 
 ## Safety boundary

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,8 +39,8 @@ Read these documents before starting any task:
 Current priority order:
 
 ```text
-1. Trust Panel MVP — expose governance visibly to users
-2. Approval gate wiring — make approval flow genuinely execution-blocking
+1. Approval gate wiring priority lock — scope the next execution-blocking lane cleanly
+2. Approval gate wiring — make approval flow genuinely execution-blocking after the reviewed lock exists
 3. Installer & bootstrap reliability
 4. Live workflow demonstrations
 5. CI stabilization
@@ -65,7 +65,8 @@ execution, multi-agent expansion, enterprise orchestration work.
 Runtime-doc regeneration — COMPLETE (2026-05-12).
 Second-pass review and roadmap sync — COMPLETE (2026-05-12).
 #141 live proof — COMPLETE (2026-05-14).
-Next: Trust Panel MVP priority lock and scoped implementation.
+Trust Panel MVP — COMPLETE / merged / live-proven (2026-05-15).
+Next: approval gate wiring under a separate scoped priority lock.
 ```
 
 Recent repo truth:
@@ -86,6 +87,7 @@ PR #156 — Search stopword cleanup merged.
 PR #157 — Post-audit continuity/status synchronization merged.
 PR #158 — Runtime-doc regeneration TODO tracking merged.
 PR #159 — Current priority/status synchronization merged.
+PR #167 — Trust Panel MVP receipt surface merged.
 ```
 
 Current grounded truth:

--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ Current active task:
 
 ```text
 #141 live proof — COMPLETE (2026-05-14).
-Next: Trust Panel MVP under a separate scoped priority lock, then approval gate wiring.
+Trust Panel MVP — COMPLETE / merged / live-proven (2026-05-15).
+Next: approval gate wiring under a separate scoped priority lock.
 ```
 
 ## Future Directions

--- a/docs/status/CURRENT_WORK_STATUS.md
+++ b/docs/status/CURRENT_WORK_STATUS.md
@@ -19,21 +19,21 @@ See FIVE_PASS_STABILITY_AND_OPERATIONAL_ROADMAP_2026-05-12.md for the post-audit
 ## Current Active Task
 
 ```text
-Trust Panel MVP — priority lock only (2026-05-14).
+Trust Panel MVP — COMPLETE / merged / live-proven (2026-05-15).
 ```
 
 Status:
 
 ```text
-Trust Panel MVP is the next scoped strategic lane after #141 live proof completion.
-This task authorizes the priority lock and continuity sync only.
-It does not authorize runtime implementation in the same change.
+PR #167 merged.
+Live visual proof recorded.
+This closeout sync does not authorize approval-gate runtime implementation in the same change.
 ```
 
 Next runtime implementation priority:
 
 ```text
-Trust Panel MVP.
+Approval gate wiring under a separate scoped priority lock.
 ```
 
 ---
@@ -166,6 +166,24 @@ merged — PR #159
 
 Main operational continuity layer synchronized to the runtime-doc regeneration task.
 
+### Trust Panel MVP
+
+Status:
+
+```text
+merged — PR #167
+```
+
+Proof:
+
+```text
+- docs/PROOFS/Trust-Panel/TRUST_PANEL_MVP_PROOF_2026-05-14.md
+- docs/status/TRUST_PANEL_MVP_CLOSEOUT_2026-05-14.md
+```
+
+The Trust Panel MVP is now implemented, merged, and proof-backed. It remains read-only and
+does not change approval behavior or execution authority.
+
 ---
 
 ## Closed / Unmerged Follow-Through
@@ -250,7 +268,7 @@ No recent merge authorizes:
 Per the current reviewed sequence:
 
 ```text
-1. Review the Trust Panel MVP lock.
-2. Implement Trust Panel MVP in a separate scoped branch.
-3. Wire approval-gate behavior after the visibility surface exists.
+1. Close Trust Panel MVP continuity/status synchronization.
+2. Create an approval gate wiring priority lock.
+3. Wire approval-gate behavior after the reviewed lock exists.
 ```

--- a/docs/status/TRUST_PANEL_MVP_CLOSEOUT_2026-05-14.md
+++ b/docs/status/TRUST_PANEL_MVP_CLOSEOUT_2026-05-14.md
@@ -1,0 +1,46 @@
+# Trust Panel MVP Closeout
+
+Date: 2026-05-14
+
+Status: COMPLETE
+
+Merge record:
+
+```text
+PR #167 — feat: add trust panel MVP receipt surface
+Merge commit: 08234906617709eba518d9158d7909fb61699dd0
+Merged at: 2026-05-15T02:07:50Z
+```
+
+Scope completed:
+
+```text
+- read-only Trust Panel MVP on top of the existing local receipts API
+- selected-receipt detail view
+- no approve / execute controls
+- focused dashboard tests
+- live visual proof recorded
+```
+
+Boundaries preserved:
+
+```text
+- no new capability
+- no authority expansion
+- no approval gate behavior change
+- no external writes
+- no OpenClaw expansion
+- no generated runtime docs changed
+```
+
+Proof:
+
+```text
+docs/PROOFS/Trust-Panel/TRUST_PANEL_MVP_PROOF_2026-05-14.md
+```
+
+Next:
+
+```text
+Approval gate wiring under a separate scoped priority lock.
+```

--- a/docs/todo/ACTIVE_TODO.md
+++ b/docs/todo/ACTIVE_TODO.md
@@ -7,21 +7,21 @@ Last reviewed: 2026-05-14
 ## Current Active Task
 
 ```text
-Trust Panel MVP — priority lock only (2026-05-14).
+Trust Panel MVP — COMPLETE / merged / live-proven (2026-05-15).
 ```
 
 Result:
 
 ```text
-#141 live proof is complete.
-Trust Panel MVP is the next reviewed lane.
-This task covers the lock and continuity sync only, not implementation.
+PR #167 merged.
+Live visual proof recorded.
+Next reviewed lane: approval gate wiring under a separate scoped priority lock.
 ```
 
 Next correct step:
 
 ```text
-Review the Trust Panel MVP lock, then implement it in a separate scoped branch.
+Close the Trust Panel MVP continuity/status sync, then create the approval gate wiring lock.
 ```
 
 ---
@@ -44,6 +44,7 @@ PR #156 — Search stopword cleanup merged.
 PR #157 — Post-audit continuity/status synchronization merged.
 PR #158 — Runtime-doc regeneration TODO tracking merged.
 PR #159 — Current priority/status synchronization merged.
+PR #167 — Trust Panel MVP receipt surface merged.
 ```
 
 ---
@@ -61,29 +62,18 @@ Generated runtime docs require a dedicated regeneration PR.
 
 ## Current Open Follow-Ups
 
-### Runtime docs regeneration — current task
+### Approval gate wiring — next lane
 
 Status:
 
 ```text
-branch created / generator not yet run
+needs separate scoped priority lock / do not implement in this closeout branch
 ```
 
-Branch:
+First step:
 
 ```text
-docs/regenerate-runtime-docs-post-openclaw-hardening
-```
-
-Acceptance:
-
-```text
-- generator has been run from current main-derived branch
-- check_runtime_doc_drift.py passes or reports expected generated diffs
-- generated files only, unless a generated-doc script failure requires a separate reviewed fix
-- no runtime code changes
-- no capability changes
-- no authority expansion
+create a reviewed approval gate wiring lock that defines the execution-blocking scope
 ```
 
 ### #142 — RS-2 capability list truncation
@@ -201,7 +191,7 @@ The recent audit and hardening merges do not approve:
 ## Next Correct Step
 
 ```text
-1. Trust Panel MVP lock review.
-2. Trust Panel MVP implementation in a separate scoped branch.
-3. Approval gate wiring after the Trust Panel surface exists.
+1. Close Trust Panel MVP continuity/status synchronization.
+2. Create an approval gate wiring priority lock.
+3. Implement approval gate wiring after the reviewed lock exists.
 ```


### PR DESCRIPTION
## Summary
Closes the Trust Panel MVP continuity/status loop after PR #167 merged.

## What changed
- marks Trust Panel MVP complete in the continuity layer
- records PR #167 in recent merged truth
- adds a Trust Panel MVP closeout note
- points the next lane at approval gate wiring under a separate scoped priority lock
- does not implement approval-gate runtime behavior in this branch

## Scope
- AGENTS.md
- .agent_context/current_priority.md
- docs/status/CURRENT_WORK_STATUS.md
- docs/todo/ACTIVE_TODO.md
- README.md
- docs/status/TRUST_PANEL_MVP_CLOSEOUT_2026-05-14.md

## Boundaries preserved
- docs-only
- no runtime code changes
- no capability changes
- no authority expansion
- no approval gate behavior changes