### PR TITLE
docs: add approval gate wiring priority lock

### DIFF
--- a/.agent_context/current_priority.md
+++ b/.agent_context/current_priority.md
@@ -3,27 +3,27 @@
 Current active task:
 
 ```text
-Trust Panel MVP — COMPLETE.
+Approval gate wiring — priority lock only.
 ```
 
-Most recent completed lock:
+Priority lock:
 
 ```text
-docs/status/ACTIVE_PRIORITY_LOCK_2026-05-14_TRUST_PANEL_MVP.md
+docs/status/ACTIVE_PRIORITY_LOCK_2026-05-15_APPROVAL_GATE_WIRING.md
 ```
 
 Status:
 
 ```text
-PR #167 merged.
-Live visual proof recorded.
-Approval gate wiring follows the Trust Panel MVP under a separate scoped priority lock.
+Trust Panel MVP is complete and merged.
+This task creates the approval gate wiring lock and continuity sync only.
+Approval-gate runtime implementation follows after lock review.
 ```
 
 Scope:
 
 ```text
-closeout / continuity synchronization only
+priority lock / continuity synchronization only
 no approval-gate runtime implementation in this task
 no capability expansion
 no authority expansion
@@ -47,6 +47,7 @@ PR #156 — Search stopword cleanup merged.
 PR #157 — Post-audit continuity/status synchronization merged.
 PR #158 — Runtime-doc regeneration TODO tracking merged.
 PR #167 — Trust Panel MVP receipt surface merged.
+PR #169 — Approval gate next-sequence correction merged.
 ```
 
 ## Recent closed / not merged truth
@@ -117,7 +118,7 @@ Most other active capabilities — certification lock phases pending.
 #143 — "tell me more" with prior context needs session-state-aware test.
 ```
 
-#141 is no longer the active follow-up. The next strategic lane is approval gate wiring under its own lock.
+#141 is no longer the active follow-up. The active strategic lane is approval gate wiring under its own lock.
 
 ## Next correct sequence
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,8 @@ Runtime-doc regeneration — COMPLETE (2026-05-12).
 Second-pass review and roadmap sync — COMPLETE (2026-05-12).
 #141 live proof — COMPLETE (2026-05-14).
 Trust Panel MVP — COMPLETE / merged / live-proven (2026-05-15).
-Next: approval gate wiring under a separate scoped priority lock.
+Approval gate wiring priority lock — ACTIVE (2026-05-15).
+Next: review the lock, then implement approval gate wiring in a separate scoped branch.
 ```
 
 Recent repo truth:
@@ -88,6 +89,7 @@ PR #157 — Post-audit continuity/status synchronization merged.
 PR #158 — Runtime-doc regeneration TODO tracking merged.
 PR #159 — Current priority/status synchronization merged.
 PR #167 — Trust Panel MVP receipt surface merged.
+PR #169 — Approval gate next-sequence correction merged.
 ```
 
 Current grounded truth:

--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ Current active task:
 ```text
 #141 live proof — COMPLETE (2026-05-14).
 Trust Panel MVP — COMPLETE / merged / live-proven (2026-05-15).
-Next: approval gate wiring under a separate scoped priority lock.
+Approval gate wiring priority lock — ACTIVE (2026-05-15).
+Next: review the lock, then implement approval gate wiring in a separate scoped branch.
 ```
 
 ## Future Directions

--- a/docs/status/ACTIVE_PRIORITY_LOCK_2026-05-15_APPROVAL_GATE_WIRING.md
+++ b/docs/status/ACTIVE_PRIORITY_LOCK_2026-05-15_APPROVAL_GATE_WIRING.md
@@ -1,0 +1,93 @@
+# Active Priority Lock - Approval Gate Wiring
+
+Status: ACTIVE
+
+Date: 2026-05-15
+
+This is human-maintained priority guidance, not generated runtime truth. Generated runtime docs
+and actual code remain authoritative if they conflict with this lock.
+
+---
+
+## Goal
+
+Make approval-required governed actions genuinely execution-blocking while keeping the approval
+state visible and inspectable.
+
+---
+
+## Scope
+
+```text
+approval-required actions must stop at a pending state until explicitly approved
+approved actions may proceed only through the governed execution path
+denied actions must remain blocked with a visible non-execution outcome
+pending / approved / denied state should be visible through existing receipt / trust surfaces where possible
+receipt and ledger state should stay consistent with the approval decision
+factual status language only
+```
+
+This lock is for approval gate wiring only.
+
+---
+
+## Strict Non-Goals
+
+```text
+no new capability
+no authority expansion
+no OpenClaw expansion
+no browser/computer-use
+no external writes beyond already-authorized capability boundaries
+no broad dashboard redesign
+no autonomous workflow execution
+no Shopify writes
+no Google connector runtime work
+no Cap 64 P5 work
+no Cap 65 P5 work
+no bundling unrelated trust/dashboard cleanup
+```
+
+---
+
+## Required Output
+
+```text
+1. Approval-required governed actions stop before execution when approval is pending.
+2. Approval decisions are visible as pending / approved / denied.
+3. No approval path bypasses GovernorMediator / execution boundaries / receipts.
+4. Denied actions do not execute.
+5. Existing visibility surfaces remain visibility-only and do not become hidden authority paths.
+```
+
+---
+
+## Implementation Boundaries
+
+```text
+- prefer wiring existing approval-required capability paths before adding any new approval concepts
+- preserve ledger / receipt inspectability
+- preserve explicit user invocation and confirmation discipline
+- keep Trust Panel / receipt surfaces factual and non-authorizing
+```
+
+---
+
+## Acceptance Criteria
+
+1. An approval-required action remains non-executed while pending.
+2. An explicit approval transitions the action from pending to governed execution.
+3. An explicit denial records the denial and leaves the action unexecuted.
+4. Tests prove no execution occurs on pending or denied paths.
+5. Tests prove approval does not widen authority or introduce a new bypass surface.
+
+---
+
+## Sequencing Rule
+
+```text
+Approval gate wiring lock first.
+Approval gate wiring implementation second.
+```
+
+Do not bundle approval-gate runtime implementation into this lock/continuity branch.

--- a/docs/status/CURRENT_WORK_STATUS.md
+++ b/docs/status/CURRENT_WORK_STATUS.md
@@ -19,21 +19,21 @@ See FIVE_PASS_STABILITY_AND_OPERATIONAL_ROADMAP_2026-05-12.md for the post-audit
 ## Current Active Task
 
 ```text
