### PR TITLE
Mitigate Ollama wait serialization

### DIFF
--- a/nova_backend/src/llm/model_network_mediator.py
+++ b/nova_backend/src/llm/model_network_mediator.py
@@ -37,8 +37,23 @@ class ModelNetworkMediator:
         self._ledger = LedgerWriter()
         self._request_times: list[float] = []
         self._session = requests.Session()
+        self._default_session = self._session
+        self._thread_local = threading.local()
         self._rate_lock = threading.Lock()
         self._session_lock = threading.Lock()
+
+    def _request_session(self):
+        if self._session is not self._default_session:
+            return self._session
+        session = getattr(self._thread_local, "session", None)
+        if session is not None:
+            return session
+        with self._session_lock:
+            session = getattr(self._thread_local, "session", None)
+            if session is None:
+                session = requests.Session()
+                self._thread_local.session = session
+            return session
 
     def _validate_url(self, url: str) -> None:
         parsed = urlparse(url)
@@ -94,13 +109,12 @@ class ModelNetworkMediator:
             correlation["session_id"] = session_id
 
         try:
-            with self._session_lock:
-                response = self._session.request(
-                    method=method.upper(),
-                    url=url,
-                    json=json_payload,
-                    timeout=timeout,
-                )
+            response = self._request_session().request(
+                method=method.upper(),
+                url=url,
+                json=json_payload,
+                timeout=timeout,
+            )
             response.raise_for_status()
             payload = response.json() if response.content else {}
         except Exception as error:

--- a/nova_backend/src/websocket/session_handler.py
+++ b/nova_backend/src/websocket/session_handler.py
@@ -3998,6 +3998,17 @@ async def run_websocket_session(ws: WebSocket, deps: Any) -> None:
                 continue
 
             # --- Bounded advisory general-chat fallback ---
+            if not silent_widget_refresh:
+                await ws_send(
+                    ws,
+                    {
+                        "type": "status",
+                        "status": "thinking",
+                        "message": "Thinking...",
+                        "phase": "llm_inference",
+                        "turn_id": incoming_turn_id,
+                    },
+                )
             skill_result = await run_general_chat_fallback(
                 mediated_text,
                 general_chat_skill=general_chat_skill,

--- a/nova_backend/tests/governance/test_model_network_mediator_concurrency.py
+++ b/nova_backend/tests/governance/test_model_network_mediator_concurrency.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import threading
+import time
+from types import SimpleNamespace
+
+
+def test_model_network_mediator_allows_overlapping_request_waits():
+    from src.llm.model_network_mediator import ModelNetworkMediator
+
+    class _Response:
+        status_code = 200
+        content = b'{"ok": true}'
+
+        @staticmethod
+        def json() -> dict:
+            return {"ok": True}
+
+        @staticmethod
+        def raise_for_status() -> None:
+            return None
+
+    class _SlowSession:
+        def request(self, **_kwargs):
+            time.sleep(0.15)
+            return _Response()
+
+    mediator = ModelNetworkMediator()
+    mediator._ledger = SimpleNamespace(log_event=lambda *_args, **_kwargs: None)
+    mediator._session = _SlowSession()
+
+    started_at = time.perf_counter()
+    threads = [
+        threading.Thread(
+            target=mediator.request_json,
+            kwargs={
+                "method": "POST",
+                "url": "http://localhost:11434/api/chat",
+                "json_payload": {"ping": "pong"},
+                "timeout": 2.0,
+            },
+        )
+        for _ in range(2)
+    ]
+
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=1.0)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert time.perf_counter() - started_at < 0.27


### PR DESCRIPTION
## Summary
- Keep Ollama /api/chat non-streaming, but remove Nova-side request serialization by using per-thread model HTTP sessions.
- Preserve explicit locks for mediator shared state and lazy session setup.
- Emit a lightweight WebSocket status frame (thinking / llm_inference) before the advisory LLM fallback begins.
- Add a regression test proving overlapping model request waits are not serialized by the mediator.

## Findings
- OLLAMA_TIMEOUT defaults to 300 seconds in nova_backend/src/nova_config.py.
- Deep analysis uses ANALYSIS_TIMEOUT_SECONDS = 90.0 via DeepSeekBridge.
- Ollama calls are centralized through llm_gateway -> llm_manager -> ModelNetworkMediator.
- /api/chat requests remain stream: False; streaming is left as a future design choice because it would affect response assembly and client contracts.

## Boundaries
- No capability expansion.
- No authority changes.
- No approval-gate certification changes.
- capability_locks.json untouched.

## Tests
- python -m pytest nova_backend/tests/governance/test_model_network_mediator_thread_safety.py nova_backend/tests/governance/test_model_network_mediator_concurrency.py nova_backend/tests/test_network_model_speech_correlation.py nova_backend/tests/test_llm_manager_version_lock.py
- python -m pytest nova_backend/tests/websocket/test_session_layer_pipeline.py nova_backend/tests/phase45/test_brain_server_basic_conversation.py -q
- python -m pytest nova_backend/tests/governance/test_model_network_mediator_concurrency.py nova_backend/tests/governance/test_model_network_mediator_thread_safety.py -q
- git diff --check