### PR TITLE
chore: ignore codex worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ scripts/pids/*.log
 
 # Local workspace artifacts
 .claude/
+.codex-worktrees/
 New-Audit-and-Issues.md
 Untitled.canvas
 Untitled*.canvas


### PR DESCRIPTION
## Summary
- Adds `.codex-worktrees/` to `.gitignore` so local Codex worktree directories are not accidentally tracked.

## Boundaries
- Gitignore-only cleanup.
- No runtime behavior changes.
- No generated runtime doc edits.
- No capability or authority changes.
- No approval-gate certification claim.

## Not included
- `BigPicture/`
- `nova_workspace/story_tracker/story_ai_regulation.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)