### PR TITLE
feat: streaming LLM fallback for advisory general-chat path

### DIFF
--- a/nova_backend/src/conversation/general_chat_runtime.py
+++ b/nova_backend/src/conversation/general_chat_runtime.py
@@ -173,6 +173,7 @@ async def run_general_chat_fallback(
     session_context: list[dict[str, Any]],
     project_threads: ProjectThreadStore,
     select_relevant_memory_context: Callable[..., list[dict[str, Any]]],
+    on_chunk: Callable[[str], None] | None = None,
 ) -> Optional[SkillResult]:
     normalized_query = str(query or "").strip()
     if not normalized_query or not general_chat_skill.can_handle(normalized_query):
@@ -269,7 +270,7 @@ async def run_general_chat_fallback(
         block for block in (request_block, task_preview.prompt_block) if block
     )
 
-    result = await general_chat_skill.handle(normalized_query, chat_context, skill_state)
+    result = await general_chat_skill.handle(normalized_query, chat_context, skill_state, on_chunk=on_chunk)
     if result is not None and isinstance(result.data, dict):
         review_card_payload = skill_state.get("request_understanding_review_card")
         if isinstance(review_card_payload, dict):

--- a/nova_backend/src/llm/llm_gateway.py
+++ b/nova_backend/src/llm/llm_gateway.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Callable, Generator
 
 from src.llm.llm_manager import llm_manager
 
@@ -35,8 +36,13 @@ def generate_chat(
     max_tokens: int = 400,
     temperature: float = 0.3,
     timeout: float | None = None,
+    on_chunk: Callable[[str], None] | None = None,
 ) -> str | None:
-    """Centralized non-authorizing local model gateway (text in, text out)."""
+    """Centralized non-authorizing local model gateway (text in, text out).
+
+    If *on_chunk* is provided, streams tokens through the callback
+    for early UX delivery while still returning the complete text.
+    """
     del mode, safety_profile
 
     try:
@@ -48,9 +54,44 @@ def generate_chat(
             timeout=timeout,
             request_id=request_id,
             session_id=session_id,
+            on_chunk=on_chunk,
         )
     except Exception as error:
         logger.error("LLM gateway call failed: %s", error)
         return None
 
     return (response_text or "").strip() or None
+
+
+def generate_chat_stream(
+    prompt: str,
+    *,
+    mode: str,
+    safety_profile: str,
+    request_id: str,
+    session_id: str | None = None,
+    system_prompt: str | None = None,
+    max_tokens: int = 400,
+    temperature: float = 0.3,
+    timeout: float | None = None,
+) -> Generator[str, None, None]:
+    """Streaming variant of generate_chat for advisory LLM fallback.
+
+    Yields text chunks as they arrive from Ollama. Non-authorizing:
+    same gateway boundary as generate_chat.
+    """
+    del mode, safety_profile
+
+    try:
+        yield from llm_manager.generate_stream(
+            prompt,
+            system_prompt=system_prompt or "",
+            temperature=temperature,
+            max_tokens=max_tokens,
+            timeout=timeout,
+            request_id=request_id,
+            session_id=session_id,
+        )
+    except Exception as error:
+        logger.error("LLM gateway stream call failed: %s", error)
+        return

--- a/nova_backend/src/llm/llm_manager.py
+++ b/nova_backend/src/llm/llm_manager.py
@@ -5,7 +5,7 @@ import json
 import logging
 import time
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Generator, Optional
 
 from src.governor.exceptions import LedgerWriteFailed
 from src.ledger.writer import LedgerWriter
@@ -290,10 +290,17 @@ class LLMManager:
         timeout: Optional[float] = None,
         request_id: Optional[str] = None,
         session_id: Optional[str] = None,
+        on_chunk: Optional[Callable[[str], None]] = None,
     ) -> Optional[str]:
         """
         Send prompt to LLM and return plain text.
         Honors circuit breaker and model version lock.
+
+        If *on_chunk* is provided, uses streaming mode and calls
+        on_chunk(text_fragment) for each token as it arrives from
+        Ollama. The complete assembled text is still returned.
+        This is purely a UX callback -- it does not change the
+        return value or any governance behavior.
         """
         if self.inference_blocked:
             logger.error("Generate called while model is blocked.")
@@ -319,6 +326,38 @@ class LLMManager:
         if system:
             messages.append({"role": "system", "content": system})
         messages.append({"role": "user", "content": prompt})
