### PR TITLE
ui: Goal Card UX clarity

### DIFF
--- a/nova_backend/static/dashboard.js
+++ b/nova_backend/static/dashboard.js
@@ -2442,14 +2442,20 @@ function createGoalCardElement(goal) {
   pauseBtn.type = "button";
   pauseBtn.className = "goal-card-action-btn";
   pauseBtn.textContent = goal.status === "paused" ? "Resume" : "Pause";
-  pauseBtn.disabled = !isPausable && goal.status !== "paused";
+  pauseBtn.disabled = true;
+  pauseBtn.title = "Display only — not connected to execution yet";
+  pauseBtn.setAttribute("aria-label",
+    (goal.status === "paused" ? "Resume" : "Pause")
+    + " (display only)");
   actions.appendChild(pauseBtn);
 
   var cancelBtn = document.createElement("button");
   cancelBtn.type = "button";
   cancelBtn.className = "goal-card-action-btn destructive";
   cancelBtn.textContent = "Cancel";
-  cancelBtn.disabled = !isCancelable;
+  cancelBtn.disabled = true;
+  cancelBtn.title = "Display only — not connected to execution yet";
+  cancelBtn.setAttribute("aria-label", "Cancel (display only)");
   actions.appendChild(cancelBtn);
 
   card.appendChild(actions);
@@ -2470,13 +2476,62 @@ function createGoalCardElement(goal) {
   return card;
 }
 
-function renderGoalCardsPage() {
-  const container = $("goal-cards-container");
-  if (!container) return;
-  container.innerHTML = "";
-  DEMO_GOAL_CARDS.forEach(function (goal) {
-    container.appendChild(createGoalCardElement(goal));
+var GOAL_STATUS_LEGEND = [
+  { key: "draft", label: "Draft" },
+  { key: "planning", label: "Planning" },
+  { key: "waiting", label: "Waiting for approval" },
+  { key: "ready", label: "Ready" },
+  { key: "running", label: "Running" },
+  { key: "paused", label: "Paused" },
+  { key: "completed", label: "Completed" },
+  { key: "blocked", label: "Blocked" },
+  { key: "canceled", label: "Canceled" },
+];
+
+function renderGoalStatusLegend() {
+  var legendWidget = $("goal-status-legend");
+  if (!legendWidget) return;
+  var host = legendWidget.querySelector(".goal-legend-items");
+  if (!host || host.children.length > 0) return;
+
+  GOAL_STATUS_LEGEND.forEach(function (entry) {
+    var item = document.createElement("span");
+    item.className = "goal-legend-item";
+
+    var dot = document.createElement("span");
+    dot.className = "goal-legend-dot";
+    dot.dataset.legend = entry.key;
+    item.appendChild(dot);
+
+    var label = document.createElement("span");
+    label.textContent = entry.label;
+    item.appendChild(label);
+
+    host.appendChild(item);
   });
+}
+
+function renderGoalCardsPage() {
+  var container = $("goal-cards-container");
+  var emptyState = $("goal-cards-empty");
+  if (!container) return;
+
+  container.innerHTML = "";
+
+  var goals = DEMO_GOAL_CARDS;
+  var hasGoals = Array.isArray(goals) && goals.length > 0;
+
+  if (emptyState) {
+    emptyState.hidden = hasGoals;
+  }
+
+  if (hasGoals) {
+    goals.forEach(function (goal) {
+      container.appendChild(createGoalCardElement(goal));
+    });
+  }
+
+  renderGoalStatusLegend();
 }
 
 /* ── End Goal Cards ────────────────────────────────────────────────── */

--- a/nova_backend/static/index.html
+++ b/nova_backend/static/index.html
@@ -1101,14 +1101,34 @@
 
       <section id="page-goals" class="page-view page-goals" hidden>
         <div class="widget page-card goal-page-hero" aria-live="polite">
-          <div class="goal-page-kicker">Governed Workflows</div>
-          <div class="goal-page-title-row">
-            <h3>Goals</h3>
-            <span class="news-page-subtle">Visible, bounded, receipt-backed</span>
+          <div class="goal-page-hero-top">
+            <div>
+              <div class="goal-page-kicker">Governed Workflows</div>
+              <div class="goal-page-title-row">
+                <h3>Goals</h3>
+                <span class="news-page-subtle">Visible, bounded, receipt-backed</span>
+              </div>
+            </div>
+            <span class="goal-demo-badge">Display only</span>
           </div>
           <p class="goal-page-intro">
             Goal Cards show what Nova is planning, what it has done,
             what needs approval, and what is blocked. Planning is not authority.
+          </p>
+        </div>
+
+        <div id="goal-status-legend" class="widget page-card goal-status-legend" aria-label="Status legend">
+          <p class="goal-card-section-label">Status legend</p>
+          <div class="goal-legend-items"></div>
+        </div>
+
+        <div id="goal-cards-empty" class="widget page-card goal-cards-empty" hidden>
+          <div class="goal-empty-icon" aria-hidden="true"></div>
+          <p class="goal-empty-title">No goals yet</p>
+          <p class="goal-empty-copy">
+            When Nova helps you work toward a goal, it will appear here
+            as a visible, governed card. You will see every step, every
+            permission boundary, and every receipt.
           </p>
         </div>
 

--- a/nova_backend/static/style.phase1.css
+++ b/nova_backend/static/style.phase1.css
@@ -672,6 +672,27 @@ body {
   padding: 14px;
 }
 
+.goal-page-hero-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.goal-demo-badge {
+  flex-shrink: 0;
+  padding: 4px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(246, 203, 143, 0.3);
+  background: rgba(246, 203, 143, 0.08);
+  color: var(--warn);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
 .goal-page-kicker {
   font-size: 0.68rem;
   font-weight: 800;
@@ -971,6 +992,82 @@ body {
   text-align: right;
 }
 
+/* Goal Card — empty state */
+
+.goal-cards-empty {
+  display: grid;
+  gap: 8px;
+  justify-items: center;
+  text-align: center;
+  padding: 32px 14px;
+}
+
+.goal-empty-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: 2px dashed rgba(143, 218, 255, 0.2);
+  background: rgba(104, 177, 255, 0.04);
+}
+
+.goal-empty-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.goal-empty-copy {
+  margin: 0;
+  max-width: 420px;
+  font-size: 0.84rem;
+  line-height: 1.5;
+  color: var(--muted);
+}
+
+/* Goal Card — status legend */
+
+.goal-status-legend {
+  display: grid;
+  gap: 8px;
+  padding: 12px 14px;
+}
+
+.goal-legend-items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.goal-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(175, 198, 230, 0.12);
+  background: rgba(255, 255, 255, 0.02);
+  font-size: 0.7rem;
+  color: var(--muted);
+}
+
+.goal-legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.goal-legend-dot[data-legend="draft"] { background: var(--muted); }
+.goal-legend-dot[data-legend="planning"] { background: var(--accent); }
+.goal-legend-dot[data-legend="waiting"] { background: var(--warn); }
+.goal-legend-dot[data-legend="ready"] { background: var(--ok); }
+.goal-legend-dot[data-legend="running"] { background: var(--ok); }
+.goal-legend-dot[data-legend="paused"] { background: var(--warn); }
+.goal-legend-dot[data-legend="completed"] { background: var(--ok); }
+.goal-legend-dot[data-legend="blocked"] { background: #ff9a9a; }
+.goal-legend-dot[data-legend="canceled"] { background: var(--muted); }
+
 /* ── End Goal Cards ──────────────────────────────────────── */
 
 .page-news {
@@ -1268,6 +1365,14 @@ body {
   }
 
   .live-help-steps {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .goal-cards-container {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .goal-card-envelope {
     grid-template-columns: minmax(0, 1fr);
   }
 


### PR DESCRIPTION
## Summary
- Add "Display only" badge to Goals page header
- Add empty-state UI for when no goals exist
- Make Pause/Cancel buttons always disabled with tooltip explaining they are not connected to execution
- Add status legend with color dots for all 9 goal statuses
- Add responsive breakpoints for goal cards and permission envelope at 680px

## Strict scope
- **Display-only** — no execution path added
- **No backend API** — static demo data only
- **No scheduler** — no background work
- **No persistence** — no state saved
- **No GovernorMediator changes** — no runtime authority change
- **No capability changes** — no capability_locks.json modification
- Frontend static files only (3 files)

## Files changed
- `nova_backend/static/index.html` — demo badge, empty state, status legend markup
- `nova_backend/static/style.phase1.css` — demo badge, empty state, legend, responsive styles
- `nova_backend/static/dashboard.js` — button tooltips, legend render, empty state logic

## Test plan
- [ ] Navigate to Goals tab — "Display only" badge visible in header
- [ ] Verify Pause/Cancel buttons are disabled with tooltip on hover
- [ ] Verify status legend renders with 9 colored dots
- [ ] Temporarily clear DEMO_GOAL_CARDS to verify empty state shows
- [ ] Resize to 680px — cards stack to single column
- [ ] Cap 65 regression: 59/59 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)