### PR TITLE
fix: add missing certification directories for locked capabilities

### DIFF
--- a/nova_backend/tests/certification/cap_22_open_file_folder/test_p1_unit.py
+++ b/nova_backend/tests/certification/cap_22_open_file_folder/test_p1_unit.py
@@ -1,0 +1,12 @@
+# tests/certification/cap_22_open_file_folder/test_p1_unit.py
+"""
+Phase 1 — Unit certification for capability 22 (open_file_folder).
+
+Re-exports the canonical executor unit tests into the certification
+pipeline. When this capability is locked, CI enforces these pass on
+every commit.
+
+Canonical unit tests:
+  tests/executors/test_open_folder_executor.py
+"""
+from tests.executors.test_open_folder_executor import *  # noqa: F401,F403

--- a/nova_backend/tests/certification/cap_22_open_file_folder/test_p2_routing.py
+++ b/nova_backend/tests/certification/cap_22_open_file_folder/test_p2_routing.py
@@ -1,0 +1,74 @@
+# tests/certification/cap_22_open_file_folder/test_p2_routing.py
+"""
+Phase 2 — Routing certification for capability 22 (open_file_folder).
+
+Verifies GovernorMediator routes folder-open intents to cap 22 and
+does NOT route unrelated intents to it.
+
+No canonical routing test file exists for cap 22 — these tests are
+written directly rather than re-exported.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _parse(text: str, session_id: str | None = None):
+    from src.governor.governor_mediator import GovernorMediator
+    return GovernorMediator.parse_governed_invocation(
+        text, session_id=session_id
+    )
+
+
+def _invocation(text: str):
+    from src.governor.governor_mediator import Invocation
+    result = _parse(text)
+    assert isinstance(result, Invocation), (
+        f"Expected Invocation for {text!r}, got {type(result).__name__}"
+    )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Folder-open intents → cap 22
+# ---------------------------------------------------------------------------
+
+def test_open_downloads_routes_to_cap22():
+    inv = _invocation("open my downloads folder")
+    assert inv.capability_id == 22
+
+
+def test_open_documents_routes_to_cap22():
+    inv = _invocation("open my documents folder")
+    assert inv.capability_id == 22
+
+
+def test_open_pictures_routes_to_cap22():
+    inv = _invocation("open my pictures folder")
+    assert inv.capability_id == 22
+
+
+# ---------------------------------------------------------------------------
+# Non-folder intents → NOT cap 22
+# ---------------------------------------------------------------------------
+
+def test_search_does_not_route_to_cap22():
+    result = _parse("search for latest AI news")
+    from src.governor.governor_mediator import Invocation
+    if isinstance(result, Invocation):
+        assert result.capability_id != 22, (
+            "Search intent should not route to cap 22"
+        )
+
+
+def test_email_does_not_route_to_cap22():
+    result = _parse("send an email to test@example.com")
+    from src.governor.governor_mediator import Invocation
+    if isinstance(result, Invocation):
+        assert result.capability_id != 22, (
+            "Email intent should not route to cap 22"
+        )

--- a/nova_backend/tests/certification/cap_22_open_file_folder/test_p3_integration.py
+++ b/nova_backend/tests/certification/cap_22_open_file_folder/test_p3_integration.py
@@ -1,0 +1,140 @@
+# tests/certification/cap_22_open_file_folder/test_p3_integration.py
+"""
+Phase 3 — Integration certification for capability 22 (open_file_folder).
+
+Tests the full Governor spine:
+  GovernorMediator → CapabilityRegistry → ExecuteBoundary
+  → LedgerWriter → OpenFolderExecutor → ActionResult
+
+Cap 22 requires confirmation (risk_level=confirm), so integration
+tests that exercise execution pass confirmed=True. The confirmation-
+gate itself is tested separately in the approval-gate regression suite.
+
+System-control open_path is mocked; no real folder opens.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.governor.governor import Governor
+
+
+_CAPABILITY_ID = 22
+_CAPABILITY_NAME = "open_file_folder"
+
+
+def _make_governor() -> Governor:
+    return Governor()
+
+
+# ---------------------------------------------------------------------------
+# Registry / capability checks
+# ---------------------------------------------------------------------------
+
+def test_cap_22_is_registered():
+    gov = _make_governor()
+    cap = gov.registry.get(_CAPABILITY_ID)
+    assert cap is not None
+    assert cap.name == _CAPABILITY_NAME
+
+
+def test_cap_22_is_enabled():
+    gov = _make_governor()
+    assert gov.registry.is_enabled(_CAPABILITY_ID) is True
+
+
+def test_cap_22_requires_confirmation():
+    gov = _make_governor()
+    cap = gov.registry.get(_CAPABILITY_ID)
+    assert cap.requires_confirmation is True
+
+
+# ---------------------------------------------------------------------------
+# Confirmation gate — unconfirmed requests are refused
+# ---------------------------------------------------------------------------
+
+def test_unconfirmed_request_is_refused():
+    gov = _make_governor()
+    result = gov.handle_governed_invocation(
+        _CAPABILITY_ID, {"target": "downloads"}
+    )
+    assert result.success is False
+
+
+# ---------------------------------------------------------------------------
+# Preset folder — happy path through full spine (confirmed)
+# ---------------------------------------------------------------------------
+
+def test_preset_folder_passes_through_spine(tmp_path: Path):
+    gov = _make_governor()
+    downloads = tmp_path / "Downloads"
+    downloads.mkdir()
+    with patch(
+        "src.executors.open_folder_executor.PRESET_FOLDERS",
+        {"downloads": downloads},
+    ), patch(
+        "src.system_control.system_control_executor"
+        ".SystemControlExecutor.open_path",
+        return_value=True,
+    ):
+        result = gov.handle_governed_invocation(
+            _CAPABILITY_ID,
+            {"target": "downloads", "confirmed": True},
+        )
+    assert result.success is True
+
+
+def test_missing_path_returns_failure():
+    gov = _make_governor()
+    result = gov.handle_governed_invocation(
+        _CAPABILITY_ID,
+        {
+            "path": "/nonexistent/path/that/does/not/exist_cert22",
+            "confirmed": True,
+        },
+    )
+    assert result.success is False
+
+
+# ---------------------------------------------------------------------------
+# Ledger events
+# ---------------------------------------------------------------------------
+
+def test_spine_logs_action_attempted(tmp_path: Path):
+    gov = _make_governor()
+    logged: list[str] = []
+    original = gov.ledger.log_event
+
+    def _capture(event_type, payload):
+        logged.append(event_type)
+        return original(event_type, payload)
+
+    gov.ledger.log_event = _capture
+    downloads = tmp_path / "Downloads"
+    downloads.mkdir()
+    with patch(
+        "src.executors.open_folder_executor.PRESET_FOLDERS",
+        {"downloads": downloads},
+    ), patch(
+        "src.system_control.system_control_executor"
+        ".SystemControlExecutor.open_path",
+        return_value=True,
+    ):
+        gov.handle_governed_invocation(
+            _CAPABILITY_ID,
+            {"target": "downloads", "confirmed": True},
+        )
+    assert "ACTION_ATTEMPTED" in logged
+
+
+# ---------------------------------------------------------------------------
+# Governance fence
+# ---------------------------------------------------------------------------
+
+def test_unknown_capability_still_refused():
+    gov = _make_governor()
+    result = gov.handle_governed_invocation(9999, {})
+    assert result.success is False

