### PR TITLE
fix: harden RSS XML parsing and upgrade python-multipart

### DIFF
--- a/nova_backend/requirements.txt
+++ b/nova_backend/requirements.txt
@@ -4,7 +4,8 @@ httpx==0.28.1
 websockets==15.0.1
 psutil==7.1.3
 pydantic==2.12.5
-python-multipart==0.0.21
+python-multipart==0.0.29
+defusedxml==0.7.1
 aiofiles==25.1.0
 sounddevice==0.5.3
 numpy==2.2.6

--- a/nova_backend/src/tools/rss_fetch.py
+++ b/nova_backend/src/tools/rss_fetch.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import xml.etree.ElementTree as ET
+from defusedxml.ElementTree import fromstring as _safe_fromstring
 import html
 import re
 from typing import Dict, Any, List
@@ -161,7 +162,7 @@ async def fetch_rss_headlines(
         return []
 
     try:
-        root = ET.fromstring(text)
+        root = _safe_fromstring(text)
     except ET.ParseError:
         return []
 


### PR DESCRIPTION
## Summary
Bounded verification of Issue #163 external security scan findings.

### Findings reviewed
| # | Finding | Verdict | Action |
|---|---------|---------|--------|
| 1 | TomorrowIO API key | **False positive** | No key exists; weather uses env var |
| 2 | tts subprocess.run | **False positive** | User text via stdin, not shell args |
| 3 | python-multipart outdated | **True** | Upgraded 0.0.21 → 0.0.29 |
| 4 | RSS XML XXE risk | **True** | Replaced ET.fromstring with defusedxml |

### Changes
- `nova_backend/src/tools/rss_fetch.py` — use defusedxml.ElementTree.fromstring for untrusted RSS XML
- `nova_backend/requirements.txt` — add defusedxml==0.7.1, upgrade python-multipart to 0.0.29

### Scope
- No runtime authority change
- No capability change
- No GovernorMediator change
- 2 files, hardening only

## Test plan
- [x] 74/74 RSS/news tests pass
- [ ] Full suite regression (running)

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)