### PR TITLE
docs: fill approval-gate confirmation capability inventory

### DIFF
--- a/docs/capability_verification/APPROVAL_GATE_CERTIFICATION_MATRIX_2026-05-18.md
+++ b/docs/capability_verification/APPROVAL_GATE_CERTIFICATION_MATRIX_2026-05-18.md
@@ -3,7 +3,7 @@
 Status:
 
 ```text
-planning / verification scaffold only
+inventory filled / verification pending
 not a certification document
 ```
 
@@ -42,13 +42,79 @@ Full approval-gate certification remains pending.
 
 ---
 
+# Capability Inventory Source
+
+Inventory source:
+
+```text
+nova_backend/src/config/registry.json on main at 1b0ab10900ca3ceb2955520a6e658e6d8f674605
+```
+
+Registry rule used:
+
+```text
+requires_confirmation == true
+```
+
+Current confirmation-bound capability inventory:
+
+```text
+Cap 22 — open_file_folder
+Cap 64 — send_email_draft
+```
+
+No other active capability in `registry.json` currently has `requires_confirmation: true`.
+
+---
+
 # Required Certification Matrix
 
-| Capability | Confirmation Required | Pending State Tested | Approve Path Tested | Deny Path Tested | Cancel/Unrelated Input Tested | Ledger Sequence Tested | Live WS Session Tested | Runtime Verified | Certification Status |
+| Capability | Registry Confirmation Required | Pending State Tested | Approve Path Tested | Deny Path Tested | Cancel/Unrelated Input Tested | Ledger Sequence Tested | Live WS Session Tested | Runtime Verified | Certification Status |
 |---|---|---|---|---|---|---|---|---|---|
-| Cap 22 | yes | yes | yes | yes | yes | partial | yes | partial | pending |
-| Cap 64 | yes | yes | yes | yes | yes | partial | yes | partial | pending |
-| Other confirmation-bound capabilities | unknown/incomplete audit | pending | pending | pending | pending | pending | pending | pending | pending |
+| Cap 22 `open_file_folder` | yes | yes — PR #171 / #172 focused coverage | yes — PR #171 / #172 focused coverage | yes — PR #171 / #172 focused coverage | yes — PR #172 focused coverage | partial — focused governed ledger sequence covered | yes — PR #172 focused coverage | partial | pending |
+| Cap 64 `send_email_draft` | yes | yes — PR #171 / #172 focused coverage | yes — PR #171 / #172 focused coverage | yes — PR #171 / #172 focused coverage | yes — PR #172 focused coverage | partial — focused governed ledger sequence covered | yes — PR #172 focused coverage | partial | pending |
+
+---
+
+# Non-Confirmation Active Capabilities
+
+The following active capabilities currently have `requires_confirmation: false` in `registry.json` and are not part of approval-gate certification scope unless registry truth changes:
+
+```text
+16 governed_web_search
+17 open_website
+18 speak_text
+19 volume_up_down
+20 media_play_pause
+21 brightness_control
+31 response_verification
+32 os_diagnostics
+48 multi_source_reporting
+49 headline_summary
+50 intelligence_brief
+51 topic_memory_map
+52 story_tracker_update
+53 story_tracker_view
+54 analysis_document
+55 weather_snapshot
+56 news_snapshot
+57 calendar_snapshot
+58 screen_capture
+59 screen_analysis
+60 explain_anything
+61 memory_governance
+62 external_reasoning_review
+63 openclaw_execute
+65 shopify_intelligence_report
+```
+
+Important note:
+
+```text
+Some non-confirmation capabilities may still be persistent, networked, or externally observable.
+This matrix only tracks approval-gate certification for registry-confirmation-bound capabilities.
+It does not certify the broader governance posture of every active capability.
+```
 
 ---
 
@@ -56,11 +122,13 @@ Full approval-gate certification remains pending.
 
 ## 1. Capability inventory complete
 
