### PR TITLE
feat: Goal Card local display-state

### DIFF
--- a/Nova-Frontend-Dashboard/dashboard.js
+++ b/Nova-Frontend-Dashboard/dashboard.js
@@ -2111,6 +2111,693 @@ function renderMemoryCenterSurface() {
     : "Edit, lock, unlock, defer, and delete stay governed. This page now adds an inline check before state-changing requests are sent.";
 }
 
+/* ── Goal Cards (display-only prototype) ───────────────────────────── */
+
+/**
+ * Demo goal card data. This is static/demo state only.
+ * No execution, no scheduler, no persistence, no backend authority.
+ * Planning is not authority. Goal state is not permission.
+ */
+const DEMO_GOAL_CARDS = [
+  {
+    goal_id: "goal_auralis_launch_001",
+    title: "Prepare Auralis Shopify launch",
+    status: "planning",
+    created_at: "2026-05-22T12:00:00Z",
+    updated_at: "2026-05-22T14:30:00Z",
+    steps: [
+      {
+        step_id: "step_001",
+        title: "Run read-only Shopify intelligence report",
+        status: "completed",
+        required_capability: 65,
+        approval_required: false,
+      },
+      {
+        step_id: "step_002",
+        title: "Summarize products, inventory, and order signals",
+        status: "completed",
+        required_capability: null,
+        approval_required: false,
+      },
+      {
+        step_id: "step_003",
+        title: "Draft a launch checklist",
+        status: "running",
+        required_capability: null,
+        approval_required: false,
+      },
+      {
+        step_id: "step_004",
+        title: "Draft outreach email for user review",
+        status: "planned",
+        required_capability: 64,
+        approval_required: true,
+      },
+      {
+        step_id: "step_005",
+        title: "Wait for user approval before any external effect",
+        status: "planned",
+        required_capability: null,
+        approval_required: true,
+      },
+    ],
+    permission_envelope: {
+      allowed_capabilities: [
+        { id: 16, name: "Web search" },
+        { id: 22, name: "Open folder" },
+        { id: 64, name: "Email draft" },
+        { id: 65, name: "Shopify read" },
+      ],
+      blocked_actions: [
+        "Shopify writes",
+        "Printify",
+        "Purchases",
+        "Publishing",
+        "Browser control",
+        "Customer messages",
+      ],
+      requires_confirmation: [22, 64],
+    },
+    ledger_refs: [
+      { type: "ACTION_COMPLETED", capability_id: 65,
+        summary: "Shopify intelligence report (read-only)" },
+      { type: "ACTION_COMPLETED", capability_id: null,
+        summary: "Product/inventory summary generated" },
+    ],
+  },
+  {
+    goal_id: "goal_repo_cleanup_002",
+    title: "Clean up Nova repo continuity",
+    status: "completed",
+    created_at: "2026-05-21T09:00:00Z",
+    updated_at: "2026-05-22T00:23:00Z",
+    steps: [
+      {
+        step_id: "step_010",
+        title: "Review current priority and active TODO docs",
+        status: "completed",
+        required_capability: null,
+        approval_required: false,
+      },
+      {
+        step_id: "step_011",
+        title: "Identify stale or conflicting docs",
+        status: "completed",
+        required_capability: null,
+        approval_required: false,
+      },
+      {
+        step_id: "step_012",
+        title: "Draft cleanup plan",
+        status: "completed",
+        required_capability: null,
+        approval_required: false,
+      },
+      {
+        step_id: "step_013",
+        title: "Apply changes after approval",
+        status: "completed",
+        required_capability: 22,
+        approval_required: true,
+      },
+    ],
+    permission_envelope: {
+      allowed_capabilities: [
+        { id: 16, name: "Web search" },
+        { id: 22, name: "Open folder" },
+      ],
+      blocked_actions: [
+        "Delete branches",
+        "Merge PRs",
+        "Modify runtime",
+        "Change locks",
+      ],
+      requires_confirmation: [22],
+    },
+    ledger_refs: [
+      { type: "ACTION_COMPLETED", capability_id: 22,
+        summary: "Opened docs folder for review" },
+    ],
+  },
+  {
+    goal_id: "goal_blocked_example_003",
+    title: "Set up Printify integration",
+    status: "blocked",
+    created_at: "2026-05-22T15:00:00Z",
+    updated_at: "2026-05-22T15:00:00Z",
+    steps: [
+      {
+        step_id: "step_020",
+        title: "Connect Printify API",
+        status: "blocked",
+        required_capability: null,
+        approval_required: true,
+      },
+    ],
+    permission_envelope: {
+      allowed_capabilities: [],
+      blocked_actions: [
+        "Printify API",
+        "External writes",
+        "Product creation",
+        "Order management",
+      ],
+      requires_confirmation: [],
+    },
+    ledger_refs: [],
+  },
+];
+
+const STEP_INDICATORS = {
+  planned: "·",
+  proposed: "?",
+  waiting_for_approval: "!",
+  approved: "✓",
+  running: "▶",
+  completed: "✓",
+  failed: "✗",
+  blocked: "‒",
+  skipped: "–",
+  canceled: "–",
+};
+
+/* ── Goal Card local display-state ─────────────────────────────────── */
+/* Pure frontend state: expand/collapse, selection, filtering, sorting.
+ * No execution authority. No backend persistence.
+ * localStorage used only for UI preferences (expanded cards, filters). */
+
+var _goalDisplayState = {
+  expandedCards: {},   // goal_id → true/false
+  selectedCard: null,  // goal_id or null
+  activeFilter: null,  // status string or null (show all)
+  sortMode: "updated", // "updated" or "status"
+};
+
+function _loadGoalDisplayState() {
+  try {
+    var raw = localStorage.getItem("nova_goal_display_state");
+    if (raw) {
+      var parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === "object") {
+        _goalDisplayState.expandedCards = parsed.expandedCards || {};
+        _goalDisplayState.activeFilter = parsed.activeFilter || null;
+        _goalDisplayState.sortMode = parsed.sortMode || "updated";
+      }
+    }
+  } catch (_e) { /* ignore corrupt localStorage */ }
+}
+
+function _saveGoalDisplayState() {
+  try {
+    localStorage.setItem("nova_goal_display_state", JSON.stringify({
+      expandedCards: _goalDisplayState.expandedCards,
+      activeFilter: _goalDisplayState.activeFilter,
+      sortMode: _goalDisplayState.sortMode,
+    }));
+  } catch (_e) { /* quota or private browsing */ }
+}
+
+function _toggleGoalExpanded(goalId) {
+  _goalDisplayState.expandedCards[goalId] =
+    !_goalDisplayState.expandedCards[goalId];
+  _saveGoalDisplayState();
+  renderGoalCardsPage();
+}
+
+function _selectGoalCard(goalId) {
+  _goalDisplayState.selectedCard =
+    _goalDisplayState.selectedCard === goalId ? null : goalId;
+  renderGoalCardsPage();
+}
+
+function _setGoalFilter(status) {
+  _goalDisplayState.activeFilter =
+    _goalDisplayState.activeFilter === status ? null : status;
+  _saveGoalDisplayState();
+  renderGoalCardsPage();
+}
+
+function _setGoalSort(mode) {
+  _goalDisplayState.sortMode = mode;
+  _saveGoalDisplayState();
+  renderGoalCardsPage();
+}
+
+function _getGoalProgress(goal) {
+  if (!Array.isArray(goal.steps) || goal.steps.length === 0) {
+    return { completed: 0, total: 0, pct: 0 };
+  }
+  var completed = goal.steps.filter(function (s) {
+    return s.status === "completed";
+  }).length;
+  return {
+    completed: completed,
+    total: goal.steps.length,
+    pct: Math.round((completed / goal.steps.length) * 100),
+  };
+}
+
+var GOAL_STATUS_ORDER = {
+  running: 0, waiting_for_approval: 1, ready: 2, planning: 3,
+  blocked: 4, paused: 5, draft: 6, completed: 7, canceled: 8, failed: 9,
+};
+
+function _sortGoals(goals, mode) {
+  var sorted = goals.slice();
+  if (mode === "status") {
+    sorted.sort(function (a, b) {
+      var oa = GOAL_STATUS_ORDER[a.status] != null
+        ? GOAL_STATUS_ORDER[a.status] : 99;
+      var ob = GOAL_STATUS_ORDER[b.status] != null
+        ? GOAL_STATUS_ORDER[b.status] : 99;
+      if (oa !== ob) return oa - ob;
+      return (b.updated_at || "").localeCompare(a.updated_at || "");
+    });
+  } else {
+    sorted.sort(function (a, b) {
+      return (b.updated_at || "").localeCompare(a.updated_at || "");
+    });
+  }
+  return sorted;
+}
+
+/* ── End display-state helpers ────────────────────────────────────── */
+
+function createGoalCardElement(goal) {
+  var isExpanded = !!_goalDisplayState.expandedCards[goal.goal_id];
+  var isSelected = _goalDisplayState.selectedCard === goal.goal_id;
+  var progress = _getGoalProgress(goal);
+
+  const card = document.createElement("article");
+  card.className = "goal-card";
+  if (isExpanded) card.classList.add("goal-card--expanded");
+  if (isSelected) card.classList.add("goal-card--selected");
+  card.dataset.goalId = goal.goal_id;
+  card.dataset.goalStatus = goal.status || "draft";
+
+  // Header: title + progress + status badge (always visible)
+  const header = document.createElement("div");
+  header.className = "goal-card-header";
+  header.style.cursor = "pointer";
+  header.setAttribute("role", "button");
+  header.setAttribute("aria-expanded", String(isExpanded));
+  header.setAttribute("tabindex", "0");
+  header.title = isExpanded ? "Collapse details" : "Expand details";
+
+  // Expand chevron
+  const chevron = document.createElement("span");
+  chevron.className = "goal-card-chevron";
+  chevron.textContent = isExpanded ? "▾" : "▸";
+  chevron.setAttribute("aria-hidden", "true");
+  header.appendChild(chevron);
+
+  const title = document.createElement("h4");
+  title.className = "goal-card-title";
+  title.textContent = String(goal.title || "Untitled goal").trim();
+  header.appendChild(title);
+
+  const badge = document.createElement("span");
+  badge.className = "goal-card-status";
+  badge.dataset.status = goal.status || "draft";
+  badge.textContent = (goal.status || "draft").replace(/_/g, " ");
+  header.appendChild(badge);
+
+  // Click header to expand/collapse
+  header.addEventListener("click", function (e) {
+    e.stopPropagation();
+    _toggleGoalExpanded(goal.goal_id);
+  });
+  header.addEventListener("keydown", function (e) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      _toggleGoalExpanded(goal.goal_id);
+    }
+  });
+
+  card.appendChild(header);
+
+  // Progress bar (always visible, below header)
+  if (progress.total > 0) {
+    const progressWrap = document.createElement("div");
+    progressWrap.className = "goal-card-progress";
+
+    const progressBar = document.createElement("div");
+    progressBar.className = "goal-card-progress-bar";
+
+    const progressFill = document.createElement("div");
+    progressFill.className = "goal-card-progress-fill";
+    progressFill.style.width = progress.pct + "%";
+    progressFill.dataset.goalStatus = goal.status || "draft";
+    progressBar.appendChild(progressFill);
+    progressWrap.appendChild(progressBar);
+
+    const progressLabel = document.createElement("span");
+    progressLabel.className = "goal-card-progress-label";
+    progressLabel.textContent = progress.completed + "/" + progress.total
+      + " steps";
+    progressWrap.appendChild(progressLabel);
+
+    card.appendChild(progressWrap);
+  }
+
+  // Collapsible body
+  const body = document.createElement("div");
+  body.className = "goal-card-body";
+  if (!isExpanded) body.hidden = true;
+
+  // Steps
+  if (Array.isArray(goal.steps) && goal.steps.length > 0) {
+    const stepsLabel = document.createElement("p");
+    stepsLabel.className = "goal-card-section-label";
+    stepsLabel.textContent = "Steps";
+    body.appendChild(stepsLabel);
+
+    const stepsList = document.createElement("div");
+    stepsList.className = "goal-card-steps";
+
+    goal.steps.forEach(function (step) {
+      const stepEl = document.createElement("div");
+      stepEl.className = "goal-card-step";
+      stepEl.dataset.stepStatus = step.status || "planned";
+
+      const indicator = document.createElement("span");
+      indicator.className = "goal-card-step-indicator";
+      indicator.textContent = STEP_INDICATORS[step.status] || "·";
+      stepEl.appendChild(indicator);
+
+      const stepTitle = document.createElement("span");
+      stepTitle.className = "goal-card-step-title";
+      stepTitle.textContent = String(step.title || "").trim();
+      if (step.approval_required && step.status !== "completed") {
+        stepTitle.textContent += " (approval required)";
+      }
+      stepEl.appendChild(stepTitle);
+
+      stepsList.appendChild(stepEl);
+    });
+
+    body.appendChild(stepsList);
+  }
+
+  // Permission envelope
+  var env = goal.permission_envelope;
+  if (env) {
+    const envLabel = document.createElement("p");
+    envLabel.className = "goal-card-section-label";
+    envLabel.textContent = "Permission envelope";
+    body.appendChild(envLabel);
+
+    const envGrid = document.createElement("div");
+    envGrid.className = "goal-card-envelope";
+
+    // Allowed column
+    if (Array.isArray(env.allowed_capabilities)
+        && env.allowed_capabilities.length > 0) {
+      const allowedCol = document.createElement("div");
+      allowedCol.className = "goal-card-envelope-col";
+
+      const allowedLabel = document.createElement("p");
+      allowedLabel.className = "goal-card-section-label";
+      allowedLabel.textContent = "Allowed";
+      allowedCol.appendChild(allowedLabel);
+
+      const allowedTags = document.createElement("div");
+      allowedTags.className = "goal-card-tag-list";
+      env.allowed_capabilities.forEach(function (cap) {
+        const tag = document.createElement("span");
+        tag.className = "goal-card-tag allowed";
+        tag.textContent = cap.name || ("Cap " + cap.id);
+        allowedTags.appendChild(tag);
+      });
+      allowedCol.appendChild(allowedTags);
+      envGrid.appendChild(allowedCol);
+    }
+
+    // Blocked column
+    if (Array.isArray(env.blocked_actions)
+        && env.blocked_actions.length > 0) {
+      const blockedCol = document.createElement("div");
+      blockedCol.className = "goal-card-envelope-col";
+
+      const blockedLabel = document.createElement("p");
+      blockedLabel.className = "goal-card-section-label";
+      blockedLabel.textContent = "Blocked";
+      blockedCol.appendChild(blockedLabel);
+
+      const blockedTags = document.createElement("div");
+      blockedTags.className = "goal-card-tag-list";
+      env.blocked_actions.forEach(function (action) {
+        const tag = document.createElement("span");
+        tag.className = "goal-card-tag blocked";
+        tag.textContent = String(action);
+        blockedTags.appendChild(tag);
+      });
+      blockedCol.appendChild(blockedTags);
+      envGrid.appendChild(blockedCol);
+    }
+
+    body.appendChild(envGrid);
+  }
+
+  // Receipt references
+  if (Array.isArray(goal.ledger_refs) && goal.ledger_refs.length > 0) {
+    const receiptsLabel = document.createElement("p");
+    receiptsLabel.className = "goal-card-section-label";
+    receiptsLabel.textContent = "Receipts";
+    body.appendChild(receiptsLabel);
+
+    const receiptsList = document.createElement("div");
+    receiptsList.className = "goal-card-receipts";
+
+    goal.ledger_refs.forEach(function (ref) {
+      const receiptEl = document.createElement("div");
+      receiptEl.className = "goal-card-receipt";
+
+      const dot = document.createElement("span");
+      dot.className = "goal-card-receipt-dot";
+      dot.classList.add(
+        ref.type === "ACTION_COMPLETED" ? "completed" : "attempted"
+      );
+      receiptEl.appendChild(dot);
+
+      if (ref.capability_id != null) {
+        const capBadge = document.createElement("span");
+        capBadge.className = "goal-card-receipt-cap";
+        capBadge.textContent = "Cap " + ref.capability_id;
+        receiptEl.appendChild(capBadge);
+      }
+
+      const text = document.createElement("span");
+      text.textContent = String(ref.summary || ref.type || "");
+      receiptEl.appendChild(text);
+
+      receiptsList.appendChild(receiptEl);
+    });
+
+    body.appendChild(receiptsList);
+  }
+
+  // Actions (inert UI only — display-only prototype)
+  const actions = document.createElement("div");
+  actions.className = "goal-card-actions";
+
+  var pauseBtn = document.createElement("button");
+  pauseBtn.type = "button";
+  pauseBtn.className = "goal-card-action-btn";
+  pauseBtn.textContent = goal.status === "paused" ? "Resume" : "Pause";
+  pauseBtn.disabled = true;
+  pauseBtn.title = "Display only — not connected to execution yet";
+  pauseBtn.setAttribute("aria-label",
+    (goal.status === "paused" ? "Resume" : "Pause")
+    + " (display only)");
+  actions.appendChild(pauseBtn);
+
+  var cancelBtn = document.createElement("button");
+  cancelBtn.type = "button";
+  cancelBtn.className = "goal-card-action-btn destructive";
+  cancelBtn.textContent = "Cancel";
+  cancelBtn.disabled = true;
+  cancelBtn.title = "Display only — not connected to execution yet";
+  cancelBtn.setAttribute("aria-label", "Cancel (display only)");
+  actions.appendChild(cancelBtn);
+
+  body.appendChild(actions);
+
+  // Updated timestamp
+  if (goal.updated_at) {
+    const updated = document.createElement("div");
+    updated.className = "goal-card-updated";
+    try {
+      updated.textContent = "Updated "
+        + new Date(goal.updated_at).toLocaleString();
+    } catch (_e) {
+      updated.textContent = "Updated " + goal.updated_at;
+    }
+    body.appendChild(updated);
+  }
+
+  card.appendChild(body);
+
+  // Click card body to select (not the header, which toggles expand)
+  card.addEventListener("click", function () {
+    _selectGoalCard(goal.goal_id);
+  });
+
+  return card;
+}
+
+var GOAL_STATUS_LEGEND = [
+  { key: "draft", label: "Draft" },
+  { key: "planning", label: "Planning" },
+  { key: "waiting", label: "Waiting for approval" },
+  { key: "ready", label: "Ready" },
+  { key: "running", label: "Running" },
+  { key: "paused", label: "Paused" },
+  { key: "completed", label: "Completed" },
+  { key: "blocked", label: "Blocked" },
+  { key: "canceled", label: "Canceled" },
+];
+
+function renderGoalStatusLegend() {
+  var legendWidget = $("goal-status-legend");
+  if (!legendWidget) return;
+  var host = legendWidget.querySelector(".goal-legend-items");
+  if (!host || host.children.length > 0) return;
+
+  GOAL_STATUS_LEGEND.forEach(function (entry) {
+    var item = document.createElement("span");
+    item.className = "goal-legend-item";
+    item.style.cursor = "pointer";
+    item.title = "Filter by " + entry.label;
+    if (_goalDisplayState.activeFilter === entry.key) {
+      item.classList.add("goal-legend-item--active");
+    }
+
+    var dot = document.createElement("span");
+    dot.className = "goal-legend-dot";
+    dot.dataset.legend = entry.key;
+    item.appendChild(dot);
+
+    var label = document.createElement("span");
+    label.textContent = entry.label;
+    item.appendChild(label);
+
+    item.addEventListener("click", function () {
+      _setGoalFilter(entry.key);
+    });
+
+    host.appendChild(item);
+  });
+}
+
+function _renderGoalToolbar() {
+  var existing = $("goal-toolbar");
+  if (existing) existing.remove();
+
+  var toolbar = document.createElement("div");
+  toolbar.id = "goal-toolbar";
+  toolbar.className = "goal-toolbar";
+
+  // Sort toggle
+  var sortGroup = document.createElement("div");
+  sortGroup.className = "goal-toolbar-group";
+
+  var sortLabel = document.createElement("span");
+  sortLabel.className = "goal-toolbar-label";
+  sortLabel.textContent = "Sort:";
+  sortGroup.appendChild(sortLabel);
+
+  ["updated", "status"].forEach(function (mode) {
+    var btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "goal-toolbar-btn";
+    if (_goalDisplayState.sortMode === mode) {
+      btn.classList.add("active");
+    }
+    btn.textContent = mode === "updated" ? "Recent" : "By status";
+    btn.addEventListener("click", function () { _setGoalSort(mode); });
+    sortGroup.appendChild(btn);
+  });
+
+  toolbar.appendChild(sortGroup);
+
+  // Filter indicator
+  if (_goalDisplayState.activeFilter) {
+    var clearBtn = document.createElement("button");
+    clearBtn.type = "button";
+    clearBtn.className = "goal-toolbar-btn goal-toolbar-clear";
+    clearBtn.textContent = "Clear filter: "
+      + _goalDisplayState.activeFilter.replace(/_/g, " ");
+    clearBtn.addEventListener("click", function () {
+      _setGoalFilter(null);
+    });
+    toolbar.appendChild(clearBtn);
+  }
+
+  return toolbar;
+}
+
+function renderGoalCardsPage() {
+  _loadGoalDisplayState();
+
+  var container = $("goal-cards-container");
+  var emptyState = $("goal-cards-empty");
+  if (!container) return;
+
+  container.innerHTML = "";
+
+  var goals = DEMO_GOAL_CARDS;
+  var hasGoals = Array.isArray(goals) && goals.length > 0;
+
+  // Filter
+  if (_goalDisplayState.activeFilter && hasGoals) {
+    goals = goals.filter(function (g) {
+      return g.status === _goalDisplayState.activeFilter;
+    });
+  }
+
+  // Sort
+  goals = _sortGoals(goals, _goalDisplayState.sortMode);
+
+  var hasVisible = goals.length > 0;
+
+  if (emptyState) {
+    emptyState.hidden = hasVisible;
+    if (!hasVisible && _goalDisplayState.activeFilter) {
+      emptyState.hidden = false;
+      var emptyTitle = emptyState.querySelector(".goal-empty-title");
+      if (emptyTitle) {
+        emptyTitle.textContent = "No "
+          + _goalDisplayState.activeFilter.replace(/_/g, " ")
+          + " goals";
+      }
+    }
+  }
+
+  // Insert toolbar before cards
+  var heroWidget = container.parentElement
+    && container.parentElement.querySelector(".goal-page-hero");
+  var toolbarEl = _renderGoalToolbar();
+  if (heroWidget && heroWidget.nextSibling) {
+    // Insert after legend, before container
+    var legendEl = $("goal-status-legend");
+    var insertBefore = legendEl
+      ? legendEl.nextSibling : container;
+    container.parentElement.insertBefore(toolbarEl, insertBefore);
+  }
+
+  if (hasVisible) {
+    goals.forEach(function (goal) {
+      container.appendChild(createGoalCardElement(goal));
+    });
+  }
+
+  renderGoalStatusLegend();
+}
+
+/* ── End Goal Cards ────────────────────────────────────────────────── */
+
 /* Control-center surfaces moved to dashboard-control-center.js. */
 
 /* Chat, news, and general interaction surfaces moved to dashboard-chat-news.js. */

