### PR TITLE
docs: sync status after basic workflow fixes

### DIFF
--- a/.agent_context/current_priority.md
+++ b/.agent_context/current_priority.md
@@ -18,7 +18,14 @@ Status:
 Trust Panel MVP is complete and merged.
 Approval-gate focused regression and behavioral live-session coverage are merged
 for tested Cap 22 / Cap 64 confirmation paths.
+PR #175 documented Nova basic workflow verification.
+PR #176 fixed and merged the basic workflow regressions found by that pass.
+PR #177, PR #178, PR #179, and PR #180 cleared baseline CI blockers needed
+for clean verification.
+Core CI, Runtime Docs, Governance, Fingerprint Clean, and Phase-3.5 Verification
+passed before PR #176 merged.
 Full approval-gate certification remains pending until broader/full-suite proof exists.
+Website-preview live-backend validation remains follow-up debt.
 ```
 
 Scope:
@@ -52,6 +59,12 @@ PR #167 — Trust Panel MVP receipt surface merged.
 PR #169 — Approval gate next-sequence correction merged.
 PR #171 — Approval gate focused regression coverage merged.
 PR #172 — Approval gate behavioral live-session coverage merged.
+PR #175 — Nova basic workflow verification report merged.
+PR #176 — Nova basic workflow regression fixes merged.
+PR #177 — Baseline CI blocker cleanup merged.
+PR #178 — Baseline CI blocker cleanup merged.
+PR #179 — Baseline CI blocker cleanup merged.
+PR #180 — Frontend mirror sync baseline fix merged.
 ```
 
 ## Recent closed / not merged truth
@@ -128,8 +141,9 @@ Most other active capabilities — certification lock phases pending.
 
 ```text
 1. Keep #171 / #172 as focused coverage, not certification.
-2. Run broader/full-suite approval-gate verification when practical.
-3. Only then decide whether the approval-gate lock can move toward certification/closeout.
+2. Keep #175 / #176 as basic workflow verification and fixes, not approval-gate certification.
+3. Run broader/full-suite approval-gate verification when practical.
+4. Only then decide whether the approval-gate lock can move toward certification/closeout.
 ```
 
 ## Safety boundary

--- a/docs/status/CURRENT_WORK_STATUS.md
+++ b/docs/status/CURRENT_WORK_STATUS.md
@@ -1,6 +1,6 @@
 # Nova Current Work Status
 
-Last reviewed: 2026-05-17
+Last reviewed: 2026-05-18
 
 This is a human-maintained continuity note for the current development slice.
 
@@ -19,7 +19,7 @@ See FIVE_PASS_STABILITY_AND_OPERATIONAL_ROADMAP_2026-05-12.md for the post-audit
 ## Current Active Task
 
 ```text
-Approval gate wiring - focused coverage merged / certification pending (2026-05-17).
+Approval gate wiring - focused coverage merged / certification pending (2026-05-18).
 ```
 
 Status:
@@ -28,7 +28,14 @@ Status:
 Trust Panel MVP is complete and proof-backed.
 Approval-gate focused regression and behavioral live-session coverage are merged
 for tested Cap 22 / Cap 64 confirmation paths.
+PR #175 documented Nova basic workflow verification.
+PR #176 fixed and merged the basic workflow regressions found by that pass.
+PR #177, PR #178, PR #179, and PR #180 cleared baseline CI blockers needed
+for clean verification.
+Core CI, Runtime Docs, Governance, Fingerprint Clean, and Phase-3.5 Verification
+passed before PR #176 merged.
 Full approval-gate certification remains pending until broader/full-suite proof exists.
+Website-preview live-backend validation remains follow-up debt.
 ```
 
 Current approval-gate status:
@@ -36,7 +43,11 @@ Current approval-gate status:
 ```text
 Focused regression coverage: merged.
 Behavioral live-session coverage: merged.
+Basic workflow verification report: merged.
+Basic workflow regressions: fixed / merged.
+Baseline CI blockers for clean verification: cleared / merged.
 Full approval-gate certification: pending.
+Website-preview live-backend validation: follow-up debt.
 ```
 
 ---
@@ -237,6 +248,58 @@ yes resumes with confirmed=True through governed invocation
 no / cancel / unrelated input does not execute the pending action
 ```
 
