### PR TITLE
fix: move deterministic command handlers before ambient clarification

### DIFF
--- a/nova_backend/src/websocket/session_handler.py
+++ b/nova_backend/src/websocket/session_handler.py
@@ -1029,6 +1029,218 @@ async def run_websocket_session(ws: WebSocket, deps: Any) -> None:
                 await _complete_immediate_turn(_topic_stack_message(session_state, session_state["turn_count"]))
                 continue
 
+            # ── Deterministic-command fast path ──────────────────────────
+            # These recognized commands MUST fire before ambient clarification
+            # so first-turn inputs like "news" or "weather in Boston" reach
+            # their dedicated handlers instead of being intercepted by
+            # context-free follow-up heuristics.
+
+            if TIME_QUERY_RE.match(command_text):
+                await _complete_immediate_turn(
+                    _render_local_time_message(),
+                    suggested_actions=[
+                        {"label": "System status", "command": "system status"},
+                        {"label": "Today's news", "command": "today's news"},
+                    ],
+                )
+                continue
+
+            _arithmetic_answer = _try_arithmetic(command_text)
+            if _arithmetic_answer is not None:
+                await _complete_immediate_turn(_arithmetic_answer)
+                continue
+
+            if is_headline_summary_request(command_text):
+                await _complete_immediate_turn(
+                    render_headline_summary_from_cache(session_state.get("news_cache")),
+                    suggested_actions=[
+                        {"label": "Refresh news", "command": "news"},
+                        {"label": "Show sources", "command": "sources"},
+                    ],
+                    remember_response=False,
+                    tone_domain="daily",
+                )
+                continue
+
+            if lowered in {"news", "headlines", "latest news", "top news"}:
+                _, news_result = await invoke_governed_text_command(
+                    governor,
+                    "news",
+                    session_id,
+                )
+                if news_result is None:
+                    if not silent_widget_refresh:
+                        await send_chat_message(ws, "News is currently unavailable.", tone_domain="daily")
+                    await ws_send(
+                        ws,
+                        {
+                            "type": "news",
+                            "items": [],
+                            "summary": "News is currently unavailable.",
+                            "categories": {},
+                        },
+                    )
+                    session_state["trust_status"] = failure_ladder.record_failure(
+                        session_state.get("trust_status", {}),
+                        reason="Temporary issue",
+                        external=True,
+                        last_external_call="News update",
+                    )
+                    await send_trust_status(ws, session_state["trust_status"])
+                    await send_chat_done(ws)
+                    continue
+                news_widget = {}
+                if isinstance(news_result.data, dict):
+                    news_widget = dict(news_result.data.get("widget") or {})
+
+                if news_result.success:
+                    message = _structure_long_message(news_result.message)
+                    if not silent_widget_refresh:
+                        session_state["last_response"] = message
+                        await send_chat_message(ws, message, tone_domain="daily")
+                    if isinstance(news_widget, dict) and news_widget.get("type") == "news":
+                        items = list(news_widget.get("items") or [])
+                        categories = dict(news_widget.get("categories") or {})
+                        session_state["news_cache"] = items
+                        session_state["news_categories"] = categories
+                        session_state["last_sources"] = _extract_sources_from_results(items)
+                        session_state["last_source_links"] = _extract_source_links(items)
+                        await ws_send(ws, news_widget)
+                    else:
+                        await ws_send(
+                            ws,
+                            {
+                                "type": "news",
+                                "items": [],
+                                "summary": "News is currently unavailable.",
+                                "categories": {},
+                            },
+                        )
+                    session_state["trust_status"] = failure_ladder.record_external_success(
+                        session_state.get("trust_status", {}),
+                        "News update",
+                    )
+                else:
+                    if not silent_widget_refresh:
+                        await send_chat_message(ws, "News is currently unavailable.", tone_domain="daily")
+                    if isinstance(news_widget, dict) and news_widget.get("type") == "news":
+                        await ws_send(ws, news_widget)
+                    else:
+                        await ws_send(
+                            ws,
+                            {
+                                "type": "news",
+                                "items": [],
+                                "summary": "News is currently unavailable.",
+                                "categories": {},
+                            },
+                        )
+                    session_state["trust_status"] = failure_ladder.record_failure(
+                        session_state.get("trust_status", {}),
+                        reason="Temporary issue",
+                        external=True,
+                        last_external_call="News update",
+                    )
+                await send_trust_status(ws, session_state["trust_status"])
+                await send_chat_done(ws)
+                continue
+
+            if lowered in {"weather", "weather update", "current weather"} or re.match(
+                r"^weather\s+in\s+[a-z0-9 ,.\-]+$", lowered
+            ):
+                _, weather_result = await invoke_governed_text_command(
+                    governor,
+                    "weather",
+                    session_id,
+                )
+                if weather_result is None:
+                    if not silent_widget_refresh:
+                        await send_chat_message(ws, "Weather is currently unavailable.", tone_domain="daily")
+                    await ws_send(
+                        ws,
+                        {
+                            "type": "weather",
+                            "data": {
+                                "summary": "Weather is currently unavailable.",
+                                "temperature": None,
+                                "condition": "Unavailable",
+                                "location": "Local",
+                                "forecast": "",
+                                "alerts": [],
+                            },
+                        },
+                    )
+                    session_state["trust_status"] = failure_ladder.record_failure(
+                        session_state.get("trust_status", {}),
+                        reason="Temporary issue",
+                        external=True,
+                        last_external_call="Weather update",
+                    )
+                    await send_trust_status(ws, session_state["trust_status"])
+                    await send_chat_done(ws)
+                    continue
+                weather_widget = {}
+                if isinstance(weather_result.data, dict):
+                    weather_widget = dict(weather_result.data.get("widget") or {})
+
+                if weather_result.success:
+                    message = _structure_long_message(weather_result.message)
+                    if not silent_widget_refresh:
+                        session_state["last_response"] = message
+                        await send_chat_message(ws, message, tone_domain="daily")
+                    if isinstance(weather_widget, dict) and weather_widget.get("type") == "weather":
+                        await ws_send(ws, weather_widget)
+                    else:
+                        await ws_send(
+                            ws,
+                            {
+                                "type": "weather",
+                                "data": {
+                                    "summary": message,
+                                    "temperature": None,
+                                    "condition": "",
+                                    "location": "Local",
+                                    "forecast": "",
+                                    "alerts": [],
+                                },
+                            },
+                        )
+                    session_state["trust_status"] = failure_ladder.record_external_success(
+                        session_state.get("trust_status", {}),
+                        "Weather update",
+                    )
+                else:
+                    if not silent_widget_refresh:
+                        await send_chat_message(ws, "Weather is currently unavailable.", tone_domain="daily")
+                    if isinstance(weather_widget, dict) and weather_widget.get("type") == "weather":
+                        await ws_send(ws, weather_widget)
+                    else:
+                        await ws_send(
+                            ws,
+                            {
+                                "type": "weather",
+                                "data": {
+                                    "summary": "Weather is currently unavailable.",
+                                    "temperature": None,
+                                    "condition": "Unavailable",
+                                    "location": "Local",
+                                    "forecast": "",
+                                    "alerts": [],
+                                },
+                            },
+                        )
+                    session_state["trust_status"] = failure_ladder.record_failure(
+                        session_state.get("trust_status", {}),
+                        reason="Temporary issue",
+                        external=True,
+                        last_external_call="Weather update",
+                    )
+                await send_trust_status(ws, session_state["trust_status"])
+                await send_chat_done(ws)
+                continue
+
+            # ── End deterministic fast path ──────────────────────────────
+
             # RC-2/3/4/5/6: Ambient clarification — context-free follow-ups and informal
             # confusion phrases.  Fire only when the session has no useful prior context
             # (no last_response). With prior context let the LLM handle as a follow-up.
