### PR TITLE
fix: update test fakes to accept on_chunk kwarg from PR #210

### DIFF
--- a/nova_backend/tests/conversation/test_general_chat_runtime.py
+++ b/nova_backend/tests/conversation/test_general_chat_runtime.py
@@ -17,7 +17,7 @@ class _FakeGeneralChatSkill:
     def can_handle(self, query: str) -> bool:
         return bool(query.strip())
 
-    async def handle(self, query: str, context=None, session_state=None):
+    async def handle(self, query: str, context=None, session_state=None, on_chunk=None):
         self.calls.append(
             {
                 "query": query,

--- a/nova_backend/tests/conversation/test_planning_run_preview.py
+++ b/nova_backend/tests/conversation/test_planning_run_preview.py
@@ -20,7 +20,7 @@ class _FakeGeneralChatSkill:
     def can_handle(self, query: str) -> bool:
         return bool(query.strip())
 
-    async def handle(self, query: str, context=None, session_state=None):
+    async def handle(self, query: str, context=None, session_state=None, on_chunk=None):
         self.calls.append({"query": query, "session_state": dict(session_state or {})})
         return SkillResult(success=True, message="ok", skill="general_chat")
 

--- a/nova_backend/tests/conversation/test_request_understanding_formatter.py
+++ b/nova_backend/tests/conversation/test_request_understanding_formatter.py
@@ -169,7 +169,7 @@ class _FakeGeneralChatSkill:
     def can_handle(self, query: str) -> bool:
         return bool(query.strip())
 
-    async def handle(self, query: str, context=None, session_state=None):
+    async def handle(self, query: str, context=None, session_state=None, on_chunk=None):
         self.calls.append({"query": query, "session_state": dict(session_state or {})})
         return self._result
 

--- a/nova_backend/tests/conversation/test_request_understanding_review_card.py
+++ b/nova_backend/tests/conversation/test_request_understanding_review_card.py
@@ -20,7 +20,7 @@ class _FakeGeneralChatSkill:
     def can_handle(self, query: str) -> bool:
         return bool(query.strip())
 
-    async def handle(self, query: str, context=None, session_state=None):
+    async def handle(self, query: str, context=None, session_state=None, on_chunk=None):
         self.calls.append({"query": query, "session_state": dict(session_state or {})})
         return SkillResult(success=True, message="ok", skill="general_chat")
 

--- a/nova_backend/tests/phase45/test_brain_server_basic_conversation.py
+++ b/nova_backend/tests/phase45/test_brain_server_basic_conversation.py
@@ -182,7 +182,7 @@ def test_pending_escalation_confirmation_returns_deeper_general_chat_answer(monk
     ws = _ScriptedWebSocket(["Why do GPUs matter?", "yes"])
     calls = {"count": 0}
 
-    async def _fake_handle(self, query: str, context=None, session_state=None):
+    async def _fake_handle(self, query: str, context=None, session_state=None, on_chunk=None):
         calls["count"] += 1
         if calls["count"] == 1:
             return SkillResult(


### PR DESCRIPTION
## Summary
- Fixes 30 test failures caused by PR #210's `on_chunk` parameter addition
- Updates 5 test files with fake `GeneralChatSkill.handle()` signatures
- No runtime code changes — tests only

## Root cause
PR #210 added `on_chunk=None` to `GeneralChatSkill.handle()` and
`run_general_chat_fallback()`. Test fakes in 5 files didn't accept the
new kwarg, causing `TypeError: got an unexpected keyword argument 'on_chunk'`.

## Files changed (5)
| File | Change |
|------|--------|
| `tests/conversation/test_general_chat_runtime.py` | +`on_chunk=None` to fake handle() |
| `tests/conversation/test_planning_run_preview.py` | +`on_chunk=None` to fake handle() |
| `tests/conversation/test_request_understanding_formatter.py` | +`on_chunk=None` to fake handle() |
| `tests/conversation/test_request_understanding_review_card.py` | +`on_chunk=None` to fake handle() |
| `tests/phase45/test_brain_server_basic_conversation.py` | +`on_chunk=None` to fake handle() |

## Test plan
- [x] 30 previously failing tests now pass
- [x] 60 total tests in affected files pass
- [x] No runtime behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)