### PR TITLE
docs: reconcile open issue accounting

### DIFF
--- a/.agent_context/current_priority.md
+++ b/.agent_context/current_priority.md
@@ -192,17 +192,40 @@ Most other active capabilities — certification lock phases pending.
 
 ## Open carried-forward follow-ups
 
+Active follow-ups:
+
 ```text
-#141 — closed.
 #142 — RS-2 capability list truncation needs reproduction.
 #143 — "tell me more" with prior context needs session-state-aware test.
-#208 — closed (everyday reliability complete).
 #214 — Multi-turn context continuity hardening (evidence captured).
+```
+
+Open planning / future trackers (not active workstreams):
+
+```text
+#67 — Agent workspaces / Google email-calendar coordination planning.
+#71 — Governed local memory workspace planning.
+#73 — Governed learning layer planning.
+#74 — Brain matrix / Daily Brief boundary planning.
+#189 — Ecosystem simulation / operator proof / multi-model advisory.
+```
+
+Open hardening review:
+
+```text
+#163 — External security scan findings. Needs bounded verification.
+```
+
+Recently closed:
+
+```text
+#141 — closed.
+#208 — closed (everyday reliability complete, PRs #206-#213).
 #215 — closed (boundary clarity fixed, commit 2485761).
 #216 — closed. Cap 65 P5 complete, locked (2026-05-22).
 ```
 
-Open issues: #142, #143, #214. All others closed.
+Open issues: 9 total (3 active, 5 planning/future, 1 hardening).
 
 ## Next correct sequence
 

--- a/docs/status/CURRENT_WORK_STATUS.md
+++ b/docs/status/CURRENT_WORK_STATUS.md
@@ -665,15 +665,36 @@ Generated runtime docs are current as of the latest recorded drift check on PR #
 
 ## Open Carried-Forward Follow-Ups
 
+Active follow-ups:
+
 ```text
 #142 — RS-2 capability list truncation needs reproduction.
 #143 — "tell me more" with prior context needs session-state-aware test.
+#214 — Multi-turn context continuity hardening (evidence captured).
 ```
 
-Recently completed proof:
+Open planning / future trackers (not active workstreams):
 
 ```text
-#141 — Search widget WebSocket surfacing fix and live proof complete; issue is closed.
+#67 — Agent workspaces / Google email-calendar coordination planning.
+#71 — Governed local memory workspace planning.
+#73 — Governed learning layer planning.
+#74 — Brain matrix / Daily Brief boundary planning.
+#189 — Ecosystem simulation / operator proof / multi-model advisory.
+```
+
+Open hardening review:
+
+```text
+#163 — External security scan findings. Needs bounded verification.
+```
+
+Recently closed:
+
+```text
+#141 — closed. Search widget WebSocket surfacing fix and live proof.
+#208 — closed. Everyday reliability complete (PRs #206-#213).
+#216 — closed. Cap 65 P5 complete, locked (2026-05-22).
 ```
 
 ---
@@ -734,7 +755,8 @@ No recent merge authorizes:
 ```text
 1. All four certified capabilities locked (Cap 16, 22, 64, 65).
 2. All major workstreams closed (reliability, quality, approval-gate).
-3. Open issues: #142, #143, #214. PR #217 open (goal-card docs).
-4. Do not expand capabilities or add Shopify/website workflows.
-5. Do not reopen the approval-gate lane unless registry truth changes.
+3. Goal Card display-only UI merged (PRs #217, #218, #219).
+4. Open issues: 9 total (3 active, 5 planning/future, 1 hardening).
+5. Do not expand capabilities or add Shopify/website workflows.
+6. Do not reopen the approval-gate lane unless registry truth changes.
 ```

--- a/docs/todo/ACTIVE_TODO.md
+++ b/docs/todo/ACTIVE_TODO.md
@@ -319,3 +319,29 @@ Scope:
 live-backend validation only
 no runtime authority expansion
 ```
+
+---
+
+## Open Planning / Future Trackers
+
+These are not active workstreams. They track future direction and
+should not be treated as blockers or active tasks.
+
+```text
+#67 — Agent workspaces / Google email-calendar coordination planning.
+#71 — Governed local memory workspace planning.
+#73 — Governed learning layer planning.
+#74 — Brain matrix / Daily Brief boundary planning.
+#189 — Ecosystem simulation / operator proof / multi-model advisory.
+```
+
+---
+
+## Open Hardening Review
+
+```text
+#163 — External security scan findings.
+       Needs bounded verification, not broad rewrite.
+       Checklist: TomorrowIO key, tts subprocess, python-multipart,
+       RSS XML parsing, defusedxml. Document true/false-positive.
+```


### PR DESCRIPTION
## Summary
- Status docs claimed only 3 open issues; GitHub has 9
- Classify all open issues into proper buckets:
  - **Active follow-ups:** #142, #143, #214
  - **Planning/future trackers:** #67, #71, #73, #74, #189
  - **Hardening review:** #163
- Closed #208 (everyday reliability complete)
- Updated current_priority.md, ACTIVE_TODO.md, CURRENT_WORK_STATUS.md

## Strict scope
- Docs-only (3 status/continuity files)
- No runtime code changes
- No capability changes
- No generated runtime docs

## Test plan
- [ ] Verify issue counts match GitHub open-issue list
- [ ] Verify no runtime files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)