### PR TITLE
docs: sync status after planning and housekeeping merges

### DIFF
--- a/.agent_context/current_priority.md
+++ b/.agent_context/current_priority.md
@@ -65,6 +65,9 @@ PR #177 — Baseline CI blocker cleanup merged.
 PR #178 — Baseline CI blocker cleanup merged.
 PR #179 — Baseline CI blocker cleanup merged.
 PR #180 — Frontend mirror sync baseline fix merged.
+PR #182 — Obsidian / Second Brain future-planning preserved.
+PR #183 — BigPicture / Auralis operating-model future-planning preserved.
+PR #184 — .codex-worktrees/ ignored in .gitignore.
 ```
 
 ## Recent closed / not merged truth

--- a/docs/status/CURRENT_WORK_STATUS.md
+++ b/docs/status/CURRENT_WORK_STATUS.md
@@ -36,6 +36,7 @@ Core CI, Runtime Docs, Governance, Fingerprint Clean, and Phase-3.5 Verification
 passed before PR #176 merged.
 Full approval-gate certification remains pending until broader/full-suite proof exists.
 Website-preview live-backend validation remains follow-up debt.
+PR #182, PR #183, and PR #184 merged planning preservation and housekeeping.
 ```
 
 Current approval-gate status:
@@ -299,6 +300,51 @@ PR #180 synced the frontend mirror from nova_backend/static
 ```
 
 Website-preview live-backend validation remains follow-up debt.
+
+### Obsidian / Second Brain future-planning preservation
+
+Status:
+
+```text
+merged — PR #182
+```
+
+Result:
+
+```text
+preserved future/brain/second_brain/ vault template and planning docs
+non-authorizing planning content only — no runtime wiring, no Cap 66
+```
+
+### BigPicture / Auralis operating-model future-planning preservation
+
+Status:
+
+```text
+merged — PR #183
+```
+
+Result:
+
+```text
+preserved future/big_picture/ operating-model and direction docs
+non-authorizing planning content only — no runtime behavior changes
+```
+
+### Housekeeping: .codex-worktrees/ gitignore
+
+Status:
+
+```text
+merged — PR #184
+```
+
+Result:
+
+```text
+added .codex-worktrees/ to .gitignore
+no runtime behavior changes
+```
 
 ---
 

--- a/docs/todo/ACTIVE_TODO.md
+++ b/docs/todo/ACTIVE_TODO.md
@@ -63,6 +63,9 @@ PR #177 — Baseline CI blocker cleanup merged.
 PR #178 — Baseline CI blocker cleanup merged.
 PR #179 — Baseline CI blocker cleanup merged.
 PR #180 — Frontend mirror sync baseline fix merged.
+PR #182 — Obsidian / Second Brain future-planning preserved.
+PR #183 — BigPicture / Auralis operating-model future-planning preserved.
+PR #184 — .codex-worktrees/ ignored in .gitignore.
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Add PR #182 (Obsidian/Second Brain planning), PR #183 (BigPicture/Auralis
  operating-model planning), and PR #184 (.codex-worktrees gitignore) to
  merged-truth lists in status and continuity docs.
- Add workstream entries for #182, #183, #184 in CURRENT_WORK_STATUS.md.

## Scope

- Docs-only status sync
- No runtime behavior changes
- No generated runtime doc edits
- No capability changes
- No Cap 66 work
- No second-brain implementation merge
- No approval-gate certification claim
- No website-preview validation claim

## Files changed

- `.agent_context/current_priority.md`
- `docs/status/CURRENT_WORK_STATUS.md`
- `docs/todo/ACTIVE_TODO.md`

## Test plan

- [x] `git diff --check` — no whitespace errors
- [x] `python scripts/check_runtime_doc_drift.py` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)