### PR TITLE
fix: preamble-tolerant routing for deterministic commands

### DIFF
--- a/nova_backend/src/conversation/response_style_router.py
+++ b/nova_backend/src/conversation/response_style_router.py
@@ -153,7 +153,11 @@ class InputNormalizer:
     POLITE_PREFIX_RE = re.compile(
         r"^\s*(?:hey\s+nova[, ]*|ok(?:ay)?\s+nova[, ]*|nova[, ]*|please[, ]*|"
         r"can you\s+|could you\s+|would you\s+|can u\s+|could u\s+|would u\s+|"
-        r"i need to\s+)",
+        r"i need to\s+|"
+        # Conversational preambles (Issue #214 — preamble-tolerant routing)
+        r"also[, ]+|and\s+also[, ]+|by the way[, ]+|anyway[, ]+|"
+        r"oh and[, ]+|oh[, ]+|one more thing[, ]+|plus[, ]+|"
+        r"so[, ]+|ok so[, ]+|alright[, ]+|hey[, ]+)",
         re.IGNORECASE,
     )
     POLITE_SUFFIX_RE = re.compile(r"(?:,\s*please|\s+please)\s*$", re.IGNORECASE)

--- a/nova_backend/tests/websocket/test_session_layer_pipeline.py
+++ b/nova_backend/tests/websocket/test_session_layer_pipeline.py
@@ -280,6 +280,58 @@ class TestGovernorRoutingPipeline:
 
 
 # ---------------------------------------------------------------------------
+# Preamble-tolerant routing (Issue #214)
+# Conversational preambles must be stripped so deterministic routes
+# still fire. The preamble should not cause fallthrough to LLM.
+# ---------------------------------------------------------------------------
+
+class TestPreambleTolerantRouting:
+    """Conversational preambles should not break deterministic routing."""
+
+    # Each tuple: (preamble + target, expected result matching bare target)
+    @pytest.mark.parametrize("raw,expected", [
+        # "also" variants
+        ("also, what is the weather", 55),
+        ("also search for AI news", 16),
+        ("also, open my downloads folder", 22),
+        # "by the way" variants
+        ("by the way, what is the weather", 55),
+        # "anyway" variants
+        ("anyway, what is the weather", 55),
+        # "oh and" / "oh" variants
+        ("oh and what is the weather", 55),
+        ("oh, search for AI news", 16),
+        # other preambles
+        ("one more thing, what is the weather", 55),
+        ("so, what is the weather", 55),
+        ("ok so what is the weather", 55),
+        ("alright, search for AI news", 16),
+        ("plus what is the weather", 55),
+        ("and also, what is the weather", 55),
+    ])
+    def test_preamble_routes_to_correct_cap(self, raw: str, expected: int):
+        result = _pipeline(raw)
+        assert result == expected, (
+            f"{repr(raw)} should route to cap {expected} after preamble "
+            f"stripping; got {result!r}"
+        )
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("also, what can you do", "CAPABILITY_HELP"),
+        ("by the way, what can you do", "CAPABILITY_HELP"),
+        ("anyway, what time is it", "TIME_QUERY"),
+        ("oh and what time is it", "TIME_QUERY"),
+        ("so, what can you do", "CAPABILITY_HELP"),
+    ])
+    def test_preamble_routes_to_session_layer(self, raw: str, expected: str):
+        result = _pipeline(raw)
+        assert result == expected, (
+            f"{repr(raw)} should route to {expected} after preamble "
+            f"stripping; got {result!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Ambient clarification — only fires without prior context
 # (context guard tested at the handler level; here we test pattern matching)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Extend `POLITE_PREFIX_RE` in `InputNormalizer` to strip conversational preambles before routing
- New preambles: `also`, `by the way`, `anyway`, `oh and`, `one more thing`, `so`, `ok so`, `alright`, `plus`, `and also`, `oh`, `hey`
- Previously "also, what is the weather" fell through to LLM fallback; now routes to cap 55
- Add `TestPreambleTolerantRouting` class (18 tests) for preamble + governor/session-layer targets

## Investigation (PR #225)

Preamble routing was 60/60 broken (100% failure rate) across 15 preamble variants x 4 deterministic targets. This was the only deterministic fix identified in the #214 investigation — the remaining 12 failures are LLM/hardware-bound.

## Test plan

- [x] 127/127 session layer pipeline tests pass (18 new + 109 existing)
- [x] 461/461 routing regression pass (conversation + governance + simulation)
- [x] 45/45 preamble+target combos match bare-command routing
- [x] No GovernorMediator changes, no session handler changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)