+
+        # Streaming path: use request_stream and call on_chunk for
+        # each token. Assembles and returns the full text identically
+        # to the non-streaming path.
+        if on_chunk is not None:
+            try:
+                parts: list[str] = []
+                for chunk in self._network.request_stream(
+                    url=f"{self.base_url.rstrip('/')}/api/chat",
+                    json_payload={
+                        "model": self.active_model,
+                        "messages": messages,
+                        "stream": True,
+                        "options": options,
+                    },
+                    timeout=request_timeout,
+                    request_id=request_id,
+                    session_id=session_id,
+                ):
+                    parts.append(chunk)
+                    try:
+                        on_chunk(chunk)
+                    except Exception:
+                        pass  # UX callback must not break inference
+                result = "".join(parts).strip() or None
+                self.failure_count = 0
+                return result
+            except ModelNetworkMediatorError as error:
+                logger.error("Streaming model call failed: %s", error)
+                # Fall through to non-streaming fallback below
+            except Exception as error:
+                logger.error("Streaming LLM error: %s", error)
 
         try:
             response = self._network.request_json(
@@ -381,6 +420,67 @@ class LLMManager:
             self._record_failure()
 
         return None
+
+    def generate_stream(
+        self,
+        prompt: str,
+        system_prompt: str = "",
+        *,
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        timeout: Optional[float] = None,
+        request_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+    ) -> Generator[str, None, None]:
+        """Stream text chunks from Ollama for advisory LLM fallback.
+
+        Same circuit-breaker, fallback-model, and failure-recording logic
+        as generate(). Yields text fragments as they arrive. The caller
+        is responsible for assembling the final response.
+        """
+        if self.inference_blocked:
+            logger.error("generate_stream called while model is blocked.")
+            return
+
+        now = time.time()
+        if now < self.circuit_open_until:
+            logger.warning("Circuit breaker open. Skipping stream request.")
+            return
+
+        system = system_prompt or self.system_prompt
+        options = dict(self.default_options)
+        if temperature is not None:
+            options["temperature"] = float(temperature)
+        if max_tokens is not None:
+            options["num_predict"] = int(max_tokens)
+        request_timeout = float(timeout) if timeout is not None else float(self.timeout)
+
+        messages: list[dict[str, str]] = []
+        if system:
+            messages.append({"role": "system", "content": system})
+        messages.append({"role": "user", "content": prompt})
+
+        try:
+            for chunk in self._network.request_stream(
+                url=f"{self.base_url.rstrip('/')}/api/chat",
+                json_payload={
+                    "model": self.active_model,
+                    "messages": messages,
+                    "stream": True,
+                    "options": options,
+                },
+                timeout=request_timeout,
+                request_id=request_id,
+                session_id=session_id,
+            ):
+                yield chunk
+            self.failure_count = 0
+        except ModelNetworkMediatorError as error:
+            logger.error("Streaming model call failed: %s", error)
+            self._record_failure()
+        except Exception as error:
+            logger.error("Streaming LLM error: %s", error)
+            self._record_failure()
 
     def health_check(self) -> bool:
         """Verify Ollama is running and the model is available."""

--- a/nova_backend/src/llm/model_network_mediator.py
+++ b/nova_backend/src/llm/model_network_mediator.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import ipaddress
+import json
 import socket
 import threading
 from dataclasses import dataclass
 from time import time
+from typing import Generator
 from urllib.parse import urlparse
 
 import requests
@@ -139,3 +141,73 @@ class ModelNetworkMediator:
             },
         )
         return ModelResponse(status_code=response.status_code, data=payload if isinstance(payload, dict) else {})