+### Nova basic workflow verification
+
+Status:
+
+```text
+merged - PR #175
+```
+
+Result:
+
+```text
+documented daily-use workflow verification, focused test chunks, latency checks,
+and a broader full-suite attempt without changing runtime behavior or authority
+```
+
+This is verification evidence only. It does not certify the approval gate globally.
+
+### Nova basic workflow regression fixes
+
+Status:
+
+```text
+merged - PR #176
+```
+
+Result:
+
+```text
+fixed the basic workflow regressions found by PR #175
+merged after Core CI, Runtime Docs, Governance, Fingerprint Clean, and
+Phase-3.5 Verification passed on the rebased branch
+```
+
+This does not close approval-gate certification.
+
+### Baseline CI blocker cleanup
+
+Status:
+
+```text
+merged - PR #177, PR #178, PR #179, PR #180
+```
+
+Result:
+
+```text
+cleared baseline CI blockers needed for clean verification
+PR #180 synced the frontend mirror from nova_backend/static
+```
+
+Website-preview live-backend validation remains follow-up debt.
+
 ---
 
 ## Closed / Unmerged Follow-Through
@@ -322,6 +385,7 @@ Per the current reviewed sequence:
 
 ```text
 1. Keep PR #171 / #172 framed as focused coverage, not certification.
-2. Run broader/full-suite approval-gate verification when practical.
-3. Only then decide whether the approval-gate lock can move toward certification/closeout.
+2. Keep PR #175 / #176 framed as basic workflow verification and fixes, not certification.
+3. Run broader/full-suite approval-gate verification when practical.
+4. Only then decide whether the approval-gate lock can move toward certification/closeout.
 ```

--- a/docs/todo/ACTIVE_TODO.md
+++ b/docs/todo/ACTIVE_TODO.md
@@ -1,13 +1,13 @@
 # Active TODO - Nova
 
-Last reviewed: 2026-05-17
+Last reviewed: 2026-05-18
 
 ---
 
 ## Current Active Task
 
 ```text
-Approval gate wiring - focused coverage merged / certification pending (2026-05-17).
+Approval gate wiring - focused coverage merged / certification pending (2026-05-18).
 ```
 
 Result:
@@ -16,13 +16,21 @@ Result:
 Trust Panel MVP is complete and proof-backed.
 Approval-gate focused regression and behavioral live-session coverage are merged
 for tested Cap 22 / Cap 64 confirmation paths.
+PR #175 documented Nova basic workflow verification.
+PR #176 fixed and merged the basic workflow regressions found by that pass.
+PR #177, PR #178, PR #179, and PR #180 cleared baseline CI blockers needed
+for clean verification.
+Core CI, Runtime Docs, Governance, Fingerprint Clean, and Phase-3.5 Verification
+passed before PR #176 merged.
 Full approval-gate certification remains pending until broader/full-suite proof exists.
+Website-preview live-backend validation remains follow-up debt.
 ```
 
 Next correct step:
 
 ```text
 Run broader/full-suite approval-gate verification when practical, then decide whether the lock can move toward certification/closeout.
+Do not treat PR #175 / PR #176 as approval-gate certification closeout.
 ```
 
 ---
@@ -49,6 +57,12 @@ PR #167 — Trust Panel MVP receipt surface merged.
 PR #169 — Approval gate next-sequence correction merged.
 PR #171 — Approval gate focused regression coverage merged.
 PR #172 — Approval gate behavioral live-session coverage merged.
+PR #175 — Nova basic workflow verification report merged.
+PR #176 — Nova basic workflow regression fixes merged.
+PR #177 — Baseline CI blocker cleanup merged.
+PR #178 — Baseline CI blocker cleanup merged.
+PR #179 — Baseline CI blocker cleanup merged.
+PR #180 — Frontend mirror sync baseline fix merged.
 ```
 
 ---
@@ -108,6 +122,21 @@ Scope:
 
 ```text
 test-only change
+```
+
+### Website-preview live-backend validation
+
+Status:
+
+```text
+follow-up debt
+```
+
+Scope:
+
+```text
+live-backend validation only
+no runtime authority expansion
 ```
 
 ---
@@ -198,6 +227,7 @@ The recent audit and hardening merges do not approve:
 
 ```text
 1. Keep PR #171 / #172 framed as focused coverage, not certification.
-2. Run broader/full-suite approval-gate verification when practical.
-3. Only then decide whether the approval-gate lock can move toward certification/closeout.
+2. Keep PR #175 / #176 framed as basic workflow verification and fixes, not approval-gate certification.
+3. Run broader/full-suite approval-gate verification when practical.
+4. Only then decide whether the approval-gate lock can move toward certification/closeout.
 ```


### PR DESCRIPTION
## Summary
- Syncs current priority, work status, and active TODO after PR #175 / PR #176 and baseline CI cleanup PRs #177-#180.
- Preserves approval-gate certification as pending until broader/full-suite proof exists.
- Records website-preview live-backend validation as follow-up debt.

## Boundaries
- Docs-only status sync.
- No runtime behavior changes.
- No generated runtime doc edits.
- No capability changes or authority expansion.

## Test plan
- git diff --check
- python scripts/check_runtime_doc_drift.py