### PR TITLE
Goal Card UX polish — clearer labels, smarter legend, reduced noise

### DIFF
--- a/Nova-Frontend-Dashboard/dashboard-chat-news.js
+++ b/Nova-Frontend-Dashboard/dashboard-chat-news.js
@@ -367,9 +367,16 @@ function renderMessageHighlights(container, highlights) {
   container.appendChild(card);
 }
 
+function shouldSkipCollapse(text) {
+  // Structured help responses should never be collapsed — they are
+  // intentionally multi-line lists, not casual long answers.
+  return String(text || "").trim().startsWith("Here's what Nova can do right now:");
+}
+
 function shouldCollapseMessage(text) {
   const raw = String(text || "");
   if (!raw.trim()) return false;
+  if (shouldSkipCollapse(raw)) return false;
   if (/https?:\/\/\S+/i.test(raw)) return false;
   const lines = raw.split(/\r?\n/).filter((line) => line.trim().length > 0);
   return raw.length > LONG_MESSAGE_CHAR_LIMIT || lines.length > LONG_MESSAGE_LINE_LIMIT;
@@ -2707,6 +2714,7 @@ function setActivePage(page) {
     news: $("page-news"),
     intro: $("page-intro"),
     home: $("page-home"),
+    goals: $("page-goals"),
     agent: $("page-agent"),
     workspace: $("page-workspace"),
     memory: $("page-memory"),
@@ -2735,6 +2743,7 @@ function setActivePage(page) {
   });
 
   activePageState = target;
+  document.body.dataset.activePage = target;
   const workspaceCurrent = $("workspace-current-label");
   if (workspaceCurrent) {
     workspaceCurrent.textContent = PAGE_LABELS[target] || "Chat";
@@ -2753,6 +2762,9 @@ function setActivePage(page) {
       requestPolicyDetail(policyCenterState.selectedId);
     }
     renderPolicyCenterPage();
+  }
+  if (target === "goals") {
+    if (typeof renderGoalCardsPage === "function") renderGoalCardsPage();
   }
   if (target === "home") {
     requestWorkspaceHomeRefresh(true);

--- a/Nova-Frontend-Dashboard/dashboard.js
+++ b/Nova-Frontend-Dashboard/dashboard.js
@@ -2270,7 +2270,7 @@ const DEMO_GOAL_CARDS = [
 ];
 
 const STEP_INDICATORS = {
-  planned: "·",
+  planned: "○",
   proposed: "?",
   waiting_for_approval: "!",
   approved: "✓",
@@ -2505,7 +2505,7 @@ function createGoalCardElement(goal) {
   if (env) {
     const envLabel = document.createElement("p");
     envLabel.className = "goal-card-section-label";
-    envLabel.textContent = "Permission envelope";
+    envLabel.textContent = "What Nova can / can’t do";
     body.appendChild(envLabel);
 
     const envGrid = document.createElement("div");
@@ -2599,30 +2599,35 @@ function createGoalCardElement(goal) {
   }
 
   // Actions (inert UI only — display-only prototype)
-  const actions = document.createElement("div");
-  actions.className = "goal-card-actions";
+  // Hide on completed/canceled cards where Pause/Cancel are semantically wrong
+  var hideActions = goal.status === "completed"
+    || goal.status === "canceled";
+  if (!hideActions) {
+    const actions = document.createElement("div");
+    actions.className = "goal-card-actions";
 
-  var pauseBtn = document.createElement("button");
-  pauseBtn.type = "button";
-  pauseBtn.className = "goal-card-action-btn";
-  pauseBtn.textContent = goal.status === "paused" ? "Resume" : "Pause";
-  pauseBtn.disabled = true;
-  pauseBtn.title = "Display only — not connected to execution yet";
-  pauseBtn.setAttribute("aria-label",
-    (goal.status === "paused" ? "Resume" : "Pause")
-    + " (display only)");
-  actions.appendChild(pauseBtn);
+    var pauseBtn = document.createElement("button");
+    pauseBtn.type = "button";
+    pauseBtn.className = "goal-card-action-btn";
+    pauseBtn.textContent = goal.status === "paused" ? "Resume" : "Pause";
+    pauseBtn.disabled = true;
+    pauseBtn.title = "Display only — not connected to execution yet";
+    pauseBtn.setAttribute("aria-label",
+      (goal.status === "paused" ? "Resume" : "Pause")
+      + " (display only)");
+    actions.appendChild(pauseBtn);
 
-  var cancelBtn = document.createElement("button");
-  cancelBtn.type = "button";
-  cancelBtn.className = "goal-card-action-btn destructive";
-  cancelBtn.textContent = "Cancel";
-  cancelBtn.disabled = true;
-  cancelBtn.title = "Display only — not connected to execution yet";
-  cancelBtn.setAttribute("aria-label", "Cancel (display only)");
-  actions.appendChild(cancelBtn);
+    var cancelBtn = document.createElement("button");
+    cancelBtn.type = "button";
+    cancelBtn.className = "goal-card-action-btn destructive";
+    cancelBtn.textContent = "Cancel";
+    cancelBtn.disabled = true;
+    cancelBtn.title = "Display only — not connected to execution yet";
+    cancelBtn.setAttribute("aria-label", "Cancel (display only)");
+    actions.appendChild(cancelBtn);
 
-  body.appendChild(actions);
+    body.appendChild(actions);
+  }
 
   // Updated timestamp
   if (goal.updated_at) {
@@ -2663,9 +2668,28 @@ function renderGoalStatusLegend() {
   var legendWidget = $("goal-status-legend");
   if (!legendWidget) return;
   var host = legendWidget.querySelector(".goal-legend-items");
-  if (!host || host.children.length > 0) return;
+  if (!host) return;
+  host.innerHTML = "";
 
-  GOAL_STATUS_LEGEND.forEach(function (entry) {
+  // Only show statuses that exist in the current goal set
+  var goals = DEMO_GOAL_CARDS;
+  var activeStatuses = {};
+  if (Array.isArray(goals)) {
+    goals.forEach(function (g) {
+      activeStatuses[g.status || "draft"] = true;
+    });
+  }
+
+  // If a filter is active, always show that status in the legend
+  if (_goalDisplayState.activeFilter) {
+    activeStatuses[_goalDisplayState.activeFilter] = true;
+  }
+
+  var visibleEntries = GOAL_STATUS_LEGEND.filter(function (entry) {
+    return !!activeStatuses[entry.key];
+  });
+
+  visibleEntries.forEach(function (entry) {
     var item = document.createElement("span");
     item.className = "goal-legend-item";
     item.style.cursor = "pointer";
@@ -2715,7 +2739,7 @@ function _renderGoalToolbar() {
     if (_goalDisplayState.sortMode === mode) {
       btn.classList.add("active");
     }
-    btn.textContent = mode === "updated" ? "Recent" : "By status";
+    btn.textContent = mode === "updated" ? "Last updated" : "By status";
     btn.addEventListener("click", function () { _setGoalSort(mode); });
     sortGroup.appendChild(btn);
   });

--- a/Nova-Frontend-Dashboard/index.html
+++ b/Nova-Frontend-Dashboard/index.html
@@ -1099,6 +1099,42 @@
         </div>
       </section>
 
+      <section id="page-goals" class="page-view page-goals" hidden>
+        <div class="widget page-card goal-page-hero" aria-live="polite">
+          <div class="goal-page-hero-top">
+            <div>
+              <div class="goal-page-kicker">Your Workflows</div>
+              <div class="goal-page-title-row">
+                <h3>Goals</h3>
+                <span class="news-page-subtle">Visible, bounded, proof-tracked</span>
+              </div>
+            </div>
+            <span class="goal-demo-badge">Display only</span>
+          </div>
+          <p class="goal-page-intro">
+            Goal Cards show what Nova is planning, what it has done,
+            what needs approval, and what is blocked. Planning is not authority.
+          </p>
+        </div>
+
+        <div id="goal-status-legend" class="widget page-card goal-status-legend" aria-label="Status legend">
+          <p class="goal-card-section-label">Status legend</p>
+          <div class="goal-legend-items"></div>
+        </div>
+
+        <div id="goal-cards-empty" class="widget page-card goal-cards-empty" hidden>
+          <div class="goal-empty-icon" aria-hidden="true"></div>
+          <p class="goal-empty-title">No goals yet</p>
+          <p class="goal-empty-copy">
+            When Nova helps you work toward a goal, it will appear here
+            as a visible, governed card. You will see every step, every
+            permission boundary, and every receipt.
+          </p>
+        </div>
+
+        <div id="goal-cards-container" class="goal-cards-container" aria-live="polite"></div>
+      </section>
+
       <section id="page-memory" class="page-view page-memory" hidden>
         <div class="widget page-card memory-page-hero" aria-live="polite">
           <div class="memory-page-kicker">Personal Intelligence</div>

--- a/Nova-Frontend-Dashboard/style.phase1.css
+++ b/Nova-Frontend-Dashboard/style.phase1.css
@@ -659,6 +659,12 @@ body {
 
 /* ── Goal Cards ──────────────────────────────────────────── */
 
+/* Reduce orb visual weight on content-heavy pages */
+body[data-active-page="goals"] .orb-shell {
+  opacity: 0.25;
+  transform: scale(0.7) translateZ(0);
+}
+
 .page-goals {
   display: grid;
   grid-template-columns: minmax(0, 1fr);

--- a/nova_backend/static/dashboard-chat-news.js
+++ b/nova_backend/static/dashboard-chat-news.js
@@ -2743,6 +2743,7 @@ function setActivePage(page) {
   });
 
   activePageState = target;
+  document.body.dataset.activePage = target;
   const workspaceCurrent = $("workspace-current-label");
   if (workspaceCurrent) {
     workspaceCurrent.textContent = PAGE_LABELS[target] || "Chat";

--- a/nova_backend/static/dashboard.js
+++ b/nova_backend/static/dashboard.js
@@ -2270,7 +2270,7 @@ const DEMO_GOAL_CARDS = [
 ];
 
 const STEP_INDICATORS = {
-  planned: "·",
+  planned: "○",
   proposed: "?",
   waiting_for_approval: "!",
   approved: "✓",
@@ -2505,7 +2505,7 @@ function createGoalCardElement(goal) {
   if (env) {
     const envLabel = document.createElement("p");
     envLabel.className = "goal-card-section-label";
-    envLabel.textContent = "Permission envelope";
+    envLabel.textContent = "What Nova can / can’t do";
     body.appendChild(envLabel);
 
     const envGrid = document.createElement("div");
@@ -2599,30 +2599,35 @@ function createGoalCardElement(goal) {
   }
 
   // Actions (inert UI only — display-only prototype)
-  const actions = document.createElement("div");
-  actions.className = "goal-card-actions";
+  // Hide on completed/canceled cards where Pause/Cancel are semantically wrong
+  var hideActions = goal.status === "completed"
+    || goal.status === "canceled";
+  if (!hideActions) {
+    const actions = document.createElement("div");
+    actions.className = "goal-card-actions";
 
-  var pauseBtn = document.createElement("button");
-  pauseBtn.type = "button";
-  pauseBtn.className = "goal-card-action-btn";
-  pauseBtn.textContent = goal.status === "paused" ? "Resume" : "Pause";
-  pauseBtn.disabled = true;
-  pauseBtn.title = "Display only — not connected to execution yet";
-  pauseBtn.setAttribute("aria-label",
-    (goal.status === "paused" ? "Resume" : "Pause")
-    + " (display only)");
-  actions.appendChild(pauseBtn);
+    var pauseBtn = document.createElement("button");
+    pauseBtn.type = "button";
+    pauseBtn.className = "goal-card-action-btn";
+    pauseBtn.textContent = goal.status === "paused" ? "Resume" : "Pause";
+    pauseBtn.disabled = true;
+    pauseBtn.title = "Display only — not connected to execution yet";
+    pauseBtn.setAttribute("aria-label",
+      (goal.status === "paused" ? "Resume" : "Pause")
+      + " (display only)");
+    actions.appendChild(pauseBtn);
 
-  var cancelBtn = document.createElement("button");
-  cancelBtn.type = "button";
-  cancelBtn.className = "goal-card-action-btn destructive";
-  cancelBtn.textContent = "Cancel";
-  cancelBtn.disabled = true;
-  cancelBtn.title = "Display only — not connected to execution yet";
-  cancelBtn.setAttribute("aria-label", "Cancel (display only)");
-  actions.appendChild(cancelBtn);
+    var cancelBtn = document.createElement("button");
+    cancelBtn.type = "button";
+    cancelBtn.className = "goal-card-action-btn destructive";
+    cancelBtn.textContent = "Cancel";
+    cancelBtn.disabled = true;
+    cancelBtn.title = "Display only — not connected to execution yet";
+    cancelBtn.setAttribute("aria-label", "Cancel (display only)");
+    actions.appendChild(cancelBtn);
 
-  body.appendChild(actions);
+    body.appendChild(actions);
+  }
 
   // Updated timestamp
   if (goal.updated_at) {
@@ -2663,9 +2668,28 @@ function renderGoalStatusLegend() {
   var legendWidget = $("goal-status-legend");
   if (!legendWidget) return;
   var host = legendWidget.querySelector(".goal-legend-items");
-  if (!host || host.children.length > 0) return;
+  if (!host) return;
+  host.innerHTML = "";
 
-  GOAL_STATUS_LEGEND.forEach(function (entry) {
+  // Only show statuses that exist in the current goal set
+  var goals = DEMO_GOAL_CARDS;
+  var activeStatuses = {};
+  if (Array.isArray(goals)) {
+    goals.forEach(function (g) {
+      activeStatuses[g.status || "draft"] = true;
+    });
+  }
+
+  // If a filter is active, always show that status in the legend
+  if (_goalDisplayState.activeFilter) {
+    activeStatuses[_goalDisplayState.activeFilter] = true;
+  }
+
+  var visibleEntries = GOAL_STATUS_LEGEND.filter(function (entry) {
+    return !!activeStatuses[entry.key];
+  });
+
+  visibleEntries.forEach(function (entry) {
     var item = document.createElement("span");
     item.className = "goal-legend-item";
     item.style.cursor = "pointer";
@@ -2715,7 +2739,7 @@ function _renderGoalToolbar() {
     if (_goalDisplayState.sortMode === mode) {
       btn.classList.add("active");
     }
-    btn.textContent = mode === "updated" ? "Recent" : "By status";
+    btn.textContent = mode === "updated" ? "Last updated" : "By status";
     btn.addEventListener("click", function () { _setGoalSort(mode); });
     sortGroup.appendChild(btn);
   });

--- a/nova_backend/static/index.html
+++ b/nova_backend/static/index.html
@@ -1103,10 +1103,10 @@
         <div class="widget page-card goal-page-hero" aria-live="polite">
           <div class="goal-page-hero-top">
             <div>
-              <div class="goal-page-kicker">Governed Workflows</div>
+              <div class="goal-page-kicker">Your Workflows</div>
               <div class="goal-page-title-row">
                 <h3>Goals</h3>
-                <span class="news-page-subtle">Visible, bounded, receipt-backed</span>
+                <span class="news-page-subtle">Visible, bounded, proof-tracked</span>
               </div>
             </div>
             <span class="goal-demo-badge">Display only</span>

--- a/nova_backend/static/style.phase1.css
+++ b/nova_backend/static/style.phase1.css
@@ -659,6 +659,12 @@ body {
 
 /* ── Goal Cards ──────────────────────────────────────────── */
 
+/* Reduce orb visual weight on content-heavy pages */
+body[data-active-page="goals"] .orb-shell {
+  opacity: 0.25;
+  transform: scale(0.7) translateZ(0);
+}
+
 .page-goals {
   display: grid;
   grid-template-columns: minmax(0, 1fr);


### PR DESCRIPTION
## Summary

- Rename internal governance vocabulary to user-facing language
  ("Your Workflows", "proof-tracked", "What Nova can / can't do",
  "Last updated")
- Legend now only shows statuses that exist in the current goal set
  (3 items instead of 9)
- Hide Pause/Cancel buttons on completed and canceled cards
- Replace ambiguous planned-step dot (·) with empty circle (○)
- Reduce orb visual weight on Goals page

## What this does NOT do

- No backend persistence
- No execution authority
- No scheduler or click-to-run
- No new capabilities
- No GovernorMediator changes

## Test plan

- [ ] Verify header reads "Your Workflows" / "proof-tracked"
- [ ] Verify legend shows only Planning, Blocked, Completed (3 items)
- [ ] Verify sort button reads "Last updated" instead of "Recent"
- [ ] Verify expanded permission section reads "What Nova can / can't do"
- [ ] Verify Pause/Cancel hidden on completed card
- [ ] Verify Pause/Cancel still present on planning/blocked cards
- [ ] Verify pending step shows ○ instead of ·
- [ ] Verify filter still works with reduced legend
- [ ] Verify DISPLAY ONLY badge still visible
- [ ] Verify orb is smaller/dimmer on Goals page

🤖 Generated with [Claude Code](https://claude.com/claude-code)