### PR TITLE
docs: sync status after proof-scaffold sequence

### DIFF
--- a/.agent_context/current_priority.md
+++ b/.agent_context/current_priority.md
@@ -71,6 +71,14 @@ PR #180 — Frontend mirror sync baseline fix merged.
 PR #182 — Obsidian / Second Brain future-planning preserved.
 PR #183 — BigPicture / Auralis operating-model future-planning preserved.
 PR #184 — .codex-worktrees/ ignored in .gitignore.
+PR #185 — Post-housekeeping status doc sync merged.
+PR #186 — Four-pass safe cleanup and approval-gate certification scaffold merged.
+PR #187 — Post-PR186 continuity sync merged.
+PR #188 — Approval-gate confirmation capability inventory filled.
+PR #190 — Ecosystem simulation matrix merged.
+PR #191 — Approval gate workflow simulations merged.
+PR #192 — Cap 64 operator journey proof scaffold merged.
+PR #193 — Cap 22 operator journey proof scaffold merged.
 ```
 
 ## Recent closed / not merged truth

--- a/docs/status/CURRENT_WORK_STATUS.md
+++ b/docs/status/CURRENT_WORK_STATUS.md
@@ -366,6 +366,101 @@ preserved certification-pending status
 no runtime authority expansion
 ```
 
+### Post-PR186 continuity sync
+
+Status:
+
+```text
+merged — PR #187
+```
+
+### Approval-gate confirmation capability inventory
+
+Status:
+
+```text
+merged — PR #188
+```
+
+Result:
+
+```text
+filled confirmation-bound capability inventory
+Cap 22 (open_file_folder) and Cap 64 (send_email_draft) identified as
+the two confirmation-required capabilities
+inventory complete does not mean proof complete
+```
+
+### Ecosystem simulation matrix
+
+Status:
+
+```text
+merged — PR #190
+```
+
+Result:
+
+```text
+added docs/simulations/ECOSYSTEM_SIMULATION_MATRIX.md
+corrected BigPicture status path
+narrowed Second Brain Slice 1 to schema/parser/no-mutation health-lint
+no runtime changes
+```
+
+### Approval gate workflow simulations
+
+Status:
+
+```text
+merged — PR #191
+```
+
+Result:
+
+```text
+added docs/simulations/APPROVAL_GATE_WORKFLOW_SIMULATIONS.md
+defines Cap 64 and Cap 22 operator-journey simulation targets
+covers pending / yes / no / cancel / unrelated / timeout / disconnect / recovery
+adds evidence packet template
+no runtime changes
+```
+
+### Cap 64 operator journey proof scaffold
+
+Status:
+
+```text
+merged — PR #192
+```
+
+Result:
+
+```text
+added docs/PROOFS/Operator-Journeys/CAP64_EMAIL_DRAFT_OPERATOR_JOURNEY.md
+scaffold only — evidence capture remains pending
+Cap 64 P5 remains pending / not locked
+no runtime changes
+```
+
+### Cap 22 operator journey proof scaffold
+
+Status:
+
+```text
+merged — PR #193
+```
+
+Result:
+
+```text
+added docs/PROOFS/Operator-Journeys/CAP22_OPEN_FILE_FOLDER_OPERATOR_JOURNEY.md
+scaffold only — evidence capture remains pending
+includes Cap 22-specific path-root boundary proof section
+Cap 22 remains not locked / not globally certified
+no runtime changes
+```
+
 ---
 
 ## Closed / Unmerged Follow-Through

--- a/docs/todo/ACTIVE_TODO.md
+++ b/docs/todo/ACTIVE_TODO.md
@@ -72,6 +72,12 @@ PR #182 — Obsidian / Second Brain future-planning preserved.
 PR #183 — BigPicture / Auralis operating-model future-planning preserved.
 PR #184 — .codex-worktrees/ ignored in .gitignore.
 PR #186 — Four-pass safe cleanup and approval-gate certification scaffold merged.
+PR #187 — Post-PR186 continuity sync merged.
+PR #188 — Approval-gate confirmation capability inventory filled.
+PR #190 — Ecosystem simulation matrix merged.
+PR #191 — Approval gate workflow simulations merged.
+PR #192 — Cap 64 operator journey proof scaffold merged.
+PR #193 — Cap 22 operator journey proof scaffold merged.
 ```
 
 ---
@@ -97,12 +103,24 @@ Status:
 focused coverage merged / full certification pending
 ```
 
-First step:
+Current proof-scaffold status:
 
 ```text
-Use APPROVAL_GATE_CERTIFICATION_MATRIX_2026-05-18.md.
-Complete confirmation-bound capability inventory.
-Fill proof status for every confirmation-bound path.
+Confirmation-bound capability inventory: filled (PR #188).
+Ecosystem simulation matrix: landed (PR #190).
+Approval gate workflow simulations: landed (PR #191).
+Cap 64 operator journey proof scaffold: landed (PR #192).
+Cap 22 operator journey proof scaffold: landed (PR #193).
+Evidence capture for both: pending.
+Cap 64 P5: pending.
+Cap 22 lock: not locked / not globally certified.
+Full approval-gate certification: pending.
+```
+
+Next step:
+
+```text
+Capture evidence against the proof scaffolds.
 Then run broader/full-suite approval-gate verification.
 Only then decide whether the lock can move toward certification/closeout.
 ```


### PR DESCRIPTION
## Summary

- Add PRs #185, #187, #188, #190, #191, #192, #193 to merged-truth
  lists in status and continuity docs.
- Add workstream entries for confirmation inventory (#188), ecosystem
  simulation matrix (#190), workflow simulations (#191), and both
  operator-journey proof scaffolds (#192, #193).
- Update approval-gate follow-up to reflect scaffold availability and
  pending evidence capture.

## Scope

- Docs-only status sync
- No runtime behavior changes
- No generated runtime doc edits
- No capability changes
- No approval-gate certification claim
- Evidence capture remains pending for both scaffolds

## Files changed

- `.agent_context/current_priority.md`
- `docs/status/CURRENT_WORK_STATUS.md`
- `docs/todo/ACTIVE_TODO.md`

## Test plan

- [x] `git diff --check` — no whitespace errors
- [x] `python scripts/check_runtime_doc_drift.py` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)