--- a/nova_backend/tests/certification/cap_65_shopify_intelligence_report/test_p1_unit.py
+++ b/nova_backend/tests/certification/cap_65_shopify_intelligence_report/test_p1_unit.py
@@ -1,0 +1,12 @@
+# tests/certification/cap_65_shopify_intelligence_report/test_p1_unit.py
+"""
+Phase 1 — Unit certification for capability 65 (shopify_intelligence_report).
+
+Re-exports the canonical executor unit tests into the certification
+pipeline. When this capability is locked, CI enforces these pass on
+every commit.
+
+Canonical unit tests:
+  tests/executors/test_shopify_intelligence_report_executor.py
+"""
+from tests.executors.test_shopify_intelligence_report_executor import *  # noqa: F401,F403

--- a/nova_backend/tests/certification/cap_65_shopify_intelligence_report/test_p2_routing.py
+++ b/nova_backend/tests/certification/cap_65_shopify_intelligence_report/test_p2_routing.py
@@ -1,0 +1,7 @@
+# tests/certification/cap_65_shopify_intelligence_report/test_p2_routing.py
+"""
+Phase 2 — Routing certification for capability 65 (shopify_intelligence_report).
+
+Re-exports all routing tests from the canonical file.
+"""
+from tests.test_shopify_intelligence_report_routing import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary

- Create full certification directory for **Cap 22** (`open_file_folder`): `test_p1_unit.py` (re-exports executor tests), `test_p2_routing.py` (5 routing assertions), `test_p3_integration.py` (8 governor spine tests including confirmation gate)
- Add missing **Cap 65** (`shopify_intelligence_report`) files: `test_p1_unit.py` (re-exports executor tests), `test_p2_routing.py` (re-exports routing tests)
- All 4 locked capabilities (16, 22, 64, 65) now pass `test_lock_regression_guard.py` (22/22 guard tests)

## Test plan

- [x] 22/22 lock regression guard tests pass
- [x] 68 new/re-exported certification tests pass (0 failures)
- [x] Full certification suite passes (exit code 0)
- [ ] Visual review: no runtime changes, test-only additions

🤖 Generated with [Claude Code](https://claude.com/claude-code)