-Trust Panel MVP — COMPLETE / merged / live-proven (2026-05-15).
+Approval gate wiring — priority lock only (2026-05-15).
 ```
 
 Status:
 
 ```text
-PR #167 merged.
-Live visual proof recorded.
-This closeout sync does not authorize approval-gate runtime implementation in the same change.
+Trust Panel MVP is complete and proof-backed.
+This task authorizes the approval gate wiring lock and continuity sync only.
+It does not authorize approval-gate runtime implementation in the same change.
 ```
 
 Next runtime implementation priority:
 
 ```text
-Approval gate wiring under a separate scoped priority lock.
+Approval gate wiring after the reviewed lock exists.
 ```
 
 ---
@@ -184,6 +184,22 @@ Proof:
 The Trust Panel MVP is now implemented, merged, and proof-backed. It remains read-only and
 does not change approval behavior or execution authority.
 
+### Approval gate wiring priority lock
+
+Status:
+
+```text
+active — 2026-05-15
+```
+
+Lock:
+
+```text
+docs/status/ACTIVE_PRIORITY_LOCK_2026-05-15_APPROVAL_GATE_WIRING.md
+```
+
+This task does not authorize approval-gate runtime implementation in the same branch.
+
 ---
 
 ## Closed / Unmerged Follow-Through
@@ -268,7 +284,7 @@ No recent merge authorizes:
 Per the current reviewed sequence:
 
 ```text
-1. Close Trust Panel MVP continuity/status synchronization.
-2. Create an approval gate wiring priority lock.
-3. Wire approval-gate behavior after the reviewed lock exists.
+1. Review the approval gate wiring priority lock.
+2. Implement approval-gate behavior in a separate scoped branch.
+3. Verify pending / approved / denied paths stay governed and non-bypassing.
 ```

--- a/docs/todo/ACTIVE_TODO.md
+++ b/docs/todo/ACTIVE_TODO.md
@@ -7,21 +7,20 @@ Last reviewed: 2026-05-14
 ## Current Active Task
 
 ```text
-Trust Panel MVP — COMPLETE / merged / live-proven (2026-05-15).
+Approval gate wiring — priority lock only (2026-05-15).
 ```
 
 Result:
 
 ```text
-PR #167 merged.
-Live visual proof recorded.
-Next reviewed lane: approval gate wiring under a separate scoped priority lock.
+Trust Panel MVP is complete and proof-backed.
+This task covers the approval gate wiring lock and continuity sync only, not implementation.
 ```
 
 Next correct step:
 
 ```text
-Close the Trust Panel MVP continuity/status sync, then create the approval gate wiring lock.
+Review the approval gate wiring lock, then implement it in a separate scoped branch.
 ```
 
 ---
@@ -45,6 +44,7 @@ PR #157 — Post-audit continuity/status synchronization merged.
 PR #158 — Runtime-doc regeneration TODO tracking merged.
 PR #159 — Current priority/status synchronization merged.
 PR #167 — Trust Panel MVP receipt surface merged.
+PR #169 — Approval gate next-sequence correction merged.
 ```
 
 ---
@@ -67,13 +67,13 @@ Generated runtime docs require a dedicated regeneration PR.
 Status:
 
 ```text
-needs separate scoped priority lock / do not implement in this closeout branch
+priority lock active / implementation not started
 ```
 
 First step:
 
 ```text
-create a reviewed approval gate wiring lock that defines the execution-blocking scope
+review the active approval gate wiring lock and then implement it in a separate scoped branch
 ```
 
 ### #142 — RS-2 capability list truncation
@@ -191,7 +191,7 @@ The recent audit and hardening merges do not approve:
 ## Next Correct Step
 
 ```text
-1. Close Trust Panel MVP continuity/status synchronization.
-2. Create an approval gate wiring priority lock.
-3. Implement approval gate wiring after the reviewed lock exists.
+1. Review the approval gate wiring priority lock.
+2. Implement approval gate wiring in a separate scoped branch.
+3. Verify pending / approved / denied paths stay governed and non-bypassing.
 ```


### PR DESCRIPTION
## Summary
Creates the approval gate wiring priority lock and updates the continuity/status layer to point the repo at that reviewed lane.

## What changed
- adds `docs/status/ACTIVE_PRIORITY_LOCK_2026-05-15_APPROVAL_GATE_WIRING.md`
- marks approval gate wiring lock as the active task
- keeps implementation explicitly out of scope for this branch
- updates continuity docs to point to lock review first, implementation second

## Scope
- AGENTS.md
- .agent_context/current_priority.md
- docs/status/CURRENT_WORK_STATUS.md
- docs/todo/ACTIVE_TODO.md
- README.md
- docs/status/ACTIVE_PRIORITY_LOCK_2026-05-15_APPROVAL_GATE_WIRING.md

## Boundaries preserved
- docs-only
- no runtime code changes
- no capability changes
- no authority expansion
- no approval-gate runtime implementation in this branch