@@ -1082,33 +1294,6 @@ async def run_websocket_session(ws: WebSocket, deps: Any) -> None:
                 await _complete_immediate_turn(
                     _capability_help_message(),
                     suggested_actions=deps._capability_help_actions(),
-                )
-                continue
-
-            if TIME_QUERY_RE.match(command_text):
-                await _complete_immediate_turn(
-                    _render_local_time_message(),
-                    suggested_actions=[
-                        {"label": "System status", "command": "system status"},
-                        {"label": "Today's news", "command": "today's news"},
-                    ],
-                )
-                continue
-
-            _arithmetic_answer = _try_arithmetic(command_text)
-            if _arithmetic_answer is not None:
-                await _complete_immediate_turn(_arithmetic_answer)
-                continue
-
-            if is_headline_summary_request(command_text):
-                await _complete_immediate_turn(
-                    render_headline_summary_from_cache(session_state.get("news_cache")),
-                    suggested_actions=[
-                        {"label": "Refresh news", "command": "news"},
-                        {"label": "Show sources", "command": "sources"},
-                    ],
-                    remember_response=False,
-                    tone_domain="daily",
                 )
                 continue
 
@@ -2082,183 +2267,6 @@ async def run_websocket_session(ws: WebSocket, deps: Any) -> None:
                 context_limit = 40 if session_state.get("presence_mode") else 20
                 session_context = session_context[-context_limit:]
                 session_state["turn_count"] += 1
