### PR TITLE
docs: add Cap 64 operator journey proof scaffold

### DIFF
--- a/docs/PROOFS/Operator-Journeys/CAP64_EMAIL_DRAFT_OPERATOR_JOURNEY.md
+++ b/docs/PROOFS/Operator-Journeys/CAP64_EMAIL_DRAFT_OPERATOR_JOURNEY.md
@@ -418,8 +418,8 @@ Capture ledger excerpts from the exact proof run.
 Expected evidence source:
 
 ```text
-Trust Panel receipt surface, where available
-http://localhost:8000/api/trust/receipts as direct proof source
+Trust Panel receipt surface, where implemented and available
+http://localhost:8000/api/trust/receipts as direct proof source, if present on the current runtime
 ```
 
 Expected receipt boundary:

--- a/docs/PROOFS/Operator-Journeys/CAP64_EMAIL_DRAFT_OPERATOR_JOURNEY.md
+++ b/docs/PROOFS/Operator-Journeys/CAP64_EMAIL_DRAFT_OPERATOR_JOURNEY.md
@@ -1,0 +1,547 @@
+# Cap 64 Email Draft Operator Journey
+
+Status: proof scaffold / evidence pending / not Cap 64 P5 / not locked.
+
+Simulation source:
+
+```text
+docs/simulations/APPROVAL_GATE_WORKFLOW_SIMULATIONS.md
+```
+
+Live checklist source:
+
+```text
+docs/capability_verification/live_checklists/cap_64_send_email_draft.md
+```
+
+This document records the proof packet required for the Cap 64 email-draft
+operator journey. It does not certify Cap 64, complete P5, lock Cap 64, certify
+the full approval gate, change runtime behavior, or expand authority.
+
+Full approval-gate certification remains pending until broader/full-suite proof
+supports it.
+
+---
+
+## Current Truth
+
+```text
+Capability: Cap 64 - send_email_draft
+Runtime boundary: local mailto draft only
+Manual boundary: the user reviews and sends manually
+Certification status: P1-P4 passed historically / P5 pending / not locked
+Approval-gate status: focused coverage merged / certification pending
+```
+
+Cap 64 must not be described as:
+
+```text
+SMTP email sending
+Gmail sending
+inbox access
+autonomous email
+customer-message automation
+Cap 64 locked
+approval-gate certification complete
+```
+
+---
+
+## Operator-Journey Contract
+
+The Cap 64 journey must make this visible:
+
+```text
+What Nova understood
+What Nova can do
+What requires approval
+What Nova will not do
+What happens if the user says yes
+What happens if the user says no / cancel
+Where the evidence appears
+```
+
+Required preserved boundary:
+
+```text
+Nova drafts and recommends.
+The current authorized user approves.
+Execution stays manual or governed inside approved bounded paths.
+Trust/receipt visibility is non-authorizing.
+Memory and planning context do not grant permission.
+```
+
+---
+
+## Proof Packet Metadata
+
+| Field | Value |
+| --- | --- |
+| Simulation document version | `APPROVAL_GATE_WORKFLOW_SIMULATIONS.md` on main after PR #191 |
+| Proof document status | scaffold / evidence pending |
+| Repo commit SHA | pending capture at proof time |
+| Capability under test | Cap 64 `send_email_draft` |
+| Authority classification | confirmation-required local draft handoff |
+| Runtime code changes | none in this proof doc |
+| Generated runtime doc edits | none |
+| Certification claim | none |
+
+---
+
+## Scenario A: Request Creates Pending State
+
+User request:
+
+```text
+Draft an email to test@example.com saying the meeting moved to 3 PM.
+```
+
+Expected behavior:
+
+```text
+Nova identifies the request as Cap 64 / email draft.
+Nova explains that it can create a local draft only.
+Nova explains that approval is required before opening the draft.
+Nova creates pending confirmation state.
+Nova does not open a mail client while pending.
+Nova does not log ACTION_ATTEMPTED or ACTION_COMPLETED while pending.
+```
+
+Evidence to capture:
+
+```text
+behavioral session test output
+executor non-dispatch assertion
+ledger assertion showing no ACTION_ATTEMPTED / ACTION_COMPLETED while pending
+operator transcript or proof note
+```
+
+Current evidence:
+
+```text
+pending
+```
+
+Remaining gap:
+
+```text
+Capture this path against the current main commit during the proof run.
+```
+
+---
+
+## Scenario B: Yes Resumes Through Governed Invocation
+
+User input:
+
+```text
+yes
+```
+
+Expected behavior:
+
+```text
+Nova resumes the pending Cap 64 action only through governed invocation.
+The governed invocation includes confirmed=True.
+The request remains bounded to local mailto draft behavior.
+The approved path logs the expected governed ledger sequence.
+The user remains responsible for reviewing and sending manually.
+```
+
+Evidence to capture:
+
+```text
+behavioral session test output proving confirmed=True
+Governor ledger sequence
+manual observation that only a local draft was opened
+Trust Panel receipt or receipt API evidence
+```
+
+Current evidence:
+
+```text
+pending
+```
+
+Remaining gap:
+
+```text
+Run the approved-path proof and record ledger/receipt/manual-draft evidence.
+Do not send the draft.
+```
+
+---
+
+## Scenario C: No / Cancel Blocks Execution
+
+User inputs:
+
+```text
+no
+cancel
+```
+
+Expected behavior:
+
+```text
+Nova clears or blocks the pending Cap 64 action.
+Nova does not open a mail client.
+Nova does not dispatch the executor.
+Nova does not log ACTION_ATTEMPTED or ACTION_COMPLETED for the denied action.
+Nova explains that nothing was executed.
+```
+
+Evidence to capture:
+
+```text
+behavioral session test output
+executor non-dispatch assertion
+ledger assertion
+operator transcript or proof note
+```
+
+Current evidence:
+
+```text
+pending
+```
+
+Remaining gap:
+
+```text
+Capture denied and cancelled session paths against the current main commit.
+```
+
+---
+
+## Scenario D: Unrelated Input Does Not Approve
+
+User input:
+
+```text
+What's the weather?
+```
+
+Expected behavior:
+
+```text
+Nova does not treat unrelated input as approval.
+Nova does not execute the pending Cap 64 action.
+Nova either keeps the pending action safely unresolved or cancels/clears it
+according to the current session contract.
+Nova does not log ACTION_ATTEMPTED or ACTION_COMPLETED for the pending action.
+```
+
+Evidence to capture:
+
+```text
+behavioral session test output
+ledger assertion
+operator transcript or proof note
+```
+
+Current evidence:
+
+```text
+pending
+```
+
+Remaining gap:
+
+```text
+Capture unrelated-input behavior and record the current session contract.
+```
+
+---
+
+## Scenario E: Recovery After Interruption
+
+Interruption cases:
+
+```text
+browser refresh
+WebSocket disconnect
+server restart
+session restore where supported
+```
+
+Expected behavior:
+
+```text
+Nova does not execute the pending Cap 64 action during interruption or restore.
+Nova explains the safe current state.
+Nova requires fresh explicit approval before any governed execution can resume.
+Nova does not reuse stale approval.
+```
+
+Evidence to capture:
+
+```text
+session/recovery test output where available
+manual recovery transcript if no automated test path exists
+ledger assertion showing no hidden execution
+```
+
+Current evidence:
+
+```text
+pending
+```
+
+Remaining gap:
+
+```text
+Determine whether an automated recovery test path exists. If not, capture a
+manual transcript and mark the automated gap plainly.
+```
+
+---
+
+## Live Mailto Draft Proof
+
+This proof is separate from automated behavioral session coverage.
+
+Required live preconditions:
+
+```text
+Nova running at http://localhost:8000
+mail client or mailto handler installed and configured
+chat tab open
+test recipient only
+draft closed without sending
+```
+
+Expected live behavior:
+
+```text
+Nova asks for confirmation before opening the draft.
+After yes, the local mail client or mailto handler opens a draft.
+The draft contains the expected recipient and subject/body content.
+The user closes the draft without sending.
+At least one matching receipt is visible through the Trust Panel or
+http://localhost:8000/api/trust/receipts.
+```
+
+Must not happen:
+
+```text
+no SMTP send
+no Gmail API send
+no inbox access
+no autonomous send
+no customer-message automation
+no sent email
+```
+
+Current live evidence:
+
+```text
+pending
+```
+
+Remaining gap:
+
+```text
+Run the live checklist only when explicitly ready for Cap 64 P5 evidence.
+Do not run lock commands from this scaffold.
+```
+
+---
+
+## Required Test Commands
+
+Record exact commands and results here when the proof run happens.
+
+```text
+pending
+```
+
+Candidate focused areas:
+
+```text
+Cap 64 executor tests
+Cap 64 routing tests
+behavioral session approval-gate tests
+approval-gate regression tests
+governor / ledger tests relevant to Cap 64
+```
+
+Do not record:
+
+```text
+full-suite pass
+approval-gate certification
+Cap 64 P5 complete
+Cap 64 locked
+```
+
+unless those exact commands and proof steps actually completed.
+
+---
+
+## Ledger Evidence
+
+Expected pending / denied / unrelated behavior:
+
+```text
+No ACTION_ATTEMPTED
+No ACTION_COMPLETED
+No executor dispatch
+```
+
+Expected approved behavior:
+
+```text
+governed invocation with confirmed=True
+ACTION_ATTEMPTED before execution
+bounded local draft handoff
+ACTION_COMPLETED or documented failure result after executor return
+receipt evidence when draft creation succeeds
+```
+
+Captured ledger excerpt:
+
+```text
+pending
+```
+
+Remaining gap:
+
+```text
+Capture ledger excerpts from the exact proof run.
+```
+
+---
+
+## Receipt / Trust Panel Evidence
+
+Expected evidence source:
+
+```text
+Trust Panel receipt surface, where available
+http://localhost:8000/api/trust/receipts as direct proof source
+```
+
+Expected receipt boundary:
+
+```text
+Receipt visibility is evidence only.
+Trust Panel display does not authorize execution.
+```
+
+Captured receipt excerpt or screenshot reference:
+
+```text
+pending
+```
+
+Remaining gap:
+
+```text
+Capture receipt evidence after an approved live draft proof.
+```
+
+---
+
+## Manual Steps Performed
+
+```text
+pending
+```
+
+Required manual note when live proof is run:
+
+```text
+The draft was opened locally and closed without sending.
+```
+
+---
+
+## Blocked-Path Evidence
+
+The proof must show:
+
+```text
+pending action did not execute
+denied action did not execute
+cancelled action did not execute
+unrelated input did not execute
+ambiguous confirmation did not execute, if tested
+duplicate yes did not double-execute, if tested
+```
+
+Captured blocked-path evidence:
+
+```text
+pending
+```
+
+---
+
+## Remaining Unverified Items
+
+```text
+repo commit SHA for proof run
+focused test command output
+approved governed invocation evidence
+pending non-execution evidence
+denied/cancelled non-execution evidence
+unrelated-input non-execution evidence
+ledger excerpts
+receipt / Trust Panel evidence
+manual mailto draft observation
+recovery behavior evidence
+```
+
+---
+
+## Certification Status
+
+Current status:
+
+```text
+Evidence packet scaffold created.
+Cap 64 P5 remains pending.
+Cap 64 remains not locked.
+Full approval-gate certification remains pending.
+```
+
+Safe wording after this scaffold lands:
+
+```text
+Cap 64 operator-journey proof scaffold added. Evidence capture remains pending.
+```
+
+Do not say:
+
+```text
+Cap 64 P5 complete
+Cap 64 locked
+Cap 64 certified
+approval gate complete
+approval gate fully certified
+all approval-gate paths proven
+```
+
+---
+
+## Next Action
+
+When ready for evidence capture:
+
+```text
+1. Run focused Cap 64 / approval-gate tests.
+2. Capture pending, approved, denied/cancelled, and unrelated-input behavior.
+3. Run the live mailto draft proof without sending email.
+4. Capture ledger and receipt evidence.
+5. Update this document with exact outputs and remaining gaps.
+6. Only then decide whether Cap 64 P5 signoff is supportable.
+```
+
+Final boundary:
+
+```text
+This proof scaffold is not a lock.
+This proof scaffold is not certification.
+The current authorized user remains the approver.
+```


### PR DESCRIPTION
﻿## Summary
- Adds the Cap 64 email draft operator-journey proof scaffold under `docs/PROOFS/Operator-Journeys/`.
- References the merged approval-gate workflow simulation doc and the existing Cap 64 live checklist.
- Defines evidence slots for pending, yes/approved, no/cancel, unrelated input, recovery, ledger, receipt, and manual mailto proof.

## Boundaries
- Docs-only proof scaffold.
- Evidence remains pending.
- No runtime behavior changes.
- No generated runtime doc edits.
- No capability changes or authority expansion.
- No OpenClaw/browser/computer-use/external-write/Shopify-write/email-send/social/finance expansion.
- Does not claim Cap 64 P5, Cap 64 lock, or approval-gate certification.

## Validation
- `git diff --check`
- `python scripts/check_runtime_doc_drift.py`
- Overclaim scan for lock/certification/send terminology; hits are limited to explicit boundary and do-not-say sections.

## Follow-up
- Capture the actual Cap 64 evidence against current main when ready.
- Add `docs/PROOFS/Operator-Journeys/CAP22_OPEN_FILE_FOLDER_OPERATOR_JOURNEY.md` as the next proof scaffold.