--- a/Nova-Frontend-Dashboard/style.phase1.css
+++ b/Nova-Frontend-Dashboard/style.phase1.css
@@ -657,6 +657,573 @@ body {
   cursor: not-allowed;
 }
 
+/* ── Goal Cards ──────────────────────────────────────────── */
+
+.page-goals {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  grid-template-rows: auto;
+  gap: 10px;
+}
+
+.goal-page-hero {
+  display: grid;
+  gap: 8px;
+  padding: 14px;
+}
+
+.goal-page-hero-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.goal-demo-badge {
+  flex-shrink: 0;
+  padding: 4px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(246, 203, 143, 0.3);
+  background: rgba(246, 203, 143, 0.08);
+  color: var(--warn);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.goal-page-kicker {
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.goal-page-title-row {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.goal-page-title-row h3 {
+  margin: 0;
+}
+
+.goal-page-intro {
+  margin: 0;
+  font-size: 0.88rem;
+  line-height: 1.5;
+  color: #d6e6fb;
+}
+
+.goal-cards-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: 12px;
+}
+
+.goal-card {
+  display: grid;
+  gap: 10px;
+  padding: 14px;
+  border-radius: var(--radius);
+  border: 1px solid rgba(143, 218, 255, 0.18);
+  background: linear-gradient(
+    160deg,
+    rgba(16, 34, 58, 0.92) 0%,
+    rgba(8, 19, 36, 0.94) 100%
+  );
+  box-shadow: var(--shadow-panel);
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.goal-card--selected {
+  border-color: rgba(104, 177, 255, 0.45);
+  box-shadow: var(--shadow-panel), 0 0 0 1px rgba(104, 177, 255, 0.2);
+}
+
+.goal-card[data-goal-status="blocked"] {
+  border-color: rgba(255, 130, 130, 0.25);
+  background: linear-gradient(
+    160deg,
+    rgba(40, 20, 24, 0.92) 0%,
+    rgba(20, 10, 14, 0.94) 100%
+  );
+}
+
+.goal-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.goal-card-header:hover {
+  opacity: 0.9;
+}
+
+.goal-card-chevron {
+  flex-shrink: 0;
+  width: 16px;
+  font-size: 0.82rem;
+  color: var(--muted);
+  padding-top: 2px;
+}
+
+/* Progress bar */
+
+.goal-card-progress {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.goal-card-progress-bar {
+  flex: 1;
+  height: 4px;
+  border-radius: 2px;
+  background: rgba(175, 198, 230, 0.12);
+  overflow: hidden;
+}
+
+.goal-card-progress-fill {
+  height: 100%;
+  border-radius: 2px;
+  background: var(--ok);
+  transition: width 0.3s ease;
+}
+
+.goal-card-progress-fill[data-goal-status="blocked"] {
+  background: #ff9a9a;
+}
+
+.goal-card-progress-fill[data-goal-status="paused"] {
+  background: var(--warn);
+}
+
+.goal-card-progress-label {
+  flex-shrink: 0;
+  font-size: 0.68rem;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+/* Collapsible body */
+
+.goal-card-body {
+  display: grid;
+  gap: 10px;
+}
+
+.goal-card-body[hidden] {
+  display: none;
+}
+
+.goal-card-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.goal-card-status {
+  flex-shrink: 0;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.goal-card-status[data-status="draft"] {
+  border: 1px solid rgba(168, 187, 220, 0.3);
+  background: rgba(168, 187, 220, 0.1);
+  color: var(--muted);
+}
+
+.goal-card-status[data-status="planning"] {
+  border: 1px solid rgba(104, 177, 255, 0.3);
+  background: rgba(104, 177, 255, 0.12);
+  color: var(--accent);
+}
+
+.goal-card-status[data-status="waiting_for_approval"] {
+  border: 1px solid rgba(246, 203, 143, 0.35);
+  background: rgba(246, 203, 143, 0.1);
+  color: var(--warn);
+}
+
+.goal-card-status[data-status="ready"] {
+  border: 1px solid rgba(106, 214, 188, 0.3);
+  background: rgba(106, 214, 188, 0.1);
+  color: var(--ok);
+}
+
+.goal-card-status[data-status="running"] {
+  border: 1px solid rgba(106, 214, 188, 0.4);
+  background: rgba(106, 214, 188, 0.15);
+  color: var(--ok);
+}
+
+.goal-card-status[data-status="paused"] {
+  border: 1px solid rgba(246, 203, 143, 0.3);
+  background: rgba(246, 203, 143, 0.08);
+  color: var(--warn);
+}
+
+.goal-card-status[data-status="completed"] {
+  border: 1px solid rgba(106, 214, 188, 0.35);
+  background: rgba(106, 214, 188, 0.12);
+  color: var(--ok);
+}
+
+.goal-card-status[data-status="blocked"],
+.goal-card-status[data-status="failed"] {
+  border: 1px solid rgba(255, 130, 130, 0.3);
+  background: rgba(255, 130, 130, 0.1);
+  color: #ff9a9a;
+}
+
+.goal-card-status[data-status="canceled"] {
+  border: 1px solid rgba(168, 187, 220, 0.2);
+  background: rgba(168, 187, 220, 0.06);
+  color: var(--muted);
+}
+
+.goal-card-section-label {
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #9dbde0;
+  margin: 0;
+}
+
+.goal-card-steps {
+  display: grid;
+  gap: 4px;
+}
+
+.goal-card-step {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(175, 198, 230, 0.12);
+  background: rgba(255, 255, 255, 0.03);
+  font-size: 0.82rem;
+  line-height: 1.4;
+  color: #e4efff;
+}
+
+.goal-card-step[data-step-status="completed"] {
+  border-color: rgba(106, 214, 188, 0.2);
+}
+
+.goal-card-step[data-step-status="running"] {
+  border-color: rgba(104, 177, 255, 0.3);
+  background: rgba(104, 177, 255, 0.06);
+}
+
+.goal-card-step[data-step-status="waiting_for_approval"] {
+  border-color: rgba(246, 203, 143, 0.25);
+  background: rgba(246, 203, 143, 0.05);
+}
+
+.goal-card-step[data-step-status="blocked"] {
+  border-color: rgba(255, 130, 130, 0.2);
+  opacity: 0.7;
+}
+
+.goal-card-step-indicator {
+  flex-shrink: 0;
+  width: 18px;
+  text-align: center;
+  font-size: 0.78rem;
+}
+
+.goal-card-step-title {
+  flex: 1;
+  min-width: 0;
+}
+
+.goal-card-envelope {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.goal-card-envelope-col {
+  display: grid;
+  gap: 4px;
+}
+
+.goal-card-tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.goal-card-tag {
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.goal-card-tag.allowed {
+  border: 1px solid rgba(106, 214, 188, 0.25);
+  background: rgba(106, 214, 188, 0.08);
+  color: var(--ok);
+}
+
+.goal-card-tag.blocked {
+  border: 1px solid rgba(255, 130, 130, 0.2);
+  background: rgba(255, 130, 130, 0.06);
+  color: #ff9a9a;
+}
+
+.goal-card-receipts {
+  display: grid;
+  gap: 4px;
+}
+
+.goal-card-receipt {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(175, 198, 230, 0.1);
+  background: rgba(255, 255, 255, 0.02);
+  font-size: 0.78rem;
+  color: var(--muted);
+}
+
+.goal-card-receipt-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.goal-card-receipt-dot.completed {
+  background: var(--ok);
+}
+
+.goal-card-receipt-dot.attempted {
+  background: var(--warn);
+}
+
+.goal-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding-top: 4px;
+  border-top: 1px solid var(--line);
+}
+
+.goal-card-action-btn {
+  padding: 7px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(143, 218, 255, 0.22);
+  background: rgba(104, 177, 255, 0.08);
+  color: #edf5ff;
+  font-size: 0.78rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.goal-card-action-btn:hover {
+  border-color: rgba(143, 218, 255, 0.4);
+  background: rgba(104, 177, 255, 0.16);
+}
+
+.goal-card-action-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.goal-card-action-btn.destructive {
+  border-color: rgba(255, 130, 130, 0.22);
+  background: rgba(255, 130, 130, 0.06);
+}
+
+.goal-card-action-btn.destructive:hover {
+  border-color: rgba(255, 130, 130, 0.4);
+  background: rgba(255, 130, 130, 0.12);
+}
+
+.goal-card-updated {
+  font-size: 0.72rem;
+  color: var(--muted);
+  text-align: right;
+}
+
+/* Goal Card — empty state */
+
+.goal-cards-empty {
+  display: grid;
+  gap: 8px;
+  justify-items: center;
+  text-align: center;
+  padding: 32px 14px;
+}
+
+.goal-empty-icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: 2px dashed rgba(143, 218, 255, 0.2);
+  background: rgba(104, 177, 255, 0.04);
+}
+
+.goal-empty-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.goal-empty-copy {
+  margin: 0;
+  max-width: 420px;
+  font-size: 0.84rem;
+  line-height: 1.5;
+  color: var(--muted);
+}
+
+/* Goal Card — status legend */
+
+.goal-status-legend {
+  display: grid;
+  gap: 8px;
+  padding: 12px 14px;
+}
+
+.goal-legend-items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.goal-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(175, 198, 230, 0.12);
+  background: rgba(255, 255, 255, 0.02);
+  font-size: 0.7rem;
+  color: var(--muted);
+}
+
+.goal-legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.goal-legend-dot[data-legend="draft"] { background: var(--muted); }
+.goal-legend-dot[data-legend="planning"] { background: var(--accent); }
+.goal-legend-dot[data-legend="waiting"] { background: var(--warn); }
+.goal-legend-dot[data-legend="ready"] { background: var(--ok); }
+.goal-legend-dot[data-legend="running"] { background: var(--ok); }
+.goal-legend-dot[data-legend="paused"] { background: var(--warn); }
+.goal-legend-dot[data-legend="completed"] { background: var(--ok); }
+.goal-legend-dot[data-legend="blocked"] { background: #ff9a9a; }
+.goal-legend-dot[data-legend="canceled"] { background: var(--muted); }
+
+.goal-legend-item--active {
+  border-color: rgba(104, 177, 255, 0.4);
+  background: rgba(104, 177, 255, 0.12);
+  color: var(--text);
+}
+
+/* Receipt capability badge */
+
+.goal-card-receipt-cap {
+  flex-shrink: 0;
+  padding: 1px 6px;
+  border-radius: 999px;
+  border: 1px solid rgba(143, 218, 255, 0.2);
+  background: rgba(104, 177, 255, 0.08);
+  font-size: 0.66rem;
+  font-weight: 700;
+  color: var(--accent);
+  white-space: nowrap;
+}
+
+/* Toolbar */
+
+.goal-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 14px;
+  flex-wrap: wrap;
+}
+
+.goal-toolbar-group {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.goal-toolbar-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--muted);
+  margin-right: 2px;
+}
+
+.goal-toolbar-btn {
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(175, 198, 230, 0.15);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
+}
+
+.goal-toolbar-btn:hover {
+  border-color: rgba(143, 218, 255, 0.3);
+  background: rgba(104, 177, 255, 0.08);
+  color: var(--text);
+}
+
+.goal-toolbar-btn.active {
+  border-color: rgba(104, 177, 255, 0.4);
+  background: rgba(104, 177, 255, 0.14);
+  color: var(--text);
+}
+
+.goal-toolbar-clear {
+  border-color: rgba(246, 203, 143, 0.25);
+  background: rgba(246, 203, 143, 0.06);
+  color: var(--warn);
+}
+
+.goal-toolbar-clear:hover {
+  border-color: rgba(246, 203, 143, 0.4);
+  background: rgba(246, 203, 143, 0.12);
+}
+
+/* ── End Goal Cards ──────────────────────────────────────── */
+
 .page-news {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
@@ -952,6 +1519,14 @@ body {
   }
 
   .live-help-steps {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .goal-cards-container {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .goal-card-envelope {
     grid-template-columns: minmax(0, 1fr);
   }
 

--- a/nova_backend/static/dashboard.js
+++ b/nova_backend/static/dashboard.js
@@ -2282,14 +2282,135 @@ const STEP_INDICATORS = {
   canceled: "–",
 };
 
+/* ── Goal Card local display-state ─────────────────────────────────── */
+/* Pure frontend state: expand/collapse, selection, filtering, sorting.
+ * No execution authority. No backend persistence.
+ * localStorage used only for UI preferences (expanded cards, filters). */
+
+var _goalDisplayState = {
+  expandedCards: {},   // goal_id → true/false
+  selectedCard: null,  // goal_id or null
+  activeFilter: null,  // status string or null (show all)
+  sortMode: "updated", // "updated" or "status"
+};
+
+function _loadGoalDisplayState() {
+  try {
+    var raw = localStorage.getItem("nova_goal_display_state");
+    if (raw) {
+      var parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === "object") {
+        _goalDisplayState.expandedCards = parsed.expandedCards || {};
+        _goalDisplayState.activeFilter = parsed.activeFilter || null;
+        _goalDisplayState.sortMode = parsed.sortMode || "updated";
+      }
+    }
+  } catch (_e) { /* ignore corrupt localStorage */ }
+}
+
+function _saveGoalDisplayState() {
+  try {
+    localStorage.setItem("nova_goal_display_state", JSON.stringify({
+      expandedCards: _goalDisplayState.expandedCards,
+      activeFilter: _goalDisplayState.activeFilter,
+      sortMode: _goalDisplayState.sortMode,
+    }));
+  } catch (_e) { /* quota or private browsing */ }
+}
+
+function _toggleGoalExpanded(goalId) {
+  _goalDisplayState.expandedCards[goalId] =
+    !_goalDisplayState.expandedCards[goalId];
+  _saveGoalDisplayState();
+  renderGoalCardsPage();
+}
+
+function _selectGoalCard(goalId) {
+  _goalDisplayState.selectedCard =
+    _goalDisplayState.selectedCard === goalId ? null : goalId;
+  renderGoalCardsPage();
+}
+
+function _setGoalFilter(status) {
+  _goalDisplayState.activeFilter =
+    _goalDisplayState.activeFilter === status ? null : status;
+  _saveGoalDisplayState();
+  renderGoalCardsPage();
+}
+
+function _setGoalSort(mode) {
+  _goalDisplayState.sortMode = mode;
+  _saveGoalDisplayState();
+  renderGoalCardsPage();
+}
+
+function _getGoalProgress(goal) {
+  if (!Array.isArray(goal.steps) || goal.steps.length === 0) {
+    return { completed: 0, total: 0, pct: 0 };
+  }
+  var completed = goal.steps.filter(function (s) {
+    return s.status === "completed";
+  }).length;
+  return {
+    completed: completed,
+    total: goal.steps.length,
+    pct: Math.round((completed / goal.steps.length) * 100),
+  };
+}
+
+var GOAL_STATUS_ORDER = {
+  running: 0, waiting_for_approval: 1, ready: 2, planning: 3,
+  blocked: 4, paused: 5, draft: 6, completed: 7, canceled: 8, failed: 9,
+};
+
+function _sortGoals(goals, mode) {
+  var sorted = goals.slice();
+  if (mode === "status") {
+    sorted.sort(function (a, b) {
+      var oa = GOAL_STATUS_ORDER[a.status] != null
+        ? GOAL_STATUS_ORDER[a.status] : 99;
+      var ob = GOAL_STATUS_ORDER[b.status] != null
+        ? GOAL_STATUS_ORDER[b.status] : 99;
+      if (oa !== ob) return oa - ob;
+      return (b.updated_at || "").localeCompare(a.updated_at || "");
+    });
+  } else {
+    sorted.sort(function (a, b) {
+      return (b.updated_at || "").localeCompare(a.updated_at || "");
+    });
+  }
+  return sorted;
+}
+
+/* ── End display-state helpers ────────────────────────────────────── */
+
 function createGoalCardElement(goal) {
+  var isExpanded = !!_goalDisplayState.expandedCards[goal.goal_id];
+  var isSelected = _goalDisplayState.selectedCard === goal.goal_id;
+  var progress = _getGoalProgress(goal);
+
   const card = document.createElement("article");
   card.className = "goal-card";
+  if (isExpanded) card.classList.add("goal-card--expanded");
+  if (isSelected) card.classList.add("goal-card--selected");
   card.dataset.goalId = goal.goal_id;
+  card.dataset.goalStatus = goal.status || "draft";
 
-  // Header: title + status badge
+  // Header: title + progress + status badge (always visible)
   const header = document.createElement("div");
   header.className = "goal-card-header";
+  header.style.cursor = "pointer";
+  header.setAttribute("role", "button");
+  header.setAttribute("aria-expanded", String(isExpanded));
+  header.setAttribute("tabindex", "0");
+  header.title = isExpanded ? "Collapse details" : "Expand details";
+
+  // Expand chevron
+  const chevron = document.createElement("span");
+  chevron.className = "goal-card-chevron";
+  chevron.textContent = isExpanded ? "▾" : "▸";
+  chevron.setAttribute("aria-hidden", "true");
+  header.appendChild(chevron);
 
   const title = document.createElement("h4");
   title.className = "goal-card-title";
@@ -2302,14 +2423,55 @@ function createGoalCardElement(goal) {
   badge.textContent = (goal.status || "draft").replace(/_/g, " ");
   header.appendChild(badge);
 
+  // Click header to expand/collapse
+  header.addEventListener("click", function (e) {
+    e.stopPropagation();
+    _toggleGoalExpanded(goal.goal_id);
+  });
+  header.addEventListener("keydown", function (e) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      _toggleGoalExpanded(goal.goal_id);
+    }
+  });
+
   card.appendChild(header);
+
+  // Progress bar (always visible, below header)
+  if (progress.total > 0) {
+    const progressWrap = document.createElement("div");
+    progressWrap.className = "goal-card-progress";
+
+    const progressBar = document.createElement("div");
+    progressBar.className = "goal-card-progress-bar";
+
+    const progressFill = document.createElement("div");
+    progressFill.className = "goal-card-progress-fill";
+    progressFill.style.width = progress.pct + "%";
+    progressFill.dataset.goalStatus = goal.status || "draft";
+    progressBar.appendChild(progressFill);
+    progressWrap.appendChild(progressBar);
+
+    const progressLabel = document.createElement("span");
+    progressLabel.className = "goal-card-progress-label";
+    progressLabel.textContent = progress.completed + "/" + progress.total
+      + " steps";
+    progressWrap.appendChild(progressLabel);
+
+    card.appendChild(progressWrap);
+  }
+
+  // Collapsible body
+  const body = document.createElement("div");
+  body.className = "goal-card-body";
+  if (!isExpanded) body.hidden = true;
 
   // Steps
   if (Array.isArray(goal.steps) && goal.steps.length > 0) {
     const stepsLabel = document.createElement("p");
     stepsLabel.className = "goal-card-section-label";
     stepsLabel.textContent = "Steps";
-    card.appendChild(stepsLabel);
+    body.appendChild(stepsLabel);
 
     const stepsList = document.createElement("div");
     stepsList.className = "goal-card-steps";
@@ -2335,7 +2497,7 @@ function createGoalCardElement(goal) {
       stepsList.appendChild(stepEl);
     });
 
-    card.appendChild(stepsList);
+    body.appendChild(stepsList);
   }
 
   // Permission envelope
@@ -2344,7 +2506,7 @@ function createGoalCardElement(goal) {
     const envLabel = document.createElement("p");
     envLabel.className = "goal-card-section-label";
     envLabel.textContent = "Permission envelope";
-    card.appendChild(envLabel);
+    body.appendChild(envLabel);
 
     const envGrid = document.createElement("div");
     envGrid.className = "goal-card-envelope";
@@ -2395,7 +2557,7 @@ function createGoalCardElement(goal) {
       envGrid.appendChild(blockedCol);
     }
 
-    card.appendChild(envGrid);
+    body.appendChild(envGrid);
   }
 
   // Receipt references
@@ -2403,7 +2565,7 @@ function createGoalCardElement(goal) {
     const receiptsLabel = document.createElement("p");
     receiptsLabel.className = "goal-card-section-label";
     receiptsLabel.textContent = "Receipts";
-    card.appendChild(receiptsLabel);
+    body.appendChild(receiptsLabel);
 
     const receiptsList = document.createElement("div");
     receiptsList.className = "goal-card-receipts";
@@ -2419,6 +2581,13 @@ function createGoalCardElement(goal) {
       );
       receiptEl.appendChild(dot);
 
+      if (ref.capability_id != null) {
+        const capBadge = document.createElement("span");
+        capBadge.className = "goal-card-receipt-cap";
+        capBadge.textContent = "Cap " + ref.capability_id;
+        receiptEl.appendChild(capBadge);
+      }
+
       const text = document.createElement("span");
       text.textContent = String(ref.summary || ref.type || "");
       receiptEl.appendChild(text);
@@ -2426,17 +2595,12 @@ function createGoalCardElement(goal) {
       receiptsList.appendChild(receiptEl);
     });
 
-    card.appendChild(receiptsList);
+    body.appendChild(receiptsList);
   }
 
   // Actions (inert UI only — display-only prototype)
   const actions = document.createElement("div");
   actions.className = "goal-card-actions";
-
-  var isPausable = ["planning", "running", "ready",
-    "waiting_for_approval"].indexOf(goal.status) !== -1;
-  var isCancelable = goal.status !== "completed"
-    && goal.status !== "canceled" && goal.status !== "failed";
 
   var pauseBtn = document.createElement("button");
   pauseBtn.type = "button";
@@ -2458,7 +2622,7 @@ function createGoalCardElement(goal) {
   cancelBtn.setAttribute("aria-label", "Cancel (display only)");
   actions.appendChild(cancelBtn);
 
-  card.appendChild(actions);
+  body.appendChild(actions);
 
   // Updated timestamp
   if (goal.updated_at) {
@@ -2470,8 +2634,15 @@ function createGoalCardElement(goal) {
     } catch (_e) {
       updated.textContent = "Updated " + goal.updated_at;
     }
-    card.appendChild(updated);
+    body.appendChild(updated);
   }
+
+  card.appendChild(body);
+
+  // Click card body to select (not the header, which toggles expand)
+  card.addEventListener("click", function () {
+    _selectGoalCard(goal.goal_id);
+  });
 
   return card;
 }
@@ -2497,6 +2668,11 @@ function renderGoalStatusLegend() {
   GOAL_STATUS_LEGEND.forEach(function (entry) {
     var item = document.createElement("span");
     item.className = "goal-legend-item";
+    item.style.cursor = "pointer";
+    item.title = "Filter by " + entry.label;
+    if (_goalDisplayState.activeFilter === entry.key) {
+      item.classList.add("goal-legend-item--active");
+    }
 
     var dot = document.createElement("span");
     dot.className = "goal-legend-dot";
@@ -2507,11 +2683,64 @@ function renderGoalStatusLegend() {
     label.textContent = entry.label;
     item.appendChild(label);
 
+    item.addEventListener("click", function () {
+      _setGoalFilter(entry.key);
+    });
+
     host.appendChild(item);
   });
 }
 
+function _renderGoalToolbar() {
+  var existing = $("goal-toolbar");
+  if (existing) existing.remove();
+
+  var toolbar = document.createElement("div");
+  toolbar.id = "goal-toolbar";
+  toolbar.className = "goal-toolbar";
+
+  // Sort toggle
+  var sortGroup = document.createElement("div");
+  sortGroup.className = "goal-toolbar-group";
+
+  var sortLabel = document.createElement("span");
+  sortLabel.className = "goal-toolbar-label";
+  sortLabel.textContent = "Sort:";
+  sortGroup.appendChild(sortLabel);
+
+  ["updated", "status"].forEach(function (mode) {
+    var btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "goal-toolbar-btn";
+    if (_goalDisplayState.sortMode === mode) {
+      btn.classList.add("active");
+    }
+    btn.textContent = mode === "updated" ? "Recent" : "By status";
+    btn.addEventListener("click", function () { _setGoalSort(mode); });
+    sortGroup.appendChild(btn);
+  });
+
+  toolbar.appendChild(sortGroup);
+
+  // Filter indicator
+  if (_goalDisplayState.activeFilter) {
+    var clearBtn = document.createElement("button");
+    clearBtn.type = "button";
+    clearBtn.className = "goal-toolbar-btn goal-toolbar-clear";
+    clearBtn.textContent = "Clear filter: "
+      + _goalDisplayState.activeFilter.replace(/_/g, " ");
+    clearBtn.addEventListener("click", function () {
+      _setGoalFilter(null);
+    });
+    toolbar.appendChild(clearBtn);
+  }
+
+  return toolbar;
+}
+
 function renderGoalCardsPage() {
+  _loadGoalDisplayState();
+
   var container = $("goal-cards-container");
   var emptyState = $("goal-cards-empty");
   if (!container) return;
@@ -2521,11 +2750,44 @@ function renderGoalCardsPage() {
   var goals = DEMO_GOAL_CARDS;
   var hasGoals = Array.isArray(goals) && goals.length > 0;
 
-  if (emptyState) {
-    emptyState.hidden = hasGoals;
+  // Filter
+  if (_goalDisplayState.activeFilter && hasGoals) {
+    goals = goals.filter(function (g) {
+      return g.status === _goalDisplayState.activeFilter;
+    });
   }
 
-  if (hasGoals) {
+  // Sort
+  goals = _sortGoals(goals, _goalDisplayState.sortMode);
+
+  var hasVisible = goals.length > 0;
+
+  if (emptyState) {
+    emptyState.hidden = hasVisible;
+    if (!hasVisible && _goalDisplayState.activeFilter) {
+      emptyState.hidden = false;
+      var emptyTitle = emptyState.querySelector(".goal-empty-title");
+      if (emptyTitle) {
+        emptyTitle.textContent = "No "
+          + _goalDisplayState.activeFilter.replace(/_/g, " ")
+          + " goals";
+      }
+    }
+  }
+
+  // Insert toolbar before cards
+  var heroWidget = container.parentElement
+    && container.parentElement.querySelector(".goal-page-hero");
+  var toolbarEl = _renderGoalToolbar();
+  if (heroWidget && heroWidget.nextSibling) {
+    // Insert after legend, before container
+    var legendEl = $("goal-status-legend");
+    var insertBefore = legendEl
+      ? legendEl.nextSibling : container;
+    container.parentElement.insertBefore(toolbarEl, insertBefore);
+  }
+
+  if (hasVisible) {
     goals.forEach(function (goal) {
       container.appendChild(createGoalCardElement(goal));
     });

--- a/nova_backend/static/style.phase1.css
+++ b/nova_backend/static/style.phase1.css
@@ -737,6 +737,21 @@ body {
     rgba(8, 19, 36, 0.94) 100%
   );
   box-shadow: var(--shadow-panel);
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.goal-card--selected {
+  border-color: rgba(104, 177, 255, 0.45);
+  box-shadow: var(--shadow-panel), 0 0 0 1px rgba(104, 177, 255, 0.2);
+}
+
+.goal-card[data-goal-status="blocked"] {
+  border-color: rgba(255, 130, 130, 0.25);
+  background: linear-gradient(
+    160deg,
+    rgba(40, 20, 24, 0.92) 0%,
+    rgba(20, 10, 14, 0.94) 100%
+  );
 }
 
 .goal-card-header {
@@ -744,6 +759,67 @@ body {
   align-items: flex-start;
   justify-content: space-between;
   gap: 10px;
+}
+
+.goal-card-header:hover {
+  opacity: 0.9;
+}
+
+.goal-card-chevron {
+  flex-shrink: 0;
+  width: 16px;
+  font-size: 0.82rem;
+  color: var(--muted);
+  padding-top: 2px;
+}
+
+/* Progress bar */
+
+.goal-card-progress {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.goal-card-progress-bar {
+  flex: 1;
+  height: 4px;
+  border-radius: 2px;
+  background: rgba(175, 198, 230, 0.12);
+  overflow: hidden;
+}
+
+.goal-card-progress-fill {
+  height: 100%;
+  border-radius: 2px;
+  background: var(--ok);
+  transition: width 0.3s ease;
+}
+
+.goal-card-progress-fill[data-goal-status="blocked"] {
+  background: #ff9a9a;
+}
+
+.goal-card-progress-fill[data-goal-status="paused"] {
+  background: var(--warn);
+}
+
+.goal-card-progress-label {
+  flex-shrink: 0;
+  font-size: 0.68rem;
+  color: var(--muted);
+  white-space: nowrap;
+}
+
+/* Collapsible body */
+
+.goal-card-body {
+  display: grid;
+  gap: 10px;
+}
+
+.goal-card-body[hidden] {
+  display: none;
 }
 
 .goal-card-title {
@@ -1067,6 +1143,84 @@ body {
 .goal-legend-dot[data-legend="completed"] { background: var(--ok); }
 .goal-legend-dot[data-legend="blocked"] { background: #ff9a9a; }
 .goal-legend-dot[data-legend="canceled"] { background: var(--muted); }
+
+.goal-legend-item--active {
+  border-color: rgba(104, 177, 255, 0.4);
+  background: rgba(104, 177, 255, 0.12);
+  color: var(--text);
+}
+
+/* Receipt capability badge */
+
+.goal-card-receipt-cap {
+  flex-shrink: 0;
+  padding: 1px 6px;
+  border-radius: 999px;
+  border: 1px solid rgba(143, 218, 255, 0.2);
+  background: rgba(104, 177, 255, 0.08);
+  font-size: 0.66rem;
+  font-weight: 700;
+  color: var(--accent);
+  white-space: nowrap;
+}
+
+/* Toolbar */
+
+.goal-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 14px;
+  flex-wrap: wrap;
+}
+
+.goal-toolbar-group {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.goal-toolbar-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--muted);
+  margin-right: 2px;
+}
+
+.goal-toolbar-btn {
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid rgba(175, 198, 230, 0.15);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s, color 0.15s;
+}
+
+.goal-toolbar-btn:hover {
+  border-color: rgba(143, 218, 255, 0.3);
+  background: rgba(104, 177, 255, 0.08);
+  color: var(--text);
+}
+
+.goal-toolbar-btn.active {
+  border-color: rgba(104, 177, 255, 0.4);
+  background: rgba(104, 177, 255, 0.14);
+  color: var(--text);
+}
+
+.goal-toolbar-clear {
+  border-color: rgba(246, 203, 143, 0.25);
+  background: rgba(246, 203, 143, 0.06);
+  color: var(--warn);
+}
+
+.goal-toolbar-clear:hover {
+  border-color: rgba(246, 203, 143, 0.4);
+  background: rgba(246, 203, 143, 0.12);
+}
 
 /* ── End Goal Cards ──────────────────────────────────────── */
 


### PR DESCRIPTION
## Summary
- Adds pure frontend display-state management for Goal Cards — expand/collapse
  with chevron indicator, progress bars, card selection, status filtering via
  clickable legend, sort toggle (recent / by status), blocked-card styling,
  receipt capability badges, and localStorage persistence for UI preferences.
- No execution authority, no backend persistence, no new capabilities.
  Strictly "workflow usability without authority expansion."
- Frontend mirror (`Nova-Frontend-Dashboard/`) synced.

## What's new
| Feature | Detail |
|---------|--------|
| Expand/collapse | Chevron (▸/▾), keyboard accessible (Enter/Space) |
| Progress bars | Step completion (e.g. "2/5 steps"), color-coded by status |
| Card selection | Blue border highlight, toggle on click |
| Status filtering | Click legend items to filter; click again to clear |
| Sort toggle | Toolbar buttons: Recent (updated_at) / By status |
| Blocked styling | Red-tinted background and border for blocked cards |
| Capability badges | Receipt entries show capability pill (e.g. "Cap 65") |
| Persistence | localStorage for expanded cards, filter, sort preferences |

## Test plan
- [ ] Load dashboard at localhost:8000, navigate to Goal Cards page
- [ ] Click card headers to expand/collapse — verify chevron rotates
- [ ] Verify progress bars show correct step counts
- [ ] Click legend items to filter by status; click again to clear
- [ ] Toggle sort mode between Recent and By status
- [ ] Refresh page — verify expanded cards, filter, and sort persist
- [ ] Verify blocked card has distinct red-tinted styling
- [ ] Verify receipt entries show capability badges
- [ ] Keyboard: Tab to card header, press Enter/Space to expand

🤖 Generated with [Claude Code](https://claude.com/claude-code)