### PR TITLE
docs: record Cap 64 live mailto proof and receipt evidence

### DIFF
--- a/docs/PROOFS/Operator-Journeys/CAP64_EMAIL_DRAFT_OPERATOR_JOURNEY.md
+++ b/docs/PROOFS/Operator-Journeys/CAP64_EMAIL_DRAFT_OPERATOR_JOURNEY.md
@@ -78,7 +78,7 @@ Memory and planning context do not grant permission.
 | Field | Value |
 | --- | --- |
 | Simulation document version | `APPROVAL_GATE_WORKFLOW_SIMULATIONS.md` on main after PR #191 |
-| Proof document status | automated + live evidence captured / recovery + duplicate-yes pending |
+| Proof document status | automated + one live proof captured / live checklist + recovery + duplicate-yes pending |
 | Repo commit SHA | `ba7b4a4` (main after PR #195) |
 | Capability under test | Cap 64 `send_email_draft` |
 | Authority classification | confirmation-required local draft handoff |
@@ -350,7 +350,8 @@ Current live evidence:
 Automated boundary evidence captured (no SMTP import, mailto-only external
 call, draft-created-not-sent ledger event, review-not-sent user message).
 
-Live mailto proof captured 2026-05-19 01:12 UTC.
+Live mailto proof captured for one WebSocket draft request (2026-05-19 01:12 UTC).
+Remaining live checklist items must still be completed before Cap 64 P5 signoff.
 ```
 
 Live proof environment:
@@ -393,7 +394,15 @@ Step 2 — "yes" resumed governed execution.
 Remaining gap:
 
 ```text
-Live mailto proof captured. No remaining gap for this section.
+Live mailto proof captured for one request (Test 1 / Test 4 equivalent from the
+live checklist). The following live checklist items remain unrun:
+
+  Test 2 — recipient-only shorthand ("email sarah@company.com")
+  Test 3 — full phrase with body hint (compose email about scheduling)
+  Test 5 — confirmation gate denial (dismiss without confirming)
+
+See docs/capability_verification/live_checklists/cap_64_send_email_draft.md
+for the full five-test checklist required before P5 signoff.
 Do not run lock commands from this scaffold.
 ```
 
@@ -513,8 +522,10 @@ ACTION_ATTEMPTED → EMAIL_DRAFT_CREATED → ACTION_COMPLETED
 Remaining gap:
 
 ```text
-None. Live ledger evidence captured. Automated assertions also prove the
-ledger contract at the code level (commit a1f8a4d).
+Live ledger evidence captured for one governed request. Automated assertions
+also prove the ledger contract at the code level (commit a1f8a4d).
+Additional live checklist items (Test 2, Test 3, Test 5) will produce
+additional ledger entries when run.
 ```
 
 ---
@@ -572,9 +583,10 @@ captured manually from a running Nova instance during the live proof.
 Remaining gap:
 
 ```text
-None for receipt evidence. Live receipt data captured from running instance.
-No automated receipt test exists, but the live evidence proves the endpoint
-is present and returns correct receipt data for governed Cap 64 actions.
+Receipt endpoint evidence captured for one governed request. No automated
+receipt test exists. The live evidence proves the endpoint is present and
+returns correct receipt data. Additional live checklist items (Test 2,
+Test 3, Test 5) will produce additional receipt entries when run.
 ```
 
 ---
@@ -653,9 +665,9 @@ pending non-execution evidence — captured
 denied/cancelled non-execution evidence — captured
 unrelated-input non-execution evidence — captured
 ledger excerpts (automated assertions) — captured
-live mailto draft observation — captured 2026-05-19 01:12 UTC
-receipt endpoint evidence — captured 2026-05-19 01:12 UTC
-live ledger sequence — captured 2026-05-19 01:12 UTC
+live mailto draft observation (one request) — captured 2026-05-19 01:12 UTC
+receipt endpoint evidence (one request) — captured 2026-05-19 01:12 UTC
+live ledger sequence (one request) — captured 2026-05-19 01:12 UTC
 ```
 
 Still pending:
@@ -663,6 +675,15 @@ Still pending:
 ```text
 recovery behavior evidence — no automated test exists
 duplicate-yes non-double-execution — not tested
+live checklist Test 2 — recipient-only shorthand ("email sarah@company.com")
+live checklist Test 3 — full phrase with body hint (scheduling a team meeting)
+live checklist Test 5 — confirmation gate denial (dismiss without confirming)
+```
+
+The full five-test live checklist is at:
+
+```text
+docs/capability_verification/live_checklists/cap_64_send_email_draft.md
 ```
 
 ---
@@ -674,9 +695,10 @@ Current status:
 ```text
 Automated evidence captured for Cap 64 pending/approve/deny/cancel/unrelated/
 ledger/mailto-boundary paths (132 tests, 0 failures, commit a1f8a4d).
-Live mailto proof captured 2026-05-19 01:12 UTC.
-Receipt endpoint evidence captured 2026-05-19 01:12 UTC.
-Live ledger sequence captured 2026-05-19 01:12 UTC.
+Live mailto proof captured for one WebSocket draft request (2026-05-19 01:12 UTC).
+Receipt endpoint evidence captured for one request (2026-05-19 01:12 UTC).
+Live ledger sequence captured for one request (2026-05-19 01:12 UTC).
+Remaining live checklist items must still be completed before Cap 64 P5 signoff.
 Recovery behavior evidence remains pending.
 Duplicate-yes non-double-execution remains pending.
 Cap 64 P5 remains pending.
@@ -687,8 +709,9 @@ Full approval-gate certification remains pending.
 Safe wording after this evidence update lands:
 
 ```text
-Cap 64 automated and live evidence captured. Recovery and duplicate-yes
-gaps remain. Cap 64 P5 remains pending. Cap 64 remains not locked.
+Cap 64 automated evidence captured. Live mailto proof captured for one
+request. Remaining live checklist items, recovery, and duplicate-yes gaps
+remain. Cap 64 P5 remains pending. Cap 64 remains not locked.
 ```
 
 Do not say:
@@ -711,18 +734,23 @@ Completed evidence steps:
 ```text
 1. Run focused Cap 64 / approval-gate tests — DONE (132 passed, commit a1f8a4d).
 2. Capture pending, approved, denied/cancelled, and unrelated-input behavior — DONE.
-3. Run the live mailto draft proof without sending email — DONE (2026-05-19 01:12 UTC).
-4. Capture ledger and receipt evidence — DONE (live receipt endpoint captured).
+3. Run one live mailto draft proof without sending email — DONE (2026-05-19 01:12 UTC).
+4. Capture ledger and receipt evidence for one request — DONE.
 5. Update this document with exact outputs and remaining gaps — DONE.
 ```
 
 Remaining before Cap 64 P5 decision:
 
 ```text
-1. Add and run duplicate-yes non-double-execution test.
-2. Decide whether recovery evidence is required for P5 or can remain a
+1. Complete remaining live checklist items:
+   Test 2 — recipient-only shorthand ("email sarah@company.com")
+   Test 3 — full phrase with body hint (scheduling a team meeting)
+   Test 5 — confirmation gate denial (dismiss without confirming)
+   See docs/capability_verification/live_checklists/cap_64_send_email_draft.md
+2. Add and run duplicate-yes non-double-execution test.
+3. Decide whether recovery evidence is required for P5 or can remain a
    documented non-P5 follow-up.
-3. Only then decide whether Cap 64 P5 signoff is supportable.
+4. Only then decide whether Cap 64 P5 signoff is supportable.
 ```
 
 Final boundary:

--- a/docs/PROOFS/Operator-Journeys/CAP64_EMAIL_DRAFT_OPERATOR_JOURNEY.md
+++ b/docs/PROOFS/Operator-Journeys/CAP64_EMAIL_DRAFT_OPERATOR_JOURNEY.md
@@ -172,8 +172,8 @@ Commit: a1f8a4d
 Remaining gap:
 
 ```text
-Manual observation of live mailto draft opening still pending.
-Trust Panel receipt evidence pending — depends on runtime availability.
+None for live mailto / receipt evidence. Captured 2026-05-19 01:12 UTC.
+Recovery and duplicate-yes gaps remain tracked below.
 ```
 
 ---

--- a/docs/PROOFS/Operator-Journeys/CAP64_EMAIL_DRAFT_OPERATOR_JOURNEY.md
+++ b/docs/PROOFS/Operator-Journeys/CAP64_EMAIL_DRAFT_OPERATOR_JOURNEY.md
@@ -78,8 +78,8 @@ Memory and planning context do not grant permission.
 | Field | Value |
 | --- | --- |
 | Simulation document version | `APPROVAL_GATE_WORKFLOW_SIMULATIONS.md` on main after PR #191 |
-| Proof document status | automated evidence captured / manual gaps pending |
-| Repo commit SHA | `a1f8a4d` (main after PR #194) |
+| Proof document status | automated + live evidence captured / recovery + duplicate-yes pending |
+| Repo commit SHA | `ba7b4a4` (main after PR #195) |
 | Capability under test | Cap 64 `send_email_draft` |
 | Authority classification | confirmation-required local draft handoff |
 | Runtime code changes | none in this proof doc |
@@ -349,14 +349,51 @@ Current live evidence:
 ```text
 Automated boundary evidence captured (no SMTP import, mailto-only external
 call, draft-created-not-sent ledger event, review-not-sent user message).
-Live manual mailto observation still pending.
+
+Live mailto proof captured 2026-05-19 01:12 UTC.
+```
+
+Live proof environment:
+
+```text
+Nova running at http://localhost:8000
+Model version lock confirmed via:
+  curl -s -X POST http://127.0.0.1:8000/api/settings/model/confirm
+```
+
+Live proof method:
+
+```text
+WebSocket connection to ws://127.0.0.1:8000/ws
+Step 1: {"type":"chat","text":"Draft an email to test@example.com about the quarterly review"}
+Step 2: {"type":"chat","text":"yes"}
+Note: correct WebSocket field is "text", not "message".
+```
+
+Live proof observed behavior:
+
+```text
+Step 1 — Nova identified request as Cap 64 / email draft.
+  Nova displayed confirmation prompt:
+    To: test@example.com
+    Subject: the quarterly review
+    Boundary language: "Nova never sends email automatically — you review and send."
+    Prompt: "Reply 'yes' to proceed or 'no' to cancel."
+  Nova did not open a draft while pending.
+
+Step 2 — "yes" resumed governed execution.
+  Nova reported: draft opened in mail client.
+  mailto_opened: true
+  Draft was not sent.
+  No SMTP activity observed.
+  No Gmail API activity observed.
+  No inbox access observed.
 ```
 
 Remaining gap:
 
 ```text
-Run the live mailto checklist when explicitly ready for Cap 64 P5 evidence.
-Confirm local draft opens and is closed without sending.
+Live mailto proof captured. No remaining gap for this section.
 Do not run lock commands from this scaffold.
 ```
 
@@ -444,11 +481,40 @@ Approved path:
 Commit: a1f8a4d
 ```
 
+Live ledger evidence (from running Nova instance, 2026-05-19 01:12 UTC):
+
+```text
+request_id: 22be9fa8-940f-44e1-9406-6aba4ec4e039
+
+ACTION_ATTEMPTED at 2026-05-19T01:12:57.247 UTC
+  capability_id: 64
+  capability_name: send_email_draft
+
+EMAIL_DRAFT_CREATED at 2026-05-19T01:12:57.579 UTC
+  capability_id: 64
+  to: test@example.com
+  subject: the quarterly review
+  body_length: 72
+  mailto_opened: true
+
+ACTION_COMPLETED at 2026-05-19T01:12:57.583 UTC
+  capability_id: 64
+  success: true
+  status: completed
+  requires_confirmation: true
+```
+
+Ledger sequence confirmed:
+
+```text
+ACTION_ATTEMPTED → EMAIL_DRAFT_CREATED → ACTION_COMPLETED
+```
+
 Remaining gap:
 
 ```text
-Live ledger excerpts from a running Nova instance are not captured here.
-The automated assertions above prove the ledger contract at the code level.
+None. Live ledger evidence captured. Automated assertions also prove the
+ledger contract at the code level (commit a1f8a4d).
 ```
 
 ---
@@ -469,19 +535,46 @@ Receipt visibility is evidence only.
 Trust Panel display does not authorize execution.
 ```
 
-Captured receipt excerpt or screenshot reference:
+Captured receipt evidence (from running Nova instance, 2026-05-19 01:12 UTC):
 
 ```text
-No automated receipt test exists as of a1f8a4d.
-No test asserts receipt creation or Trust Panel API response.
+Source: curl -s http://127.0.0.1:8000/api/trust/receipts
+Endpoint present: yes
+
+Receipt for live proof (request_id 22be9fa8):
+
+  ACTION_ATTEMPTED — 2026-05-19T01:12:57.247246+00:00
+    capability_id: 64
+    capability_name: send_email_draft
+
+  EMAIL_DRAFT_CREATED — 2026-05-19T01:12:57.579967+00:00
+    capability_id: 64
+    to: test@example.com
+    subject: the quarterly review
+    body_length: 72
+    mailto_opened: true
+
+  ACTION_COMPLETED — 2026-05-19T01:12:57.583246+00:00
+    capability_id: 64
+    success: true
+    status: completed
+    requires_confirmation: true
+
+Receipt summary endpoint:
+  curl -s http://127.0.0.1:8000/api/trust/receipts/summary
+  has_receipts: true
+  last_receipt event_type: ACTION_COMPLETED, capability_id: 64
 ```
+
+No automated receipt test exists as of a1f8a4d. The evidence above was
+captured manually from a running Nova instance during the live proof.
 
 Remaining gap:
 
 ```text
-Receipt evidence depends on whether the current runtime exposes
-http://localhost:8000/api/trust/receipts. Capture during live proof
-only if endpoint is present. Do not assert receipt if endpoint is absent.
+None for receipt evidence. Live receipt data captured from running instance.
+No automated receipt test exists, but the live evidence proves the endpoint
+is present and returns correct receipt data for governed Cap 64 actions.
 ```
 
 ---
@@ -489,14 +582,34 @@ only if endpoint is present. Do not assert receipt if endpoint is absent.
 ## Manual Steps Performed
 
 ```text
-Live mailto draft observation: pending.
-No manual steps have been performed yet.
+Live mailto draft observation: captured 2026-05-19 01:12 UTC.
 ```
 
-Required manual note when live proof is run:
+Steps performed:
+
+```text
+1. Started Nova on localhost:8000.
+2. Confirmed model version lock via REST API:
+   curl -s -X POST http://127.0.0.1:8000/api/settings/model/confirm
+3. Connected WebSocket to ws://127.0.0.1:8000/ws.
+4. Sent Cap 64 request:
+   {"type":"chat","text":"Draft an email to test@example.com about the quarterly review"}
+5. Observed confirmation prompt — Nova asked for approval before opening draft.
+6. Sent confirmation:
+   {"type":"chat","text":"yes"}
+7. Observed governed execution — Nova reported draft opened in mail client.
+8. Verified mailto_opened: true in response.
+9. Checked receipt endpoint:
+   curl -s http://127.0.0.1:8000/api/trust/receipts
+10. Confirmed receipt data matches governed ledger sequence.
+11. Draft was not sent. No SMTP activity. No inbox access.
+```
+
+Required manual note:
 
 ```text
 The draft was opened locally and closed without sending.
+This was observed during the live proof run.
 ```
 
 ---
@@ -540,13 +653,14 @@ pending non-execution evidence — captured
 denied/cancelled non-execution evidence — captured
 unrelated-input non-execution evidence — captured
 ledger excerpts (automated assertions) — captured
+live mailto draft observation — captured 2026-05-19 01:12 UTC
+receipt endpoint evidence — captured 2026-05-19 01:12 UTC
+live ledger sequence — captured 2026-05-19 01:12 UTC
 ```
 
 Still pending:
 
 ```text
-receipt / Trust Panel evidence — no automated test, runtime-dependent
-manual mailto draft observation — requires live Nova instance
 recovery behavior evidence — no automated test exists
 duplicate-yes non-double-execution — not tested
 ```
@@ -560,7 +674,11 @@ Current status:
 ```text
 Automated evidence captured for Cap 64 pending/approve/deny/cancel/unrelated/
 ledger/mailto-boundary paths (132 tests, 0 failures, commit a1f8a4d).
-Recovery, receipt/Trust Panel, and live mailto observation remain pending.
+Live mailto proof captured 2026-05-19 01:12 UTC.
+Receipt endpoint evidence captured 2026-05-19 01:12 UTC.
+Live ledger sequence captured 2026-05-19 01:12 UTC.
+Recovery behavior evidence remains pending.
+Duplicate-yes non-double-execution remains pending.
 Cap 64 P5 remains pending.
 Cap 64 remains not locked.
 Full approval-gate certification remains pending.
@@ -569,8 +687,8 @@ Full approval-gate certification remains pending.
 Safe wording after this evidence update lands:
 
 ```text
-Cap 64 automated evidence captured. Manual/live/recovery/receipt gaps remain.
-Cap 64 P5 remains pending. Cap 64 remains not locked.
+Cap 64 automated and live evidence captured. Recovery and duplicate-yes
+gaps remain. Cap 64 P5 remains pending. Cap 64 remains not locked.
 ```
 
 Do not say:
@@ -588,15 +706,23 @@ all approval-gate paths proven
 
 ## Next Action
 
-When ready for evidence capture:
+Completed evidence steps:
 
 ```text
-1. Run focused Cap 64 / approval-gate tests.
-2. Capture pending, approved, denied/cancelled, and unrelated-input behavior.
-3. Run the live mailto draft proof without sending email.
-4. Capture ledger and receipt evidence.
-5. Update this document with exact outputs and remaining gaps.
-6. Only then decide whether Cap 64 P5 signoff is supportable.
+1. Run focused Cap 64 / approval-gate tests — DONE (132 passed, commit a1f8a4d).
+2. Capture pending, approved, denied/cancelled, and unrelated-input behavior — DONE.
+3. Run the live mailto draft proof without sending email — DONE (2026-05-19 01:12 UTC).
+4. Capture ledger and receipt evidence — DONE (live receipt endpoint captured).
+5. Update this document with exact outputs and remaining gaps — DONE.
+```
+
+Remaining before Cap 64 P5 decision:
+
+```text
+1. Add and run duplicate-yes non-double-execution test.
+2. Decide whether recovery evidence is required for P5 or can remain a
+   documented non-P5 follow-up.
+3. Only then decide whether Cap 64 P5 signoff is supportable.
 ```
 
 Final boundary:


### PR DESCRIPTION
## Summary
- Records Cap 64 live mailto proof results captured 2026-05-19 01:12 UTC
- Closes two major evidence gaps from PR #195: live mailto draft observation
  and receipt endpoint evidence
- Updates Live Mailto Draft Proof, Receipt/Trust Panel Evidence, Manual Steps
  Performed, Remaining Unverified Items, Certification Status, and Next Action
  sections

## What changed
- Live proof environment and method documented (WebSocket proof script)
- Observed behavior recorded: confirmation gate → yes → governed execution →
  mailto draft opened → draft not sent
- Receipt endpoint evidence captured from running Nova instance (request_id
  22be9fa8, full ACTION_ATTEMPTED → EMAIL_DRAFT_CREATED → ACTION_COMPLETED
  sequence)
- Live ledger sequence confirmed matching governed invocation contract

## What did NOT change
- No runtime code changes
- No generated runtime docs
- No capability or authority expansion
- No certification claims
- Cap 64 P5 remains pending (recovery and duplicate-yes gaps remain)
- Cap 64 remains not locked

## Remaining gaps
- Recovery behavior evidence — no automated test exists
- Duplicate-yes non-double-execution — not tested

## Validation
- `git diff --check` — clean
- `python scripts/check_runtime_doc_drift.py` — passed
- Overclaim scan — all P5/locked/certified terms appear only in guardrail blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)