### PR TITLE
fix: exempt capability help from frontend collapse (Issue #142)

### DIFF
--- a/nova_backend/static/dashboard-chat-news.js
+++ b/nova_backend/static/dashboard-chat-news.js
@@ -367,9 +367,16 @@ function renderMessageHighlights(container, highlights) {
   container.appendChild(card);
 }
 
+function shouldSkipCollapse(text) {
+  // Structured help responses should never be collapsed — they are
+  // intentionally multi-line lists, not casual long answers.
+  return String(text || "").trim().startsWith("Here's what Nova can do right now:");
+}
+
 function shouldCollapseMessage(text) {
   const raw = String(text || "");
   if (!raw.trim()) return false;
+  if (shouldSkipCollapse(raw)) return false;
   if (/https?:\/\/\S+/i.test(raw)) return false;
   const lines = raw.split(/\r?\n/).filter((line) => line.trim().length > 0);
   return raw.length > LONG_MESSAGE_CHAR_LIMIT || lines.length > LONG_MESSAGE_LINE_LIMIT;


### PR DESCRIPTION
## Summary

- Root cause identified: RS-2 capability help response (1199 chars, 16 lines) was collapsed to a 2-line preview by `shouldCollapseMessage()` because it exceeded `LONG_MESSAGE_CHAR_LIMIT=280` and `LONG_MESSAGE_LINE_LIMIT=4`
- Fix: add `shouldSkipCollapse()` that exempts structured help responses starting with "Here's what Nova can do right now:" from collapse
- Generic long messages still collapse normally
- Frontend-only change — no backend, WebSocket, or capability modifications

## Investigation findings

| Layer | Status |
|-------|--------|
| Backend `_capability_help_message()` | Complete (1199 chars) |
| Personality agent pass | Complete (no data loss) |
| WebSocket `ws_send()` | Complete (no size limit) |
| Frontend `appendChatMessage()` | **Collapsed to 2-line preview** (root cause) |

## Test plan

- [x] Investigation confirmed root cause is frontend-only
- [x] `shouldSkipCollapse` returns true for capability help prefix
- [x] `shouldCollapseMessage` still collapses generic long messages
- [x] URL-containing messages still exempt from collapse (existing behavior preserved)

Closes #142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)