-                continue
-
-            if lowered in {"weather", "weather update", "current weather"} or re.match(
-                r"^weather\s+in\s+[a-z0-9 ,.\-]+$", lowered
-            ):
-                _, weather_result = await invoke_governed_text_command(
-                    governor,
-                    "weather",
-                    session_id,
-                )
-                if weather_result is None:
-                    if not silent_widget_refresh:
-                        await send_chat_message(ws, "Weather is currently unavailable.", tone_domain="daily")
-                    await ws_send(
-                        ws,
-                        {
-                            "type": "weather",
-                            "data": {
-                                "summary": "Weather is currently unavailable.",
-                                "temperature": None,
-                                "condition": "Unavailable",
-                                "location": "Local",
-                                "forecast": "",
-                                "alerts": [],
-                            },
-                        },
-                    )
-                    session_state["trust_status"] = failure_ladder.record_failure(
-                        session_state.get("trust_status", {}),
-                        reason="Temporary issue",
-                        external=True,
-                        last_external_call="Weather update",
-                    )
-                    await send_trust_status(ws, session_state["trust_status"])
-                    await send_chat_done(ws)
-                    continue
-                weather_widget = {}
-                if isinstance(weather_result.data, dict):
-                    weather_widget = dict(weather_result.data.get("widget") or {})
-
-                if weather_result.success:
-                    message = _structure_long_message(weather_result.message)
-                    if not silent_widget_refresh:
-                        session_state["last_response"] = message
-                        await send_chat_message(ws, message, tone_domain="daily")
-                    if isinstance(weather_widget, dict) and weather_widget.get("type") == "weather":
-                        await ws_send(ws, weather_widget)
-                    else:
-                        await ws_send(
-                            ws,
-                            {
-                                "type": "weather",
-                                "data": {
-                                    "summary": message,
-                                    "temperature": None,
-                                    "condition": "",
-                                    "location": "Local",
-                                    "forecast": "",
-                                    "alerts": [],
-                                },
-                            },
-                        )
-                    session_state["trust_status"] = failure_ladder.record_external_success(
-                        session_state.get("trust_status", {}),
-                        "Weather update",
-                    )
-                else:
-                    if not silent_widget_refresh:
-                        await send_chat_message(ws, "Weather is currently unavailable.", tone_domain="daily")
-                    if isinstance(weather_widget, dict) and weather_widget.get("type") == "weather":
-                        await ws_send(ws, weather_widget)
-                    else:
-                        await ws_send(
-                            ws,
-                            {
-                                "type": "weather",
-                                "data": {
-                                    "summary": "Weather is currently unavailable.",
-                                    "temperature": None,
-                                    "condition": "Unavailable",
-                                    "location": "Local",
-                                    "forecast": "",
-                                    "alerts": [],
-                                },
-                            },
-                        )
-                    session_state["trust_status"] = failure_ladder.record_failure(
-                        session_state.get("trust_status", {}),
-                        reason="Temporary issue",
-                        external=True,
-                        last_external_call="Weather update",
-                    )
-                await send_trust_status(ws, session_state["trust_status"])
-                await send_chat_done(ws)
-                continue
-
-            if lowered in {"news", "headlines", "latest news", "top news"}:
-                _, news_result = await invoke_governed_text_command(
-                    governor,
-                    "news",
-                    session_id,
-                )
-                if news_result is None:
-                    if not silent_widget_refresh:
-                        await send_chat_message(ws, "News is currently unavailable.", tone_domain="daily")
-                    await ws_send(
-                        ws,
-                        {
-                            "type": "news",
-                            "items": [],
-                            "summary": "News is currently unavailable.",
-                            "categories": {},
-                        },
-                    )
-                    session_state["trust_status"] = failure_ladder.record_failure(
-                        session_state.get("trust_status", {}),
-                        reason="Temporary issue",
-                        external=True,
-                        last_external_call="News update",
-                    )
-                    await send_trust_status(ws, session_state["trust_status"])
-                    await send_chat_done(ws)
-                    continue
-                news_widget = {}
-                if isinstance(news_result.data, dict):
-                    news_widget = dict(news_result.data.get("widget") or {})
-
-                if news_result.success:
-                    message = _structure_long_message(news_result.message)
-                    if not silent_widget_refresh:
-                        session_state["last_response"] = message
-                        await send_chat_message(ws, message, tone_domain="daily")
-                    if isinstance(news_widget, dict) and news_widget.get("type") == "news":
-                        items = list(news_widget.get("items") or [])
-                        categories = dict(news_widget.get("categories") or {})
-                        session_state["news_cache"] = items
-                        session_state["news_categories"] = categories
-                        session_state["last_sources"] = _extract_sources_from_results(items)
-                        session_state["last_source_links"] = _extract_source_links(items)
-                        await ws_send(ws, news_widget)
-                    else:
-                        await ws_send(
-                            ws,
-                            {
-                                "type": "news",
-                                "items": [],
-                                "summary": "News is currently unavailable.",
-                                "categories": {},
-                            },
-                        )
-                    session_state["trust_status"] = failure_ladder.record_external_success(
-                        session_state.get("trust_status", {}),
-                        "News update",
-                    )
-                else:
-                    if not silent_widget_refresh:
-                        await send_chat_message(ws, "News is currently unavailable.", tone_domain="daily")
-                    if isinstance(news_widget, dict) and news_widget.get("type") == "news":
-                        await ws_send(ws, news_widget)
-                    else:
-                        await ws_send(
-                            ws,
-                            {
-                                "type": "news",
-                                "items": [],
-                                "summary": "News is currently unavailable.",
-                                "categories": {},
-                            },
-                        )
-                    session_state["trust_status"] = failure_ladder.record_failure(
-                        session_state.get("trust_status", {}),
-                        reason="Temporary issue",
-                        external=True,
-                        last_external_call="News update",
-                    )
-                await send_trust_status(ws, session_state["trust_status"])
-                await send_chat_done(ws)
                 continue
 
             if lowered in {

--- a/nova_backend/tests/governance/test_deterministic_routing_gaps.py
+++ b/nova_backend/tests/governance/test_deterministic_routing_gaps.py
@@ -191,3 +191,121 @@ class TestWeatherInCityRouting:
         assert pattern.match("weather in san francisco")
         assert not pattern.match("weather")
         assert not pattern.match("weather today")
+
+
+# ---------------------------------------------------------------------------
+# Handler ordering — deterministic commands before ambient clarification
+# ---------------------------------------------------------------------------
+
+class TestHandlerOrdering:
+    """Verify deterministic commands are handled before ambient clarification.
+
+    After PR #213, the session_handler routes time, arithmetic, news, and
+    weather commands BEFORE the ambient clarification block.  This means
+    first-turn inputs like "news" or "weather in Boston" (no prior context)
+    cannot be intercepted by context-free follow-up heuristics.
+    """
+
+    def _handler_line(self, marker: str) -> int:
+        """Return the first line number where *marker* appears in session_handler."""
+        import inspect
+        from src.websocket import session_handler as mod
+
+        source = inspect.getsource(mod)
+        for i, line in enumerate(source.splitlines(), start=1):
+            if marker in line:
+                return i
+        raise AssertionError(f"marker {marker!r} not found in session_handler")
+
+    def test_time_query_before_ambient_clarification(self):
+        time_line = self._handler_line("TIME_QUERY_RE.match(command_text)")
+        ambient_line = self._handler_line("AMBIENT_CLARIFICATION_PATTERNS if pat.match")
+        assert time_line < ambient_line, (
+            f"TIME_QUERY_RE ({time_line}) must fire before "
+            f"AMBIENT_CLARIFICATION_PATTERNS ({ambient_line})"
+        )
+
+    def test_arithmetic_before_ambient_clarification(self):
+        arith_line = self._handler_line("_try_arithmetic(command_text)")
+        ambient_line = self._handler_line("AMBIENT_CLARIFICATION_PATTERNS if pat.match")
+        assert arith_line < ambient_line, (
+            f"_try_arithmetic ({arith_line}) must fire before "
+            f"AMBIENT_CLARIFICATION_PATTERNS ({ambient_line})"
+        )
+
+    def test_news_handler_before_ambient_clarification(self):
+        news_line = self._handler_line(
+            'lowered in {"news", "headlines", "latest news", "top news"}'
+        )
+        ambient_line = self._handler_line("AMBIENT_CLARIFICATION_PATTERNS if pat.match")
+        assert news_line < ambient_line, (
+            f"News handler ({news_line}) must fire before "
+            f"AMBIENT_CLARIFICATION_PATTERNS ({ambient_line})"
+        )
+
+    def test_weather_handler_before_ambient_clarification(self):
+        weather_line = self._handler_line(
+            'lowered in {"weather", "weather update", "current weather"}'
+        )
+        ambient_line = self._handler_line("AMBIENT_CLARIFICATION_PATTERNS if pat.match")
+        assert weather_line < ambient_line, (
+            f"Weather handler ({weather_line}) must fire before "
+            f"AMBIENT_CLARIFICATION_PATTERNS ({ambient_line})"
+        )
+
+    def test_headline_summary_before_ambient_clarification(self):
+        headline_line = self._handler_line("is_headline_summary_request(command_text)")
+        ambient_line = self._handler_line("AMBIENT_CLARIFICATION_PATTERNS if pat.match")
+        assert headline_line < ambient_line, (
+            f"Headline summary ({headline_line}) must fire before "
+            f"AMBIENT_CLARIFICATION_PATTERNS ({ambient_line})"
+        )
+
+    def test_news_not_in_ambient_clarification_patterns(self):
+        """Verify 'news' doesn't match any ambient clarification pattern."""
+        from src.websocket.intent_patterns import AMBIENT_CLARIFICATION_PATTERNS
+
+        for pat, _ in AMBIENT_CLARIFICATION_PATTERNS:
+            assert not pat.match("news"), (
+                f"'news' must not match ambient pattern {pat.pattern}"
+            )
+            assert not pat.match("News"), (
+                f"'News' must not match ambient pattern {pat.pattern}"
+            )
+
+    def test_weather_not_in_ambient_clarification_patterns(self):
+        """Verify weather commands don't match any ambient clarification pattern."""
+        from src.websocket.intent_patterns import AMBIENT_CLARIFICATION_PATTERNS
+
+        for phrase in ["weather", "weather in Boston", "current weather"]:
+            for pat, _ in AMBIENT_CLARIFICATION_PATTERNS:
+                assert not pat.match(phrase), (
+                    f"{phrase!r} must not match ambient pattern {pat.pattern}"
+                )
+
+    def test_arithmetic_not_in_ambient_clarification_patterns(self):
+        """Verify arithmetic doesn't match any ambient clarification pattern."""
+        from src.websocket.intent_patterns import AMBIENT_CLARIFICATION_PATTERNS
+
+        for phrase in ["247 times 38", "what is 10 plus 5"]:
+            for pat, _ in AMBIENT_CLARIFICATION_PATTERNS:
+                assert not pat.match(phrase), (
+                    f"{phrase!r} must not match ambient pattern {pat.pattern}"
+                )
+
+    def test_ambiguous_followup_still_matches_ambient_clarification(self):
+        """Ambient clarification must still fire for genuinely ambiguous phrases."""
+        from src.websocket.intent_patterns import AMBIENT_CLARIFICATION_PATTERNS
+
+        ambiguous_phrases = [
+            "tell me more",
+            "go deeper",
+            "what went wrong",
+            "i'm lost",
+        ]
+        for phrase in ambiguous_phrases:
+            matched = any(pat.match(phrase) for pat, _ in AMBIENT_CLARIFICATION_PATTERNS)
+            assert matched, (
+                f"Ambiguous phrase {phrase!r} should still match "
+                f"ambient clarification"
+            )


### PR DESCRIPTION
## Summary
- Moves news, weather, time, arithmetic, and headline-summary handlers **above** the ambient clarification block in `session_handler.py`
- Prevents first-turn inputs like `"news"` or `"weather in Boston"` from being intercepted by context-free follow-up heuristics when `last_response` is empty
- Adds 9 handler-ordering regression tests to `test_deterministic_routing_gaps.py`

## What changed

**Handler chain ordering** (before → after):

```
BEFORE:                          AFTER:
  ambient clarification            time query ✓
  email inbox                      arithmetic ✓
  help orient                      headline summary ✓
  timeless reminder                news ✓
  capability help                  weather ✓
  time query                       ── end fast path ──
  arithmetic                       ambient clarification
  headline summary                 email inbox
  …900 lines…                      help orient
  weather                          timeless reminder
  news                             capability help
```

## Scope discipline
- No capability expansion
- No approval-gate changes
- No capability_locks.json changes
- No OpenClaw authority changes
- No Shopify/website workflows

## Test plan
- [x] 29/29 deterministic routing tests pass (10 arithmetic + 6 news + 4 weather + 9 ordering)
- [x] 88/88 conversation tests pass (general_chat_runtime, request_understanding, planning_run_preview)
- [x] 149/149 governance tests pass (full suite including phase45)
- [ ] Rerun 20-persona simulation after merge to measure improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)