-Required:
+Current state:
 
 ```text
-Enumerate every confirmation-bound capability and every execution entry path.
+complete for current registry truth — Cap 22 and Cap 64 only
 ```
+
+Certification remains pending because inventory completion is not proof completion.
 
 ---
 
@@ -75,6 +143,13 @@ no/cancel path does not execute
 unrelated input does not execute
 ```
 
+Current state:
+
+```text
+focused coverage exists for Cap 22 / Cap 64 via PR #171 and PR #172
+broader/full-suite verification pending
+```
+
 ---
 
 ## 3. Ledger proof complete
@@ -84,11 +159,18 @@ Required:
 ```text
 ACTION_ATTEMPTED
 ACTION_COMPLETED
-ACTION_DENIED
-pending-state events
+ACTION_DENIED or equivalent refusal/cancel/no-execution evidence
+pending-state events where implemented
 ```
 
 must appear only in expected governed sequences.
+
+Current state:
+
+```text
+partial focused ledger coverage exists
+full certification-level ledger review pending
+```
 
 ---
 
@@ -98,7 +180,14 @@ Required:
 
 ```text
 WebSocket/session approval flows verified
-frontend state transitions verified
+frontend state transitions verified where applicable
+```
+
+Current state:
+
+```text
+focused WebSocket/session coverage exists for Cap 22 / Cap 64 via PR #172
+broader/full-suite live-session verification pending
 ```
 
 ---
@@ -110,6 +199,14 @@ Required:
 ```text
 must-fail tests for bypass attempts
 executor dispatch forbidden during pending state
+approval cannot be inferred from unrelated text
+```
+
+Current state:
+
+```text
+focused regression coverage exists
+full certification-level bypass matrix pending
 ```
 
 ---
@@ -132,7 +229,8 @@ autonomous workflows
 # Current Safe Interpretation
 
 ```text
-Approval-gate focused coverage exists for tested Cap 22 / Cap 64 paths.
+Approval-gate focused coverage exists for current confirmation-bound Cap 22 / Cap 64 paths.
+The current confirmation-bound capability inventory is filled from registry truth.
 Broader/full-suite approval-gate certification is still pending.
 ```
 

--- a/docs/capability_verification/APPROVAL_GATE_CERTIFICATION_MATRIX_2026-05-18.md
+++ b/docs/capability_verification/APPROVAL_GATE_CERTIFICATION_MATRIX_2026-05-18.md
@@ -63,7 +63,7 @@ Cap 22 — open_file_folder
 Cap 64 — send_email_draft
 ```
 
-No other active capability in `registry.json` currently has `requires_confirmation: true`.
+Based on this registry snapshot, no other active capability has `requires_confirmation: true`.
 
 ---
 


### PR DESCRIPTION
## Summary

Fills the approval-gate confirmation capability inventory using current registry truth.

Docs-only.
No runtime code changes.
No generated runtime doc edits.
No capability lock changes.
No authority expansion.

## Included

- grounded inventory against `nova_backend/src/config/registry.json`
- identified current confirmation-bound capabilities from registry truth
- mapped current focused proof coverage state for Cap 22 / Cap 64
- clarified distinction between inventory completion and certification completion
- clarified distinction between approval-gate certification scope and broader governance posture
- tied inventory wording to a specific registry snapshot

## Current grounded inventory

```text
Cap 22 — open_file_folder
Cap 64 — send_email_draft
```

Based on the audited registry snapshot, no other active capability currently has:

```text
requires_confirmation: true
```

## Explicit non-goals

This PR does not:

- certify the approval gate
- modify runtime behavior
- modify generated runtime truth
- modify capability locks
- expand OpenClaw authority
- authorize browser/computer-use
- authorize autonomous workflows

## Current safe truth

```text
Approval-gate focused coverage exists for current confirmation-bound Cap 22 / Cap 64 paths.
The current confirmation-bound capability inventory is filled from registry truth.
Broader/full-suite approval-gate certification is still pending.
```