+
+    def request_stream(
+        self,
+        *,
+        url: str,
+        json_payload: dict,
+        timeout: float = 30.0,
+        request_id: str | None = None,
+        session_id: str | None = None,
+    ) -> Generator[str, None, None]:
+        """Stream text chunks from a local model endpoint.
+
+        Same validation, rate-limiting, and ledger discipline as
+        request_json. Yields decoded text fragments from Ollama's
+        streaming JSON-lines format. Logs a single MODEL_NETWORK_CALL
+        on completion (not per-chunk).
+        """
+        self._check_rate_limit()
+        self._validate_url(url)
+        correlation: dict[str, str] = {}
+        if request_id:
+            correlation["request_id"] = request_id
+        if session_id:
+            correlation["session_id"] = session_id
+
+        try:
+            response = self._request_session().post(
+                url,
+                json=json_payload,
+                timeout=timeout,
+                stream=True,
+            )
+            response.raise_for_status()
+        except Exception as error:
+            self._ledger.log_event(
+                "MODEL_NETWORK_CALL_FAILED",
+                {"url": url, "method": "POST", "error": str(error),
+                 **correlation},
+            )
+            raise ModelNetworkMediatorError(str(error)) from error
+
+        try:
+            for raw_line in response.iter_lines(decode_unicode=True):
+                if not raw_line:
+                    continue
+                try:
+                    chunk = json.loads(raw_line)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                text = (chunk.get("message") or {}).get("content") or ""
+                if text:
+                    yield text
+        except Exception as error:
+            self._ledger.log_event(
+                "MODEL_NETWORK_CALL_FAILED",
+                {"url": url, "method": "POST",
+                 "error": f"stream read: {error}", **correlation},
+            )
+            raise ModelNetworkMediatorError(
+                f"stream read: {error}"
+            ) from error
+        finally:
+            response.close()
+
+        self._ledger.log_event(
+            "MODEL_NETWORK_CALL",
+            {"url": url, "method": "POST",
+             "status_code": response.status_code, "streamed": True,
+             **correlation},
+        )

--- a/nova_backend/src/skills/general_chat.py
+++ b/nova_backend/src/skills/general_chat.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import asyncio
 import re
 from dataclasses import dataclass, field
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple
 
 from src.conversation.complexity_heuristics import ComplexityHeuristics
 from src.conversation.deepseek_bridge import DeepSeekBridge
@@ -1639,6 +1639,7 @@ class GeneralChatSkill(BaseSkill):
         *,
         context: Optional[list] = None,
         session_state: Optional[dict] = None,
+        on_chunk: Optional[Callable] = None,
     ) -> SkillResult | None:
         social = self._local_social_result(query)
         if social is not None:
@@ -1695,6 +1696,7 @@ class GeneralChatSkill(BaseSkill):
                 system_prompt=system_prompt,
                 max_tokens=max_tokens,
                 temperature=0.7 if mode == "casual" else 0.5,
+                on_chunk=on_chunk,
             )
             text = self._sanitize_response(text or "")
             fallback = self._local_conceptual_fallback(normalized_query, session_state)
@@ -1877,14 +1879,20 @@ class GeneralChatSkill(BaseSkill):
         except Exception:
             pass
 
-    async def handle(self, query: str, context: Optional[list] = None, session_state: Optional[dict] = None) -> SkillResult | None:
+    async def handle(
+        self,
+        query: str,
+        context: Optional[list] = None,
+        session_state: Optional[dict] = None,
+        on_chunk: Optional[Callable] = None,
+    ) -> SkillResult | None:
         social = self._local_social_result(query)
         if social is not None:
             return social
 
         # Backward compatible path
         if context is None or session_state is None:
-            return await self._run_local_model(query, context=context, session_state=session_state)
+            return await self._run_local_model(query, context=context, session_state=session_state, on_chunk=on_chunk)
 
         normalized_query = InputNormalizer.normalize(query)
         semantic_clarification = self._semantic_clarification_prompt(
@@ -1991,6 +1999,7 @@ class GeneralChatSkill(BaseSkill):
             normalized_query,
             context=context,
             session_state=session_state,
+            on_chunk=on_chunk,
         )
         if local is None:
             return None

--- a/nova_backend/src/websocket/session_handler.py
+++ b/nova_backend/src/websocket/session_handler.py
@@ -4009,6 +4009,26 @@ async def run_websocket_session(ws: WebSocket, deps: Any) -> None:
                         "turn_id": incoming_turn_id,
                     },
                 )
+
+            # Streaming UX callback: sends early chat_stream frames
+            # so the client sees tokens arriving before the full
+            # response is assembled and post-processed. This is purely
+            # additive UX -- it does not change governance behavior.
+            _stream_loop = asyncio.get_running_loop()
+
+            def _on_advisory_chunk(text: str) -> None:
+                asyncio.run_coroutine_threadsafe(
+                    ws_send(
+                        ws,
+                        {
+                            "type": "chat_stream",
+                            "text": text,
+                            "turn_id": incoming_turn_id,
+                        },
+                    ),
+                    _stream_loop,
+                )
+
             skill_result = await run_general_chat_fallback(
                 mediated_text,
                 general_chat_skill=general_chat_skill,
@@ -4016,6 +4036,7 @@ async def run_websocket_session(ws: WebSocket, deps: Any) -> None:
                 session_context=session_context,
                 project_threads=project_threads,
                 select_relevant_memory_context=_select_relevant_memory_context,
+                on_chunk=_on_advisory_chunk,
             )
 
             if skill_result:

