### PR TITLE
docs: correct approval gate next sequence

### DIFF
--- a/.agent_context/current_priority.md
+++ b/.agent_context/current_priority.md
@@ -122,8 +122,8 @@ Most other active capabilities — certification lock phases pending.
 ## Next correct sequence
 
 ```text
-1. Close Trust Panel MVP continuity/status synchronization.
-2. Create an approval gate wiring priority lock.
+1. Create an approval gate wiring priority lock.
+2. Review the approval gate wiring lock.
 3. Implement approval gate wiring after the reviewed lock exists.
 ```
 


### PR DESCRIPTION
## Summary
Fixes the post-Trust-Panel next sequence so the repo now starts from approval gate wiring priority-lock creation rather than repeating the already-merged Trust Panel closeout.

## Scope
- `.agent_context/current_priority.md` only

## Boundaries preserved
- docs-only
- no runtime code changes
- no generated runtime docs
- no approval-gate implementation
- no capability changes
- no authority expansion