### PR TITLE
feat: Goal Card display-only UI prototype

### DIFF
--- a/nova_backend/static/dashboard-chat-news.js
+++ b/nova_backend/static/dashboard-chat-news.js
@@ -2707,6 +2707,7 @@ function setActivePage(page) {
     news: $("page-news"),
     intro: $("page-intro"),
     home: $("page-home"),
+    goals: $("page-goals"),
     agent: $("page-agent"),
     workspace: $("page-workspace"),
     memory: $("page-memory"),
@@ -2753,6 +2754,9 @@ function setActivePage(page) {
       requestPolicyDetail(policyCenterState.selectedId);
     }
     renderPolicyCenterPage();
+  }
+  if (target === "goals") {
+    if (typeof renderGoalCardsPage === "function") renderGoalCardsPage();
   }
   if (target === "home") {
     requestWorkspaceHomeRefresh(true);

--- a/nova_backend/static/dashboard-config.js
+++ b/nova_backend/static/dashboard-config.js
@@ -23,6 +23,7 @@ window.NOVA_DASHBOARD_CONFIG = {
     home: "Home",
     agent: "Agent",
     workspace: "Workspace",
+    goals: "Goals",
     memory: "Memory",
     policy: "Rules",
     trust: "Trust",
@@ -31,6 +32,7 @@ window.NOVA_DASHBOARD_CONFIG = {
   PRIMARY_NAV_ITEMS: [
     { page: "chat", label: "Chat" },
     { page: "home", label: "Home" },
+    { page: "goals", label: "Goals" },
     { page: "agent", label: "Agent" },
     { page: "news", label: "News" },
     { page: "workspace", label: "Workspace" },

--- a/nova_backend/static/dashboard.js
+++ b/nova_backend/static/dashboard.js
@@ -2111,6 +2111,376 @@ function renderMemoryCenterSurface() {
     : "Edit, lock, unlock, defer, and delete stay governed. This page now adds an inline check before state-changing requests are sent.";
 }
 
+/* ── Goal Cards (display-only prototype) ───────────────────────────── */
+
+/**
+ * Demo goal card data. This is static/demo state only.
+ * No execution, no scheduler, no persistence, no backend authority.
+ * Planning is not authority. Goal state is not permission.
+ */
+const DEMO_GOAL_CARDS = [
+  {
+    goal_id: "goal_auralis_launch_001",
+    title: "Prepare Auralis Shopify launch",
+    status: "planning",
+    created_at: "2026-05-22T12:00:00Z",
+    updated_at: "2026-05-22T14:30:00Z",
+    steps: [
+      {
+        step_id: "step_001",
+        title: "Run read-only Shopify intelligence report",
+        status: "completed",
+        required_capability: 65,
+        approval_required: false,
+      },
+      {
+        step_id: "step_002",
+        title: "Summarize products, inventory, and order signals",
+        status: "completed",
+        required_capability: null,
+        approval_required: false,
+      },
+      {
+        step_id: "step_003",
+        title: "Draft a launch checklist",
+        status: "running",
+        required_capability: null,
+        approval_required: false,
+      },
+      {
+        step_id: "step_004",
+        title: "Draft outreach email for user review",
+        status: "planned",
+        required_capability: 64,
+        approval_required: true,
+      },
+      {
+        step_id: "step_005",
+        title: "Wait for user approval before any external effect",
+        status: "planned",
+        required_capability: null,
+        approval_required: true,
+      },
+    ],
+    permission_envelope: {
+      allowed_capabilities: [
+        { id: 16, name: "Web search" },
+        { id: 22, name: "Open folder" },
+        { id: 64, name: "Email draft" },
+        { id: 65, name: "Shopify read" },
+      ],
+      blocked_actions: [
+        "Shopify writes",
+        "Printify",
+        "Purchases",
+        "Publishing",
+        "Browser control",
+        "Customer messages",
+      ],
+      requires_confirmation: [22, 64],
+    },
+    ledger_refs: [
+      { type: "ACTION_COMPLETED", capability_id: 65,
+        summary: "Shopify intelligence report (read-only)" },
+      { type: "ACTION_COMPLETED", capability_id: null,
+        summary: "Product/inventory summary generated" },
+    ],
+  },
+  {
+    goal_id: "goal_repo_cleanup_002",
+    title: "Clean up Nova repo continuity",
+    status: "completed",
+    created_at: "2026-05-21T09:00:00Z",
+    updated_at: "2026-05-22T00:23:00Z",
+    steps: [
+      {
+        step_id: "step_010",
+        title: "Review current priority and active TODO docs",
+        status: "completed",
+        required_capability: null,
+        approval_required: false,
+      },
+      {
+        step_id: "step_011",
+        title: "Identify stale or conflicting docs",
+        status: "completed",
+        required_capability: null,
+        approval_required: false,
+      },
+      {
+        step_id: "step_012",
+        title: "Draft cleanup plan",
+        status: "completed",
+        required_capability: null,
+        approval_required: false,
+      },
+      {
+        step_id: "step_013",
+        title: "Apply changes after approval",
+        status: "completed",
+        required_capability: 22,
+        approval_required: true,
+      },
+    ],
+    permission_envelope: {
+      allowed_capabilities: [
+        { id: 16, name: "Web search" },
+        { id: 22, name: "Open folder" },
+      ],
+      blocked_actions: [
+        "Delete branches",
+        "Merge PRs",
+        "Modify runtime",
+        "Change locks",
+      ],
+      requires_confirmation: [22],
+    },
+    ledger_refs: [
+      { type: "ACTION_COMPLETED", capability_id: 22,
+        summary: "Opened docs folder for review" },
+    ],
+  },
+  {
+    goal_id: "goal_blocked_example_003",
+    title: "Set up Printify integration",
+    status: "blocked",
+    created_at: "2026-05-22T15:00:00Z",
+    updated_at: "2026-05-22T15:00:00Z",
+    steps: [
+      {
+        step_id: "step_020",
+        title: "Connect Printify API",
+        status: "blocked",
+        required_capability: null,
+        approval_required: true,
+      },
+    ],
+    permission_envelope: {
+      allowed_capabilities: [],
+      blocked_actions: [
+        "Printify API",
+        "External writes",
+        "Product creation",
+        "Order management",
+      ],
+      requires_confirmation: [],
+    },
+    ledger_refs: [],
+  },
+];
+
+const STEP_INDICATORS = {
+  planned: "·",
+  proposed: "?",
+  waiting_for_approval: "!",
+  approved: "✓",
+  running: "▶",
+  completed: "✓",
+  failed: "✗",
+  blocked: "‒",
+  skipped: "–",
+  canceled: "–",
+};
+
+function createGoalCardElement(goal) {
+  const card = document.createElement("article");
+  card.className = "goal-card";
+  card.dataset.goalId = goal.goal_id;
+
+  // Header: title + status badge
+  const header = document.createElement("div");
+  header.className = "goal-card-header";
+
+  const title = document.createElement("h4");
+  title.className = "goal-card-title";
+  title.textContent = String(goal.title || "Untitled goal").trim();
+  header.appendChild(title);
+
+  const badge = document.createElement("span");
+  badge.className = "goal-card-status";
+  badge.dataset.status = goal.status || "draft";
+  badge.textContent = (goal.status || "draft").replace(/_/g, " ");
+  header.appendChild(badge);
+
+  card.appendChild(header);
+
+  // Steps
+  if (Array.isArray(goal.steps) && goal.steps.length > 0) {
+    const stepsLabel = document.createElement("p");
+    stepsLabel.className = "goal-card-section-label";
+    stepsLabel.textContent = "Steps";
+    card.appendChild(stepsLabel);
+
+    const stepsList = document.createElement("div");
+    stepsList.className = "goal-card-steps";
+
+    goal.steps.forEach(function (step) {
+      const stepEl = document.createElement("div");
+      stepEl.className = "goal-card-step";
+      stepEl.dataset.stepStatus = step.status || "planned";
+
+      const indicator = document.createElement("span");
+      indicator.className = "goal-card-step-indicator";
+      indicator.textContent = STEP_INDICATORS[step.status] || "·";
+      stepEl.appendChild(indicator);
+
+      const stepTitle = document.createElement("span");
+      stepTitle.className = "goal-card-step-title";
+      stepTitle.textContent = String(step.title || "").trim();
+      if (step.approval_required && step.status !== "completed") {
+        stepTitle.textContent += " (approval required)";
+      }
+      stepEl.appendChild(stepTitle);
+
+      stepsList.appendChild(stepEl);
+    });
+
+    card.appendChild(stepsList);
+  }
+
+  // Permission envelope
+  var env = goal.permission_envelope;
+  if (env) {
+    const envLabel = document.createElement("p");
+    envLabel.className = "goal-card-section-label";
+    envLabel.textContent = "Permission envelope";
+    card.appendChild(envLabel);
+
+    const envGrid = document.createElement("div");
+    envGrid.className = "goal-card-envelope";
+
+    // Allowed column
+    if (Array.isArray(env.allowed_capabilities)
+        && env.allowed_capabilities.length > 0) {
+      const allowedCol = document.createElement("div");
+      allowedCol.className = "goal-card-envelope-col";
+
+      const allowedLabel = document.createElement("p");
+      allowedLabel.className = "goal-card-section-label";
+      allowedLabel.textContent = "Allowed";
+      allowedCol.appendChild(allowedLabel);
+
+      const allowedTags = document.createElement("div");
+      allowedTags.className = "goal-card-tag-list";
+      env.allowed_capabilities.forEach(function (cap) {
+        const tag = document.createElement("span");
+        tag.className = "goal-card-tag allowed";
+        tag.textContent = cap.name || ("Cap " + cap.id);
+        allowedTags.appendChild(tag);
+      });
+      allowedCol.appendChild(allowedTags);
+      envGrid.appendChild(allowedCol);
+    }
+
+    // Blocked column
+    if (Array.isArray(env.blocked_actions)
+        && env.blocked_actions.length > 0) {
+      const blockedCol = document.createElement("div");
+      blockedCol.className = "goal-card-envelope-col";
+
+      const blockedLabel = document.createElement("p");
+      blockedLabel.className = "goal-card-section-label";
+      blockedLabel.textContent = "Blocked";
+      blockedCol.appendChild(blockedLabel);
+
+      const blockedTags = document.createElement("div");
+      blockedTags.className = "goal-card-tag-list";
+      env.blocked_actions.forEach(function (action) {
+        const tag = document.createElement("span");
+        tag.className = "goal-card-tag blocked";
+        tag.textContent = String(action);
+        blockedTags.appendChild(tag);
+      });
+      blockedCol.appendChild(blockedTags);
+      envGrid.appendChild(blockedCol);
+    }
+
+    card.appendChild(envGrid);
+  }
+
+  // Receipt references
+  if (Array.isArray(goal.ledger_refs) && goal.ledger_refs.length > 0) {
+    const receiptsLabel = document.createElement("p");
+    receiptsLabel.className = "goal-card-section-label";
+    receiptsLabel.textContent = "Receipts";
+    card.appendChild(receiptsLabel);
+
+    const receiptsList = document.createElement("div");
+    receiptsList.className = "goal-card-receipts";
+
+    goal.ledger_refs.forEach(function (ref) {
+      const receiptEl = document.createElement("div");
+      receiptEl.className = "goal-card-receipt";
+
+      const dot = document.createElement("span");
+      dot.className = "goal-card-receipt-dot";
+      dot.classList.add(
+        ref.type === "ACTION_COMPLETED" ? "completed" : "attempted"
+      );
+      receiptEl.appendChild(dot);
+
+      const text = document.createElement("span");
+      text.textContent = String(ref.summary || ref.type || "");
+      receiptEl.appendChild(text);
+
+      receiptsList.appendChild(receiptEl);
+    });
+
+    card.appendChild(receiptsList);
+  }
+
+  // Actions (inert UI only — display-only prototype)
+  const actions = document.createElement("div");
+  actions.className = "goal-card-actions";
+
+  var isPausable = ["planning", "running", "ready",
+    "waiting_for_approval"].indexOf(goal.status) !== -1;
+  var isCancelable = goal.status !== "completed"
+    && goal.status !== "canceled" && goal.status !== "failed";
+
+  var pauseBtn = document.createElement("button");
+  pauseBtn.type = "button";
+  pauseBtn.className = "goal-card-action-btn";
+  pauseBtn.textContent = goal.status === "paused" ? "Resume" : "Pause";
+  pauseBtn.disabled = !isPausable && goal.status !== "paused";
+  actions.appendChild(pauseBtn);
+
+  var cancelBtn = document.createElement("button");
+  cancelBtn.type = "button";
+  cancelBtn.className = "goal-card-action-btn destructive";
+  cancelBtn.textContent = "Cancel";
+  cancelBtn.disabled = !isCancelable;
+  actions.appendChild(cancelBtn);
+
+  card.appendChild(actions);
+
+  // Updated timestamp
+  if (goal.updated_at) {
+    const updated = document.createElement("div");
+    updated.className = "goal-card-updated";
+    try {
+      updated.textContent = "Updated "
+        + new Date(goal.updated_at).toLocaleString();
+    } catch (_e) {
+      updated.textContent = "Updated " + goal.updated_at;
+    }
+    card.appendChild(updated);
+  }
+
+  return card;
+}
+
+function renderGoalCardsPage() {
+  const container = $("goal-cards-container");
+  if (!container) return;
+  container.innerHTML = "";
+  DEMO_GOAL_CARDS.forEach(function (goal) {
+    container.appendChild(createGoalCardElement(goal));
+  });
+}
+
+/* ── End Goal Cards ────────────────────────────────────────────────── */
+
 /* Control-center surfaces moved to dashboard-control-center.js. */
 
 /* Chat, news, and general interaction surfaces moved to dashboard-chat-news.js. */

--- a/nova_backend/static/index.html
+++ b/nova_backend/static/index.html
@@ -1099,6 +1099,22 @@
         </div>
       </section>
 
+      <section id="page-goals" class="page-view page-goals" hidden>
+        <div class="widget page-card goal-page-hero" aria-live="polite">
+          <div class="goal-page-kicker">Governed Workflows</div>
+          <div class="goal-page-title-row">
+            <h3>Goals</h3>
+            <span class="news-page-subtle">Visible, bounded, receipt-backed</span>
+          </div>
+          <p class="goal-page-intro">
+            Goal Cards show what Nova is planning, what it has done,
+            what needs approval, and what is blocked. Planning is not authority.
+          </p>
+        </div>
+
+        <div id="goal-cards-container" class="goal-cards-container" aria-live="polite"></div>
+      </section>
+
       <section id="page-memory" class="page-view page-memory" hidden>
         <div class="widget page-card memory-page-hero" aria-live="polite">
           <div class="memory-page-kicker">Personal Intelligence</div>

--- a/nova_backend/static/style.phase1.css
+++ b/nova_backend/static/style.phase1.css
@@ -657,6 +657,322 @@ body {
   cursor: not-allowed;
 }
 
+/* ── Goal Cards ──────────────────────────────────────────── */
+
+.page-goals {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: auto;
+  gap: 10px;
+}
+
+.goal-page-hero {
+  display: grid;
+  gap: 8px;
+  padding: 14px;
+}
+
+.goal-page-kicker {
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.goal-page-title-row {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.goal-page-title-row h3 {
+  margin: 0;
+}
+
+.goal-page-intro {
+  margin: 0;
+  font-size: 0.88rem;
+  line-height: 1.5;
+  color: #d6e6fb;
+}
+
+.goal-cards-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: 12px;
+}
+
+.goal-card {
+  display: grid;
+  gap: 10px;
+  padding: 14px;
+  border-radius: var(--radius);
+  border: 1px solid rgba(143, 218, 255, 0.18);
+  background: linear-gradient(
+    160deg,
+    rgba(16, 34, 58, 0.92) 0%,
+    rgba(8, 19, 36, 0.94) 100%
+  );
+  box-shadow: var(--shadow-panel);
+}
+
+.goal-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.goal-card-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.goal-card-status {
+  flex-shrink: 0;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.goal-card-status[data-status="draft"] {
+  border: 1px solid rgba(168, 187, 220, 0.3);
+  background: rgba(168, 187, 220, 0.1);
+  color: var(--muted);
+}
+
+.goal-card-status[data-status="planning"] {
+  border: 1px solid rgba(104, 177, 255, 0.3);
+  background: rgba(104, 177, 255, 0.12);
+  color: var(--accent);
+}
+
+.goal-card-status[data-status="waiting_for_approval"] {
+  border: 1px solid rgba(246, 203, 143, 0.35);
+  background: rgba(246, 203, 143, 0.1);
+  color: var(--warn);
+}
+
+.goal-card-status[data-status="ready"] {
+  border: 1px solid rgba(106, 214, 188, 0.3);
+  background: rgba(106, 214, 188, 0.1);
+  color: var(--ok);
+}
+
+.goal-card-status[data-status="running"] {
+  border: 1px solid rgba(106, 214, 188, 0.4);
+  background: rgba(106, 214, 188, 0.15);
+  color: var(--ok);
+}
+
+.goal-card-status[data-status="paused"] {
+  border: 1px solid rgba(246, 203, 143, 0.3);
+  background: rgba(246, 203, 143, 0.08);
+  color: var(--warn);
+}
+
+.goal-card-status[data-status="completed"] {
+  border: 1px solid rgba(106, 214, 188, 0.35);
+  background: rgba(106, 214, 188, 0.12);
+  color: var(--ok);
+}
+
+.goal-card-status[data-status="blocked"],
+.goal-card-status[data-status="failed"] {
+  border: 1px solid rgba(255, 130, 130, 0.3);
+  background: rgba(255, 130, 130, 0.1);
+  color: #ff9a9a;
+}
+
+.goal-card-status[data-status="canceled"] {
+  border: 1px solid rgba(168, 187, 220, 0.2);
+  background: rgba(168, 187, 220, 0.06);
+  color: var(--muted);
+}
+
+.goal-card-section-label {
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #9dbde0;
+  margin: 0;
+}
+
+.goal-card-steps {
+  display: grid;
+  gap: 4px;
+}
+
+.goal-card-step {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(175, 198, 230, 0.12);
+  background: rgba(255, 255, 255, 0.03);
+  font-size: 0.82rem;
+  line-height: 1.4;
+  color: #e4efff;
+}
+
+.goal-card-step[data-step-status="completed"] {
+  border-color: rgba(106, 214, 188, 0.2);
+}
+
+.goal-card-step[data-step-status="running"] {
+  border-color: rgba(104, 177, 255, 0.3);
+  background: rgba(104, 177, 255, 0.06);
+}
+
+.goal-card-step[data-step-status="waiting_for_approval"] {
+  border-color: rgba(246, 203, 143, 0.25);
+  background: rgba(246, 203, 143, 0.05);
+}
+
+.goal-card-step[data-step-status="blocked"] {
+  border-color: rgba(255, 130, 130, 0.2);
+  opacity: 0.7;
+}
+
+.goal-card-step-indicator {
+  flex-shrink: 0;
+  width: 18px;
+  text-align: center;
+  font-size: 0.78rem;
+}
+
+.goal-card-step-title {
+  flex: 1;
+  min-width: 0;
+}
+
+.goal-card-envelope {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.goal-card-envelope-col {
+  display: grid;
+  gap: 4px;
+}
+
+.goal-card-tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.goal-card-tag {
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.goal-card-tag.allowed {
+  border: 1px solid rgba(106, 214, 188, 0.25);
+  background: rgba(106, 214, 188, 0.08);
+  color: var(--ok);
+}
+
+.goal-card-tag.blocked {
+  border: 1px solid rgba(255, 130, 130, 0.2);
+  background: rgba(255, 130, 130, 0.06);
+  color: #ff9a9a;
+}
+
+.goal-card-receipts {
+  display: grid;
+  gap: 4px;
+}
+
+.goal-card-receipt {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(175, 198, 230, 0.1);
+  background: rgba(255, 255, 255, 0.02);
+  font-size: 0.78rem;
+  color: var(--muted);
+}
+
+.goal-card-receipt-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.goal-card-receipt-dot.completed {
+  background: var(--ok);
+}
+
+.goal-card-receipt-dot.attempted {
+  background: var(--warn);
+}
+
+.goal-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding-top: 4px;
+  border-top: 1px solid var(--line);
+}
+
+.goal-card-action-btn {
+  padding: 7px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(143, 218, 255, 0.22);
+  background: rgba(104, 177, 255, 0.08);
+  color: #edf5ff;
+  font-size: 0.78rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.goal-card-action-btn:hover {
+  border-color: rgba(143, 218, 255, 0.4);
+  background: rgba(104, 177, 255, 0.16);
+}
+
+.goal-card-action-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.goal-card-action-btn.destructive {
+  border-color: rgba(255, 130, 130, 0.22);
+  background: rgba(255, 130, 130, 0.06);
+}
+
+.goal-card-action-btn.destructive:hover {
+  border-color: rgba(255, 130, 130, 0.4);
+  background: rgba(255, 130, 130, 0.12);
+}
+
+.goal-card-updated {
+  font-size: 0.72rem;
+  color: var(--muted);
+  text-align: right;
+}
+
+/* ── End Goal Cards ──────────────────────────────────────── */
+
 .page-news {
   display: grid;
   grid-template-columns: minmax(0, 1fr);


### PR DESCRIPTION
## Summary
- First visible Goal Card surface on the Nova dashboard
- Display-only prototype with static demo data (3 cards: planning, completed, blocked)
- Goals page added to primary navigation
- All 10 goal statuses styled, step indicators, permission envelope tags, receipt refs
- Pause/Cancel buttons are inert (display-only)

## Strict scope
- **No execution** — display-only, no backend API calls
- **No scheduler** — no background work
- **No persistence** — static demo data only
- **No GovernorMediator changes** — no runtime authority change
- **No capability changes** — no capability_locks.json modification
- **No OpenClaw expansion** — no authority expansion

## Files changed
- `nova_backend/static/index.html` — Goals page section
- `nova_backend/static/style.phase1.css` — Goal card component styles
- `nova_backend/static/dashboard.js` — Demo data + render function
- `nova_backend/static/dashboard-config.js` — Goals nav item + page label
- `nova_backend/static/dashboard-chat-news.js` — Goals page routing

## Based on
- `docs/future/GOVERNED_GOAL_CARDS_DESIGN.md` (merged in PR #217)

## Test plan
- [ ] Navigate to Goals tab — page renders with 3 demo cards
- [ ] Verify status badges show correct colors for planning/completed/blocked
- [ ] Verify step indicators show correct symbols
- [ ] Verify permission envelope shows allowed (green) and blocked (red) tags
- [ ] Verify Pause/Cancel buttons are visible but non-functional
- [ ] Verify no backend errors in console
- [ ] Verify no runtime authority changes (Cap 65 regression: 59/59 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)