--- a/nova_backend/tests/governance/test_streaming_llm_fallback.py
+++ b/nova_backend/tests/governance/test_streaming_llm_fallback.py
@@ -1,0 +1,217 @@
+"""Tests for the streaming advisory LLM fallback path.
+
+Verifies:
+- ModelNetworkMediator.request_stream() parses streamed Ollama JSON lines
+- LLMManager.generate() with on_chunk yields tokens via callback
+- on_chunk callback failures do not break inference
+- Non-streaming path is unchanged when on_chunk is None
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# ModelNetworkMediator.request_stream tests
+# ---------------------------------------------------------------------------
+
+class FakeStreamResponse:
+    """Simulates requests.Response with streaming iter_lines."""
+
+    def __init__(self, lines: list[str], status_code: int = 200):
+        self._lines = lines
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise Exception(f"HTTP {self.status_code}")
+
+    def iter_lines(self, decode_unicode: bool = False) -> list[str]:
+        return self._lines
+
+    def close(self) -> None:
+        pass
+
+
+def _ollama_stream_line(text: str, done: bool = False) -> str:
+    return json.dumps({"message": {"content": text}, "done": done})
+
+
+class TestMediatorRequestStream:
+    def test_yields_text_chunks(self):
+        from src.llm.model_network_mediator import ModelNetworkMediator
+
+        mediator = ModelNetworkMediator()
+        lines = [
+            _ollama_stream_line("Hello"),
+            _ollama_stream_line(" world"),
+            _ollama_stream_line("!", done=True),
+        ]
+        fake_response = FakeStreamResponse(lines)
+
+        with patch.object(
+            mediator, "_request_session"
+        ) as mock_session_fn:
+            mock_session = MagicMock()
+            mock_session.post.return_value = fake_response
+            mock_session_fn.return_value = mock_session
+
+            chunks = list(
+                mediator.request_stream(
+                    url="http://localhost:11434/api/chat",
+                    json_payload={"model": "test", "stream": True},
+                    timeout=30.0,
+                )
+            )
+
+        assert chunks == ["Hello", " world", "!"]
+
+    def test_skips_empty_and_malformed_lines(self):
+        from src.llm.model_network_mediator import ModelNetworkMediator
+
+        mediator = ModelNetworkMediator()
+        lines = [
+            "",
+            "not json",
+            _ollama_stream_line("good"),
+            json.dumps({"message": {}}),  # no content
+            _ollama_stream_line(" stuff"),
+        ]
+        fake_response = FakeStreamResponse(lines)
+
+        with patch.object(
+            mediator, "_request_session"
+        ) as mock_session_fn:
+            mock_session = MagicMock()
+            mock_session.post.return_value = fake_response
+            mock_session_fn.return_value = mock_session
+
+            chunks = list(
+                mediator.request_stream(
+                    url="http://localhost:11434/api/chat",
+                    json_payload={"model": "test", "stream": True},
+                    timeout=30.0,
+                )
+            )
+
+        assert chunks == ["good", " stuff"]
+
+    def test_validates_url(self):
+        from src.llm.model_network_mediator import (
+            ModelNetworkMediator,
+            ModelNetworkMediatorError,
+        )
+
+        mediator = ModelNetworkMediator()
+        with pytest.raises(ModelNetworkMediatorError):
+            list(
+                mediator.request_stream(
+                    url="http://evil.com/api/chat",
+                    json_payload={},
+                    timeout=10.0,
+                )
+            )
+
+
+# ---------------------------------------------------------------------------
+# LLMManager.generate with on_chunk tests
+# ---------------------------------------------------------------------------
+
+class TestManagerGenerateWithOnChunk:
+    def test_on_chunk_receives_all_tokens(self):
+        from src.llm.llm_manager import LLMManager
+
+        chunks_received: list[str] = []
+
+        def fake_request_stream(**kwargs):
+            for token in ["Hello", " ", "world"]:
+                yield token
+
+        manager = LLMManager.__new__(LLMManager)
+        manager.model = "test-model"
+        manager.fallback_model = None
+        manager.base_url = "http://localhost:11434"
+        manager.timeout = 30
+        manager.system_prompt = ""
+        manager.default_options = {}
+        manager.inference_blocked = False
+        manager.circuit_open_until = 0
+        manager.failure_count = 0
+        manager._using_fallback = False
+        manager._network = MagicMock()
+        manager._network.request_stream = MagicMock(
+            side_effect=fake_request_stream
+        )
+
+        result = manager.generate(
+            "test prompt",
+            on_chunk=lambda c: chunks_received.append(c),
+        )
+
+        assert result == "Hello world"
+        assert chunks_received == ["Hello", " ", "world"]
+
+    def test_on_chunk_failure_does_not_break_inference(self):
+        from src.llm.llm_manager import LLMManager
+
+        def fake_request_stream(**kwargs):
+            for token in ["Hello", " ", "world"]:
+                yield token
+
+        manager = LLMManager.__new__(LLMManager)
+        manager.model = "test-model"
+        manager.fallback_model = None
+        manager.base_url = "http://localhost:11434"
+        manager.timeout = 30
+        manager.system_prompt = ""
+        manager.default_options = {}
+        manager.inference_blocked = False
+        manager.circuit_open_until = 0
+        manager.failure_count = 0
+        manager._using_fallback = False
+        manager._network = MagicMock()
+        manager._network.request_stream = MagicMock(
+            side_effect=fake_request_stream
+        )
+
+        def exploding_callback(text: str) -> None:
+            raise RuntimeError("UX callback exploded")
+
+        result = manager.generate(
+            "test prompt",
+            on_chunk=exploding_callback,
+        )
+
+        # Inference still completes despite callback failure
+        assert result == "Hello world"
+
+    def test_no_on_chunk_uses_non_streaming_path(self):
+        from src.llm.llm_manager import LLMManager
+
+        manager = LLMManager.__new__(LLMManager)
+        manager.model = "test-model"
+        manager.fallback_model = None
+        manager.base_url = "http://localhost:11434"
+        manager.timeout = 30
+        manager.system_prompt = ""
+        manager.default_options = {}
+        manager.inference_blocked = False
+        manager.circuit_open_until = 0
+        manager.failure_count = 0
+        manager._using_fallback = False
+        manager._network = MagicMock()
+        manager._network.request_json.return_value = SimpleNamespace(
+            status_code=200,
+            data={"message": {"content": "non-streaming result"}},
+        )
+
+        result = manager.generate("test prompt")
+
+        assert result == "non-streaming result"
+        manager._network.request_json.assert_called_once()
+        manager._network.request_stream.assert_not_called()


### PR DESCRIPTION
## Summary
- Adds `chat_stream` WebSocket frame type for token-by-token advisory LLM delivery
- Threads `on_chunk` callback through the full call chain: session_handler → general_chat_runtime → general_chat skill → llm_gateway → llm_manager → model_network_mediator
- Uses `asyncio.run_coroutine_threadsafe` to bridge sync inference thread → async WebSocket send
- Non-streaming path is automatic fallback if streaming fails; final assembled `chat` response is always sent

## Scope constraints
- **Advisory general-chat fallback only** — governed action execution, confirmation gates, capability routing, and OpenClaw are untouched
- No capability expansion, no new skills, no approval-gate changes
- `chat_stream` is additive — clients that don't recognize it ignore it and render only the final `chat` message

## Files changed (7)
| File | Change |
|------|--------|
| `model_network_mediator.py` | +`request_stream()` generator for Ollama streaming JSON lines |
| `llm_manager.py` | +`on_chunk` param on `generate()`, +standalone `generate_stream()` |
| `llm_gateway.py` | +`on_chunk` passthrough on `generate_chat()`, +`generate_chat_stream()` |
| `general_chat.py` | +`on_chunk` param on `handle()` and `_run_local_model()` |
| `general_chat_runtime.py` | +`on_chunk` param on `run_general_chat_fallback()` |
| `session_handler.py` | +`_on_advisory_chunk` callback with async bridge, `chat_stream` frame emit |
| `test_streaming_llm_fallback.py` | 6 new tests covering mediator streaming, on_chunk delivery, callback failure isolation, non-streaming path preservation |

## Frame contract
```json
{ "type": "chat_stream", "text": "<token>", "turn_id": "<id>" }
```
Sent per-token during advisory LLM inference. Final `chat` message with full assembled text follows as before.

## Test plan
- [x] 6 new streaming tests pass (mediator + manager layers)
- [x] 3 existing mediator tests pass (non-streaming unchanged)
- [x] 119 existing WebSocket/session tests pass — 0 failures
- [ ] Rerun 20-persona live simulation after merge to measure UX improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)