### PR TITLE
fix: mock os.startfile with raising=False for Linux CI

### DIFF
--- a/nova_backend/tests/test_system_control_executor.py
+++ b/nova_backend/tests/test_system_control_executor.py
@@ -46,7 +46,7 @@ def test_open_path_uses_workspace_root_allowlist(monkeypatch, tmp_path: Path):
     def _fake_startfile(value: str) -> None:
         opened.append(value)
 
-    monkeypatch.setattr("os.startfile", _fake_startfile)
+    monkeypatch.setattr("os.startfile", _fake_startfile, raising=False)
 
     executor = SystemControlExecutor()
     assert executor.open_path(target) is True


### PR DESCRIPTION
## Summary
- `test_open_path_uses_workspace_root_allowlist` fails on Linux because `os.startfile` is Windows-only — `monkeypatch.setattr` raises `AttributeError` when the attribute doesn't exist
- Fix: add `raising=False` so monkeypatch creates the attribute on platforms where it's missing
- Pre-existing baseline failure exposed after #177/#178/#176 fixed earlier CI blockers

## Classification
- Pre-existing Linux CI baseline failure
- Not introduced by any open PR
- Same pattern as #178 (cross-platform test assumptions)

## Test plan
- [x] `test_open_path_uses_workspace_root_allowlist` passes locally on Windows
- [ ] Linux CI lint-and-test should now pass with 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)