### PR TITLE
fix: sync frontend mirror from nova_backend/static

### DIFF
--- a/Nova-Frontend-Dashboard/dashboard-chat-news.js
+++ b/Nova-Frontend-Dashboard/dashboard-chat-news.js
@@ -521,6 +521,77 @@ function collectReportSources(report) {
   return Array.from(new Set(rows)).slice(0, 12);
 }
 
+function buildStructuredReportFromBrief(brief = {}) {
+  if (!brief || typeof brief !== "object") return null;
+
+  const topic = String(brief.topic || "").trim();
+  const summary = String(brief.summary || "").trim();
+  const keyFindings = Array.isArray(brief.key_findings) ? brief.key_findings : [];
+  const supportingSources = Array.isArray(brief.supporting_sources) ? brief.supporting_sources : [];
+  const contradictions = Array.isArray(brief.contradictions) ? brief.contradictions : [];
+  const sourceCredibility = Array.isArray(brief.source_credibility) ? brief.source_credibility : [];
+  const confidenceFactors = brief.confidence_factors && typeof brief.confidence_factors === "object"
+    ? brief.confidence_factors
+    : {};
+  const counterAnalysis = String(brief.counter_analysis || "").trim();
+  const confidence = Number(brief.confidence);
+  const contractStatus = String(brief.contract_status || "").trim();
+  const validationStatus = String(brief.validation_status || "").trim();
+  const fallbackReason = String(brief.fallback_reason || "").trim();
+  const sections = [];
+
+  const pushSection = (heading, rows) => {
+    const normalizedRows = Array.isArray(rows)
+      ? rows.map((row) => String(row || "").trim()).filter(Boolean)
+      : [];
+    if (!normalizedRows.length) return;
+    sections.push({ heading, rows: normalizedRows });
+  };
+
+  pushSection("Summary", summary ? [summary] : []);
+  pushSection("Key Findings", keyFindings);
+  pushSection("Supporting Sources", supportingSources);
+  pushSection("Contradictions", contradictions);
+  pushSection(
+    "Confidence",
+    Number.isFinite(confidence) ? [`Confidence score: ${confidence.toFixed(2)}`] : [],
+  );
+  pushSection(
+    "Source Credibility",
+    sourceCredibility.map((row) => {
+      const source = String(row && row.source || "").trim();
+      const classification = String(row && row.classification || "unknown").trim() || "unknown";
+      const score = Number(row && row.score);
+      const scoreLabel = Number.isFinite(score) ? ` (${score.toFixed(2)})` : "";
+      return `${source || "Unknown source"}: ${classification}${scoreLabel}`;
+    }),
+  );
+  pushSection(
+    "Confidence Factors",
+    Object.entries(confidenceFactors).map(([label, value]) => {
+      const cleanLabel = String(label || "").replace(/_/g, " ").trim();
+      const numeric = Number(value);
+      const valueLabel = Number.isFinite(numeric) ? numeric.toFixed(2) : String(value || "").trim();
+      return `${cleanLabel}: ${valueLabel}`;
+    }),
+  );
+  pushSection("Counter Analysis", counterAnalysis ? [counterAnalysis] : []);
+  pushSection(
+    "Validation Status",
+    [
+      contractStatus ? `Contract status: ${contractStatus}` : "",
+      validationStatus ? `Validation status: ${validationStatus}` : "",
+      fallbackReason ? `Fallback reason: ${fallbackReason}` : "",
+    ],
+  );
+
+  if (!sections.length) return null;
+  return {
+    title: topic ? `NOVA INTELLIGENCE BRIEF: ${topic}` : "NOVA INTELLIGENCE BRIEF",
+    sections,
+  };
+}
+
 function parseDailyBriefV2(text) {
   const raw = String(text || "").trim();
   if (!raw.startsWith("NOVA DAILY INTELLIGENCE BRIEF")) return null;
@@ -1752,11 +1823,13 @@ function renderSearchWidget(data) {
   const container = $("search-widget");
   const results = Array.isArray(data && data.results) ? data.results : [];
   const evidence = normalizeSearchEvidence(data);
+  const structuredBrief = data && typeof data.structured_brief === "object" ? data.structured_brief : null;
+  const structuredReport = buildStructuredReportFromBrief(structuredBrief);
   if (container) {
     clear(container);
     container.classList.remove("active");
 
-    if (!results.length && !hasVisibleSearchEvidence(evidence)) {
+    if (!results.length && !structuredReport && !hasVisibleSearchEvidence(evidence)) {
       return;
     }
 
@@ -1791,34 +1864,38 @@ function renderSearchWidget(data) {
 
     appendSearchEvidencePanel(container, evidence);
 
-    const focusTopic = queryText || String(results[0]?.title || "").trim();
-    const summaryText = String((data && data.summary) || "").trim();
-    const quickAnswer = document.createElement("div");
-    quickAnswer.className = "search-quick-answer";
+    const focusTopic = queryText || String(results[0]?.title || structuredBrief?.topic || "").trim();
+    const summaryText = String((data && data.summary) || structuredBrief?.summary || "").trim();
+    if (structuredReport) {
+      renderStructuredReport(container, structuredReport);
+    } else {
+      const quickAnswer = document.createElement("div");
+      quickAnswer.className = "search-quick-answer";
 
-    const quickAnswerTitle = document.createElement("div");
-    quickAnswerTitle.className = "search-quick-answer-title";
-    quickAnswerTitle.textContent = results.length ? "Quick answer" : "Search state";
-    quickAnswer.appendChild(quickAnswerTitle);
+      const quickAnswerTitle = document.createElement("div");
+      quickAnswerTitle.className = "search-quick-answer-title";
+      quickAnswerTitle.textContent = results.length ? "Quick answer" : "Search state";
+      quickAnswer.appendChild(quickAnswerTitle);
 
-    const quickAnswerBody = document.createElement("p");
-    quickAnswerBody.className = "search-widget-summary";
-    quickAnswerBody.textContent = summaryText || (
-      results.length
-        ? `I found ${results.length} place${results.length === 1 ? "" : "s"} to start. Open the first result if you want the fastest overview.`
-        : "No reliable results are currently available for this search. Check the evidence state before retrying."
-    );
-    quickAnswer.appendChild(quickAnswerBody);
+      const quickAnswerBody = document.createElement("p");
+      quickAnswerBody.className = "search-widget-summary";
+      quickAnswerBody.textContent = summaryText || (
+        results.length
+          ? `I found ${results.length} place${results.length === 1 ? "" : "s"} to start. Open the first result if you want the fastest overview.`
+          : "No reliable results are currently available for this search. Check the evidence state before retrying."
+      );
+      quickAnswer.appendChild(quickAnswerBody);
 
-    if (results[0]) {
-      const quickAnswerMeta = document.createElement("p");
-      quickAnswerMeta.className = "search-quick-answer-meta";
-      const bestTitle = String(results[0].title || "the first result").trim();
-      const bestSource = extractDomain(results[0].url) || "the web";
-      quickAnswerMeta.textContent = `Best place to start: ${bestTitle} from ${bestSource}.`;
-      quickAnswer.appendChild(quickAnswerMeta);
+      if (results[0]) {
+        const quickAnswerMeta = document.createElement("p");
+        quickAnswerMeta.className = "search-quick-answer-meta";
+        const bestTitle = String(results[0].title || "the first result").trim();
+        const bestSource = extractDomain(results[0].url) || "the web";
+        quickAnswerMeta.textContent = `Best place to start: ${bestTitle} from ${bestSource}.`;
+        quickAnswer.appendChild(quickAnswerMeta);
+      }
+      container.appendChild(quickAnswer);
     }
-    container.appendChild(quickAnswer);
 
     if (focusTopic) {
       const guideActions = document.createElement("div");
@@ -1840,106 +1917,108 @@ function renderSearchWidget(data) {
       container.appendChild(guideActions);
     }
 
-    const sourcesSection = document.createElement("div");
-    sourcesSection.className = "search-sources-section";
+    if (results.length) {
+      const sourcesSection = document.createElement("div");
+      sourcesSection.className = "search-sources-section";
 
-    const sourcesToggleRow = document.createElement("div");
-    sourcesToggleRow.className = "search-widget-actions";
+      const sourcesToggleRow = document.createElement("div");
+      sourcesToggleRow.className = "search-widget-actions";
 
-    const sourcesToggle = document.createElement("button");
-    sourcesToggle.type = "button";
-    sourcesToggle.className = "assistant-action-btn";
-    sourcesToggle.textContent = `See where this came from (${results.length})`;
-    sourcesToggle.setAttribute("aria-expanded", "false");
-    sourcesToggleRow.appendChild(sourcesToggle);
+      const sourcesToggle = document.createElement("button");
+      sourcesToggle.type = "button";
+      sourcesToggle.className = "assistant-action-btn";
+      sourcesToggle.textContent = `See where this came from (${results.length})`;
+      sourcesToggle.setAttribute("aria-expanded", "false");
+      sourcesToggleRow.appendChild(sourcesToggle);
 
-    const sourceList = document.createElement("div");
-    sourceList.className = "search-sources-list";
-    sourceList.hidden = true;
+      const sourceList = document.createElement("div");
+      sourceList.className = "search-sources-list";
+      sourceList.hidden = true;
 
-    sourcesToggle.addEventListener("click", () => {
-      const expanded = sourceList.hidden;
-      sourceList.hidden = !expanded;
-      sourcesToggle.setAttribute("aria-expanded", expanded ? "true" : "false");
-      sourcesToggle.textContent = expanded ? "Hide sources" : `See where this came from (${results.length})`;
-    });
+      sourcesToggle.addEventListener("click", () => {
+        const expanded = sourceList.hidden;
+        sourceList.hidden = !expanded;
+        sourcesToggle.setAttribute("aria-expanded", expanded ? "true" : "false");
+        sourcesToggle.textContent = expanded ? "Hide sources" : `See where this came from (${results.length})`;
+      });
 
-    results.forEach((item, index) => {
-      const div = document.createElement("div");
-      div.className = "search-result";
-      if (index === 0) div.classList.add("search-result-primary");
+      results.forEach((item, index) => {
+        const div = document.createElement("div");
+        div.className = "search-result";
+        if (index === 0) div.classList.add("search-result-primary");
 
-      const titleRow = document.createElement("div");
-      titleRow.className = "search-result-title";
+        const titleRow = document.createElement("div");
+        titleRow.className = "search-result-title";
 
-      if (index === 0) {
-        const startBadge = document.createElement("span");
-        startBadge.className = "search-start-badge";
-        startBadge.textContent = "Start here";
-        titleRow.appendChild(startBadge);
-      }
+        if (index === 0) {
+          const startBadge = document.createElement("span");
+          startBadge.className = "search-start-badge";
+          startBadge.textContent = "Start here";
+          titleRow.appendChild(startBadge);
+        }
 
-      const idx = document.createElement("span");
-      idx.className = "citation-index";
-      idx.textContent = `[${index + 1}]`;
-      titleRow.appendChild(idx);
+        const idx = document.createElement("span");
+        idx.className = "citation-index";
+        idx.textContent = `[${index + 1}]`;
+        titleRow.appendChild(idx);
 
-      const a = document.createElement("a");
-      a.href = item.url;
-      a.textContent = item.title;
-      a.target = "_blank";
-      a.rel = "noopener noreferrer";
-      titleRow.appendChild(a);
+        const a = document.createElement("a");
+        a.href = item.url;
+        a.textContent = item.title;
+        a.target = "_blank";
+        a.rel = "noopener noreferrer";
+        titleRow.appendChild(a);
 
-      const domain = extractDomain(item.url);
-      if (domain) {
-        const domainBadge = document.createElement("span");
-        domainBadge.className = "domain-badge";
-        domainBadge.textContent = domain;
-        titleRow.appendChild(domainBadge);
-      }
+        const domain = extractDomain(item.url);
+        if (domain) {
+          const domainBadge = document.createElement("span");
+          domainBadge.className = "domain-badge";
+          domainBadge.textContent = domain;
+          titleRow.appendChild(domainBadge);
+        }
 
-      appendConfidenceBadge(titleRow, "Web result");
-      div.appendChild(titleRow);
+        appendConfidenceBadge(titleRow, "Web result");
+        div.appendChild(titleRow);
 
-      const snippet = String(item.snippet || "").trim();
-      if (snippet) {
-        const snippetEl = document.createElement("p");
-        snippetEl.className = "search-result-snippet";
-        snippetEl.textContent = snippet;
-        div.appendChild(snippetEl);
-      }
+        const snippet = String(item.snippet || "").trim();
+        if (snippet) {
+          const snippetEl = document.createElement("p");
+          snippetEl.className = "search-result-snippet";
+          snippetEl.textContent = snippet;
+          div.appendChild(snippetEl);
+        }
 
-      const actions = document.createElement("div");
-      actions.className = "search-result-actions";
+        const actions = document.createElement("div");
+        actions.className = "search-result-actions";
 
-      const openBtn = document.createElement("a");
-      openBtn.className = "assistant-action-btn";
-      openBtn.href = item.url;
-      openBtn.target = "_blank";
-      openBtn.rel = "noopener noreferrer";
-      openBtn.textContent = "Open story";
-      actions.appendChild(openBtn);
+        const openBtn = document.createElement("a");
+        openBtn.className = "assistant-action-btn";
+        openBtn.href = item.url;
+        openBtn.target = "_blank";
+        openBtn.rel = "noopener noreferrer";
+        openBtn.textContent = "Open story";
+        actions.appendChild(openBtn);
 
-      const quickTakeBtn = document.createElement("button");
-      quickTakeBtn.type = "button";
-      quickTakeBtn.className = "assistant-action-btn";
-      quickTakeBtn.textContent = "Quick take";
-      quickTakeBtn.addEventListener("click", () => injectUserText(`Give me a quick take on ${item.title}.`, "text"));
-      actions.appendChild(quickTakeBtn);
+        const quickTakeBtn = document.createElement("button");
+        quickTakeBtn.type = "button";
+        quickTakeBtn.className = "assistant-action-btn";
+        quickTakeBtn.textContent = "Quick take";
+        quickTakeBtn.addEventListener("click", () => injectUserText(`Give me a quick take on ${item.title}.`, "text"));
+        actions.appendChild(quickTakeBtn);
 
-      const compareBtn = document.createElement("button");
-      compareBtn.type = "button";
-      compareBtn.className = "assistant-action-btn";
-      compareBtn.textContent = "See wider coverage";
-      compareBtn.addEventListener("click", () => injectUserText(`research latest coverage of ${queryText || item.title}`, "text"));
-      actions.appendChild(compareBtn);
-      div.appendChild(actions);
-      sourceList.appendChild(div);
-    });
-    sourcesSection.appendChild(sourcesToggleRow);
-    sourcesSection.appendChild(sourceList);
-    container.appendChild(sourcesSection);
+        const compareBtn = document.createElement("button");
+        compareBtn.type = "button";
+        compareBtn.className = "assistant-action-btn";
+        compareBtn.textContent = "See wider coverage";
+        compareBtn.addEventListener("click", () => injectUserText(`research latest coverage of ${queryText || item.title}`, "text"));
+        actions.appendChild(compareBtn);
+        div.appendChild(actions);
+        sourceList.appendChild(div);
+      });
+      sourcesSection.appendChild(sourcesToggleRow);
+      sourcesSection.appendChild(sourceList);
+      container.appendChild(sourcesSection);
+    }
 
     const suggested = Array.isArray(data && data.suggested_actions) ? data.suggested_actions : [];
     if (suggested.length) {
@@ -2540,6 +2619,7 @@ function connectWebSocket() {
           workflowFocusState.awaitingResponse = false;
           renderWorkflowFocusWidget();
         }
+        if (typeof fetchAndRenderReceipts === "function") fetchAndRenderReceipts();
         break;
       case "thought":
         if (pendingThoughtMessageId && msg.message_id === pendingThoughtMessageId) {
@@ -2688,6 +2768,7 @@ function setActivePage(page) {
   if (target === "trust") {
     safeWSSend({ text: "trust center", silent_widget_refresh: true });
     safeWSSend({ text: "system status", silent_widget_refresh: true });
+    if (typeof fetchAndRenderReceipts === "function") fetchAndRenderReceipts();
   }
   if (target === "intro") {
     requestSettingsRuntimeRefresh();
@@ -3954,6 +4035,7 @@ window.addEventListener("DOMContentLoaded", () => {
   safeInit("renderOperatorHealthWidget", () => renderOperatorHealthWidget({}));
   safeInit("renderCapabilitySurfaceWidget", () => renderCapabilitySurfaceWidget({}));
   safeInit("renderTrustPanel", () => renderTrustPanel());
+  safeInit("fetchAndRenderReceipts", () => fetchAndRenderReceipts());
   safeInit("renderWorkspaceHomeWidget", () => renderWorkspaceHomeWidget({}));
   safeInit("renderProjectStructureMapWidget", () => renderProjectStructureMapWidget({}));
   safeInit("renderAssistiveNoticesWidget", () => renderAssistiveNoticesWidget({}));
@@ -4142,6 +4224,7 @@ window.addEventListener("DOMContentLoaded", () => {
     safeWSSend({ text: "trust center", silent_widget_refresh: true });
     safeWSSend({ text: "system status", silent_widget_refresh: true });
     safeWSSend({ text: "operational context", silent_widget_refresh: true });
+    if (typeof fetchAndRenderReceipts === "function") fetchAndRenderReceipts();
   });
 
   const trustCenterSystemBtn = $("btn-trust-center-system");

--- a/Nova-Frontend-Dashboard/dashboard-config.js
+++ b/Nova-Frontend-Dashboard/dashboard-config.js
@@ -1,4 +1,6 @@
 window.NOVA_DASHBOARD_CONFIG = {
+  // Task 1.3: default first-run prompt pushed toward a quick "magic moment".
+  FIRST_RUN_DEFAULT_PROMPT: "daily brief",
   API_BASE: `${window.location.protocol}//${window.location.host}`,
   WS_BASE: `${window.location.protocol === "https:" ? "wss" : "ws"}://${window.location.host}`,
   HEY_NOVA_WAKE_WORD: "Hey Nova",

--- a/Nova-Frontend-Dashboard/dashboard-control-center.js
+++ b/Nova-Frontend-Dashboard/dashboard-control-center.js
@@ -126,7 +126,7 @@ function applyOpenClawAgentPayload(data) {
     ? data.agent
     : (data && typeof data === "object" ? data : {});
   openClawAgentState.loaded = true;
-  openClawAgentState.summary = String(payload.summary || "").trim() || "Nova can run tasks you review and approve before they take effect.";
+  openClawAgentState.summary = String(payload.summary || "").trim() || "Home Agent helps Nova run manual tasks you can review and stop.";
   openClawAgentState.snapshot = { ...payload };
   openClawAgentState.templates = Array.isArray(payload.templates) ? payload.templates.map((item) => ({ ...item })) : [];
   openClawAgentState.activeRun = (payload.active_run && typeof payload.active_run === "object")
@@ -2519,6 +2519,311 @@ function renderTrustPanel(data = {}) {
   renderSettingsPage();
 }
 
+// ---------------------------------------------------------------------------
+// Action receipt card — fetches /api/trust/receipts and renders to
+// #trust-center-receipts. Called after chat_done, on trust refresh,
+// and when navigating to the Trust Center page.
+// ---------------------------------------------------------------------------
+
+const _RECEIPT_LABELS = {
+  EMAIL_DRAFT_CREATED:          "Email draft opened in mail client",
+  EMAIL_DRAFT_FAILED:           "Email draft failed",
+  ACTION_ATTEMPTED:             "Action attempted",
+  ACTION_COMPLETED:             "Action completed",
+  OPENCLAW_ACTION_APPROVED:     "OpenClaw action approved",
+  OPENCLAW_ACTION_DENIED:       "OpenClaw action denied",
+  OPENCLAW_ACTION_PENDING:      "OpenClaw action awaiting confirmation",
+  OPENCLAW_AGENT_RUN_COMPLETED: "OpenClaw agent run completed",
+  SCREEN_CAPTURE_COMPLETED:     "Screen capture completed",
+  MEMORY_ITEM_SAVED:            "Memory item saved",
+  MEMORY_ITEM_DELETED:          "Memory item deleted",
+  POLICY_EXECUTION_COMPLETED:   "Policy executed",
+  POLICY_EXECUTION_BLOCKED:     "Policy blocked",
+};
+
+// Outcome keys: done / failed / blocked / pending / info (no badge)
+const _RECEIPT_OUTCOME = {
+  EMAIL_DRAFT_CREATED:          "done",
+  ACTION_COMPLETED:             "done",
+  OPENCLAW_ACTION_APPROVED:     "done",
+  OPENCLAW_AGENT_RUN_COMPLETED: "done",
+  SCREEN_CAPTURE_COMPLETED:     "done",
+  MEMORY_ITEM_SAVED:            "done",
+  POLICY_EXECUTION_COMPLETED:   "done",
+  EMAIL_DRAFT_FAILED:           "failed",
+  OPENCLAW_ACTION_DENIED:       "blocked",
+  POLICY_EXECUTION_BLOCKED:     "blocked",
+  OPENCLAW_ACTION_PENDING:      "pending",
+};
+
+// Human-readable badge labels per outcome
+const _OUTCOME_LABEL = {
+  done:    "Done",
+  failed:  "Failed",
+  blocked: "Blocked",
+  pending: "Pending",
+};
+
+// Authority boundary / next-step note shown below the detail line
+const _RECEIPT_BOUNDARY = {
+  EMAIL_DRAFT_CREATED:     "Local draft only — review and send manually in your mail client",
+  EMAIL_DRAFT_FAILED:      "Mail client did not open — check that a default mail app is configured",
+  OPENCLAW_ACTION_PENDING: "Awaiting your confirmation to proceed",
+  OPENCLAW_ACTION_DENIED:  "Blocked by governance — no action taken",
+  POLICY_EXECUTION_BLOCKED: "Policy blocked — no action taken",
+};
+
+function _receiptDetail(r) {
+  const type = String(r.event_type || "").trim();
+  if (type === "EMAIL_DRAFT_CREATED" || type === "EMAIL_DRAFT_FAILED") {
+    const to      = String(r.to || r.recipient || "").trim();
+    const subject = String(r.subject || "").trim();
+    return [to && `To: ${to}`, subject && `Subject: ${subject}`].filter(Boolean).join("  ·  ");
+  }
+  if (type.startsWith("OPENCLAW_")) {
+    return String(r.action_type || r.description || r.action || "").trim();
+  }
+  if (type.startsWith("MEMORY_")) {
+    const key = String(r.key || r.content || "").trim();
+    return key.length > 60 ? key.slice(0, 57) + "…" : key;
+  }
+  if (type === "POLICY_EXECUTION_COMPLETED" || type === "POLICY_EXECUTION_BLOCKED") {
+    return String(r.policy || r.capability_id || "").trim();
+  }
+  return String(r.action || r.capability_id || "").trim();
+}
+
+function _receiptTime(ts) {
+  if (!ts) return "";
+  try {
+    return new Date(ts).toLocaleString([], {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch (_) {
+    return String(ts).slice(0, 16);
+  }
+}
+
+function _receiptKey(r, index = 0) {
+  const raw = String(
+    r.request_id
+    || r._ledger_line
+    || r.timestamp_utc
+    || r.event_type
+    || index
+  ).trim();
+  return raw || String(index);
+}
+
+function _receiptCapabilityLabel(r) {
+  return String(r.capability_name || r.action || r.capability_id || "").trim();
+}
+
+function _receiptExecutionStatus(r) {
+  const status = String(r.status || "").trim();
+  if (status) return status;
+  const type = String(r.event_type || "").trim();
+  if (type === "OPENCLAW_ACTION_PENDING") return "pending_confirmation";
+  if (type === "OPENCLAW_ACTION_DENIED" || type === "POLICY_EXECUTION_BLOCKED") return "blocked";
+  if (_RECEIPT_OUTCOME[type] === "failed") return "failed";
+  if (_RECEIPT_OUTCOME[type] === "done") return "completed";
+  return "recorded";
+}
+
+function _receiptApprovalRequired(r) {
+  if (typeof r.requires_confirmation === "boolean") {
+    return r.requires_confirmation ? "yes" : "no";
+  }
+  return String(r.event_type || "").trim() === "OPENCLAW_ACTION_PENDING" ? "yes" : "not recorded";
+}
+
+function _receiptLedgerRef(r) {
+  const line = Number(r._ledger_line || 0);
+  if (Number.isFinite(line) && line > 0) return `L${line}`;
+  return "";
+}
+
+function _receiptOutcomeLabel(r) {
+  const type = String(r.event_type || "").trim();
+  const outcome = _RECEIPT_OUTCOME[type] || "info";
+  return _OUTCOME_LABEL[outcome] || "Recorded";
+}
+
+function _receiptReason(r) {
+  return String(
+    r.failure_reason
+    || r.reason
+    || r.outcome_reason
+    || r.description
+    || r.summary
+    || ""
+  ).trim();
+}
+
+function _receiptSourcePathSummary(r) {
+  const request = String(r.request_id || "").trim() || "User request not recorded";
+  const capability = _receiptCapabilityLabel(r) || "Governed capability not recorded";
+  const execution = _receiptExecutionStatus(r);
+  const receiptRef = _receiptLedgerRef(r) || "Ledger receipt";
+  return `${request} -> ${capability} -> governed ${execution} -> ${receiptRef}`;
+}
+
+function _renderReceiptRows(host) {
+  clear(host);
+  if (!trustReviewState.receipts.length) {
+    const empty = document.createElement("div");
+    empty.className = "trust-empty";
+    empty.textContent = "No governed actions recorded yet. Governed actions appear here after they run.";
+    host.appendChild(empty);
+    return;
+  }
+  const list = document.createElement("div");
+  list.className = "trust-activity-list";
+  trustReviewState.receipts.slice(0, 12).forEach((r, index) => {
+    const key = _receiptKey(r, index);
+    const type = String(r.event_type || "").trim();
+    const label = _RECEIPT_LABELS[type] || type.toLowerCase().replace(/_/g, " ");
+    const detail = _receiptDetail(r);
+    const capability = _receiptCapabilityLabel(r);
+    const time = _receiptTime(r.timestamp_utc);
+    const outcome = _RECEIPT_OUTCOME[type] || "info";
+    const boundary = _RECEIPT_BOUNDARY[type] || "";
+    const sourcePath = _receiptSourcePathSummary(r);
+
+    const row = document.createElement("button");
+    row.type = "button";
+    row.className = "trust-activity-item";
+    if (trustReviewState.selectedReceiptKey === key) row.classList.add("active");
+    row.dataset.outcome = outcome;
+    row.addEventListener("click", () => {
+      trustReviewState.selectedReceiptKey = key;
+      renderTrustCenterPage();
+    });
+
+    const titleRow = document.createElement("div");
+    titleRow.className = "trust-activity-title-row";
+
+    if (outcome !== "info") {
+      const badge = document.createElement("span");
+      badge.className = `trust-activity-outcome trust-activity-outcome-${outcome}`;
+      badge.textContent = _OUTCOME_LABEL[outcome] || outcome;
+      titleRow.appendChild(badge);
+    }
+
+    const title = document.createElement("div");
+    title.className = "trust-activity-title";
+    title.textContent = label;
+    titleRow.appendChild(title);
+    row.appendChild(titleRow);
+
+    const meta = document.createElement("div");
+    meta.className = "trust-activity-meta";
+    meta.textContent = [
+      capability && `Capability: ${capability}`,
+      `Status: ${_receiptExecutionStatus(r)}`,
+      time,
+    ].filter(Boolean).join("  ·  ");
+    row.appendChild(meta);
+
+    if (detail) {
+      const detailRow = document.createElement("div");
+      detailRow.className = "trust-activity-reason";
+      detailRow.textContent = detail;
+      row.appendChild(detailRow);
+    }
+
+    const pathRow = document.createElement("div");
+    pathRow.className = "trust-activity-correlation";
+    pathRow.textContent = `Path: ${sourcePath}`;
+    row.appendChild(pathRow);
+
+    if (boundary) {
+      const note = document.createElement("div");
+      note.className = "trust-receipt-note";
+      note.textContent = boundary;
+      row.appendChild(note);
+    }
+
+    list.appendChild(row);
+  });
+  host.appendChild(list);
+}
+
+function _renderReceiptDetail(host) {
+  clear(host);
+  const selected = trustReviewState.receipts.find((receipt, index) => {
+    return _receiptKey(receipt, index) === String(trustReviewState.selectedReceiptKey || "").trim();
+  }) || trustReviewState.receipts[0];
+
+  if (!selected) {
+    const empty = document.createElement("div");
+    empty.className = "trust-empty";
+    empty.textContent = "Select a receipt to see how a governed request moved from user intent to capability execution and into the ledger.";
+    host.appendChild(empty);
+    return;
+  }
+
+  [
+    ["Receipt", _RECEIPT_LABELS[String(selected.event_type || "").trim()] || String(selected.event_type || "Unknown").trim() || "Unknown"],
+    ["Capability", _receiptCapabilityLabel(selected) || "Not recorded"],
+    ["Execution status", _receiptExecutionStatus(selected)],
+    ["Outcome", _receiptOutcomeLabel(selected)],
+    ["Approval required", _receiptApprovalRequired(selected)],
+    ["Timestamp", _receiptTime(selected.timestamp_utc) || "Not recorded"],
+    ["Source path", _receiptSourcePathSummary(selected)],
+    ["Request", String(selected.request_id || "Not recorded").trim() || "Not recorded"],
+    ["Ledger", _receiptLedgerRef(selected) || "Not recorded"],
+    ["Boundary", _RECEIPT_BOUNDARY[String(selected.event_type || "").trim()] || "No extra boundary note recorded"],
+    ["Detail", _receiptDetail(selected) || "No additional detail recorded"],
+    ["Why", _receiptReason(selected) || "No additional reason recorded"],
+  ].forEach(([label, value]) => {
+    const row = document.createElement("div");
+    row.className = "operator-health-row";
+
+    const labelEl = document.createElement("div");
+    labelEl.className = "operator-health-label";
+    labelEl.textContent = label;
+    row.appendChild(labelEl);
+
+    const valueEl = document.createElement("div");
+    valueEl.className = "operator-health-value";
+    valueEl.textContent = value;
+    row.appendChild(valueEl);
+
+    host.appendChild(row);
+  });
+}
+
+function fetchAndRenderReceipts() {
+  const host = $("trust-center-receipts");
+  if (!host) return;
+  fetch("/api/trust/receipts?limit=10")
+    .then((res) => (res.ok ? res.json() : Promise.reject(res.status)))
+    .then((data) => {
+      trustReviewState.receipts = Array.isArray(data.receipts) ? data.receipts.slice(0, 20) : [];
+      if (!trustReviewState.selectedReceiptKey && trustReviewState.receipts.length) {
+        trustReviewState.selectedReceiptKey = _receiptKey(trustReviewState.receipts[0], 0);
+      }
+      if (
+        trustReviewState.selectedReceiptKey
+        && !trustReviewState.receipts.some((receipt, index) => _receiptKey(receipt, index) === trustReviewState.selectedReceiptKey)
+      ) {
+        trustReviewState.selectedReceiptKey = trustReviewState.receipts.length
+          ? _receiptKey(trustReviewState.receipts[0], 0)
+          : "";
+      }
+      renderTrustCenterPage();
+    })
+    .catch(() => {
+      trustReviewState.receipts = [];
+      trustReviewState.selectedReceiptKey = "";
+      renderTrustCenterPage();
+    });
+}
+
 function getPolicyReadinessBuckets(snapshot = {}) {
   const readiness = (snapshot && typeof snapshot === "object") ? snapshot : {};
   return {
@@ -2536,6 +2841,8 @@ function renderTrustCenterPage() {
   const lastCall = $("trust-center-last-call");
   const egress = $("trust-center-egress");
   const failure = $("trust-center-failure");
+  const receiptHost = $("trust-center-receipts");
+  const receiptDetail = $("trust-center-receipt-detail");
   const activityHost = $("trust-center-activity");
   const activityDetail = $("trust-center-activity-detail");
   const blockedHost = $("trust-center-blocked");
@@ -2554,7 +2861,7 @@ function renderTrustCenterPage() {
   const reasoningGrid = $("trust-center-reasoning-grid");
   const bridgeSummary = $("trust-center-bridge-summary");
   const bridgeGrid = $("trust-center-bridge-grid");
-  if (!summary || !mode || !lastCall || !egress || !failure || !activityHost || !blockedHost || !healthSummary || !healthGrid || !policySummary || !policyLimit || !policyGroups || !policyDetail || !capabilitySummary || !capabilityHost) return;
+  if (!summary || !mode || !lastCall || !egress || !failure || !receiptHost || !receiptDetail || !activityHost || !blockedHost || !healthSummary || !healthGrid || !policySummary || !policyLimit || !policyGroups || !policyDetail || !capabilitySummary || !capabilityHost) return;
 
   summary.textContent = [
     String(trustReviewState.summary || "").trim(),
@@ -2564,6 +2871,8 @@ function renderTrustCenterPage() {
   lastCall.textContent = trustState.lastExternalCall || "None";
   egress.textContent = trustState.dataEgress || "Read-only requests only";
   failure.textContent = trustState.failureState || "Normal";
+  _renderReceiptRows(receiptHost);
+  _renderReceiptDetail(receiptDetail);
 
   clear(activityHost);
   if (!trustReviewState.activity.length) {
@@ -3200,7 +3509,7 @@ function renderOpenClawAgentPage() {
   if (summary) {
     const runnableCount = Array.isArray(setup.runnable_template_ids) ? setup.runnable_template_ids.length : 0;
     const summaryBits = [
-      String(openClawAgentState.summary || "").trim() || "Nova can run tasks you review and approve before they take effect.",
+      String(openClawAgentState.summary || "").trim() || "Home Agent helps Nova run manual tasks you can review and stop.",
       permissionEnabled
         ? (runnableCount
           ? `${runnableCount} task${runnableCount === 1 ? "" : "s"} available to run.`
@@ -3349,11 +3658,22 @@ function renderOpenClawAgentPage() {
         card.appendChild(tools);
 
         const envelopePreview = getOpenClawEnvelopePreview(template);
-        const previewCopy = document.createElement("p");
-        previewCopy.className = "first-run-note";
-        previewCopy.textContent = buildOpenClawBudgetLines(envelopePreview).join(" ")
-          || "This task will show its safety limits here when it is ready.";
-        card.appendChild(previewCopy);
+
+        // Run Permit: authority lane, allowed domains, budget caps
+        const permitLabel = document.createElement("p");
+        permitLabel.className = "first-run-note";
+        permitLabel.textContent = "Run permit";
+        card.appendChild(permitLabel);
+
+        const writesAllowed = Number(envelopePreview.max_bytes_written || template.max_bytes_written || 0) > 0;
+        const permitLaneChips = document.createElement("div");
+        permitLaneChips.className = "memory-detail-chip-row";
+        permitLaneChips.appendChild(createOverviewChip("Authority", writesAllowed ? "Writes allowed" : "Read-only"));
+        (Array.isArray(template.allowed_hostnames) ? template.allowed_hostnames : []).forEach((host) => {
+          const h = String(host || "").trim();
+          if (h) permitLaneChips.appendChild(createOverviewChip("Domain", h));
+        });
+        card.appendChild(permitLaneChips);
 
         const previewChips = document.createElement("div");
         previewChips.className = "memory-detail-chip-row";
@@ -3361,7 +3681,6 @@ function renderOpenClawAgentPage() {
           ["Steps", String(envelopePreview.max_steps || template.max_steps || 0)],
           ["Web requests", String(envelopePreview.max_network_calls || template.max_network_calls || 0)],
           ["Local files", String(envelopePreview.max_files_touched || template.max_files_touched || 0)],
-          ["Can make changes", Number(envelopePreview.max_bytes_written || template.max_bytes_written || 0) > 0 ? "Yes" : "No"],
         ].forEach(([label, value]) => previewChips.appendChild(createOverviewChip(label, value)));
         card.appendChild(previewChips);
 

--- a/Nova-Frontend-Dashboard/dashboard-surfaces.css
+++ b/Nova-Frontend-Dashboard/dashboard-surfaces.css
@@ -1948,20 +1948,49 @@ button.workspace-spotlight-card.active {
   text-transform: uppercase;
 }
 
-.trust-activity-outcome-success {
+.trust-activity-outcome-success,
+.trust-activity-outcome-done {
   border: 1px solid rgba(126, 216, 178, 0.32);
   background: rgba(47, 121, 92, 0.24);
   color: #b8f0d5;
 }
 
-.trust-activity-outcome-issue {
+.trust-activity-outcome-issue,
+.trust-activity-outcome-blocked {
   border: 1px solid rgba(255, 182, 131, 0.34);
   background: rgba(120, 55, 18, 0.28);
   color: #ffd1a8;
 }
 
-.trust-activity-item[data-outcome="issue"] {
+.trust-activity-outcome-failed {
+  border: 1px solid rgba(255, 140, 140, 0.36);
+  background: rgba(110, 28, 28, 0.28);
+  color: #ffbbbb;
+}
+
+.trust-activity-outcome-pending {
+  border: 1px solid rgba(140, 185, 255, 0.32);
+  background: rgba(28, 60, 110, 0.28);
+  color: #b8d4ff;
+}
+
+.trust-activity-item[data-outcome="issue"],
+.trust-activity-item[data-outcome="blocked"] {
   border-color: rgba(255, 182, 131, 0.28);
+}
+
+.trust-activity-item[data-outcome="failed"] {
+  border-color: rgba(255, 140, 140, 0.28);
+}
+
+.trust-activity-item[data-outcome="pending"] {
+  border-color: rgba(140, 185, 255, 0.22);
+}
+
+.trust-receipt-note {
+  font-size: 0.7rem;
+  color: rgba(180, 210, 255, 0.6);
+  margin-top: 1px;
 }
 
 .context-insight-steps {

--- a/Nova-Frontend-Dashboard/dashboard-workspace.js
+++ b/Nova-Frontend-Dashboard/dashboard-workspace.js
@@ -314,7 +314,7 @@ function renderThreadMapWidget(data = {}) {
 
     const listMemoryBtn = document.createElement("button");
     listMemoryBtn.type = "button";
-    listMemoryBtn.textContent = `View saved (${memoryCount})`;
+    listMemoryBtn.textContent = `List memory (${memoryCount})`;
     listMemoryBtn.addEventListener("click", () => injectUserText(`memory list thread ${name}`, "text"));
     actions.appendChild(listMemoryBtn);
 

--- a/Nova-Frontend-Dashboard/dashboard.js
+++ b/Nova-Frontend-Dashboard/dashboard.js
@@ -105,8 +105,10 @@ let trustState = {
 };
 let trustReviewState = {
   summary: "Live review of recent actions and network activity will appear here.",
+  receipts: [],
   activity: [],
   blocked: [],
+  selectedReceiptKey: "",
   selectedActivityKey: "",
   selectedBlockedKey: "",
   policyReadiness: {},

--- a/Nova-Frontend-Dashboard/index.html
+++ b/Nova-Frontend-Dashboard/index.html
@@ -6,6 +6,8 @@
   <title>Nova</title>
   <link rel="stylesheet" href="/static/style.phase1.css" />
   <link rel="stylesheet" href="/static/dashboard-surfaces.css" />
+  <!-- Task 1.3: first-run simplified UI. Loaded last so it can override. -->
+  <link rel="stylesheet" href="/static/dashboard-simplified.css" />
 </head>
 <body>
   <div class="orb-container" id="orb-container" aria-hidden="true">
@@ -644,6 +646,17 @@
         <div class="widget page-card trust-center-panel" aria-live="polite">
           <div class="workspace-board-section-header">
             <div>
+              <div class="workspace-home-section-title">Action Receipts</div>
+              <p class="workspace-board-section-copy">Ledger-backed record of the last governed actions — what ran, what was blocked, and why.</p>
+            </div>
+          </div>
+          <div id="trust-center-receipts" class="trust-section trust-center-list"></div>
+          <div id="trust-center-receipt-detail" class="operator-health-grid"></div>
+        </div>
+
+        <div class="widget page-card trust-center-panel" aria-live="polite">
+          <div class="workspace-board-section-header">
+            <div>
               <div class="workspace-home-section-title">Recent Governed Actions</div>
               <p class="workspace-board-section-copy">Review the latest actions, why they ran, and what effect they had.</p>
             </div>
@@ -1190,5 +1203,7 @@
   <script src="/static/dashboard-control-center.js"></script>
   <script src="/static/dashboard.js"></script>
   <script src="/static/dashboard-chat-news.js"></script>
+  <!-- Task 1.3: must load after dashboard scripts so header is in place. -->
+  <script src="/static/dashboard-simplified.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Resolve pre-existing frontend mirror drift between `nova_backend/static/` and `Nova-Frontend-Dashboard/`
- 7 files copied from `nova_backend/static/` (authoritative, last updated May 14) to `Nova-Frontend-Dashboard/` (stale since April 23)
- Fixes the Phase-3.5 "Enforce frontend mirror sync" check failure

## Classification
- Pre-existing baseline drift on main
- Not introduced by any open PR
- Same baseline-cleanup pattern as #177, #178, #179

## Test plan
- [x] `python scripts/check_frontend_mirror_sync.py` passes locally
- [ ] Phase-3.5 frontend mirror sync step should pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)