### PR TITLE
Goal Card persistence Phase 2 — local JSON + CRUD API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 src/data/*.jsonl
 memory/*.jsonl
 
+# Goal state (personal, not repo state)
+nova_backend/data/goals.json
+
 # Models
 models/
 nova_backend/models/

--- a/nova_backend/src/api/goals_api.py
+++ b/nova_backend/src/api/goals_api.py
@@ -1,0 +1,94 @@
+# src/api/goals_api.py
+"""
+Goal persistence API — CRUD for goal state records.
+
+GET  /api/goals          → list all goals
+GET  /api/goals/{id}     → single goal detail
+POST /api/goals          → create a new visible goal record
+                            from explicit user/conversation context
+PUT  /api/goals/{id}     → update goal state (status, steps)
+
+This API does NOT expose:
+  /api/goals/{id}/run
+  /api/goals/{id}/execute
+  /api/goals/{id}/schedule
+
+These endpoints are state storage only. They do not dispatch
+actions, call executors, contact the GovernorMediator, or
+write to the ledger.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from src.utils.local_request_guard import require_local_http_request
+
+
+class GoalCreate(BaseModel):
+    goal_id: str | None = None
+    title: str
+    status: str = "planning"
+    steps: list[dict] = Field(default_factory=list)
+    permission_envelope: dict = Field(default_factory=lambda: {
+        "allowed_capabilities": [],
+        "blocked_actions": [],
+        "requires_confirmation": [],
+    })
+    ledger_refs: list[dict] = Field(default_factory=list)
+
+
+class GoalUpdate(BaseModel):
+    title: str | None = None
+    status: str | None = None
+    steps: list[dict] | None = None
+    permission_envelope: dict | None = None
+    ledger_refs: list[dict] | None = None
+
+
+def build_goals_router() -> APIRouter:
+    router = APIRouter(
+        dependencies=[Depends(require_local_http_request)]
+    )
+
+    @router.get("/api/goals")
+    async def list_goals():
+        from src.goals.goal_store import goal_store
+        return {"goals": goal_store.list_goals()}
+
+    @router.get("/api/goals/{goal_id}")
+    async def get_goal(goal_id: str):
+        from src.goals.goal_store import goal_store
+        goal = goal_store.get_goal(goal_id)
+        if goal is None:
+            raise HTTPException(status_code=404, detail="Goal not found")
+        return goal
+
+    @router.post("/api/goals", status_code=201)
+    async def create_goal(body: GoalCreate):
+        from src.goals.goal_store import goal_store
+        try:
+            created = goal_store.create_goal(body.model_dump())
+            return created
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+
+    @router.put("/api/goals/{goal_id}")
+    async def update_goal(goal_id: str, body: GoalUpdate):
+        from src.goals.goal_store import goal_store
+        updates = {
+            k: v for k, v in body.model_dump().items() if v is not None
+        }
+        if not updates:
+            raise HTTPException(
+                status_code=400, detail="No fields to update"
+            )
+        try:
+            updated = goal_store.update_goal(goal_id, updates)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        if updated is None:
+            raise HTTPException(status_code=404, detail="Goal not found")
+        return updated
+
+    return router

--- a/nova_backend/src/brain_server.py
+++ b/nova_backend/src/brain_server.py
@@ -37,6 +37,7 @@ def set_current_ws_turn_id(turn_id: str):
 from src.api.audit_api import build_audit_router
 from src.api.bridge_api import build_bridge_router
 from src.api.connections_api import build_connections_router
+from src.api.goals_api import build_goals_router
 from src.api.trust_api import build_trust_router
 from src.api.live_screen_api import build_live_screen_router
 from src.api.memory_api import build_memory_router
@@ -3015,6 +3016,7 @@ async def send_pattern_review_widget(
 app.include_router(build_audit_router(sys.modules[__name__]))
 app.include_router(build_bridge_router(sys.modules[__name__]))
 app.include_router(build_connections_router())
+app.include_router(build_goals_router())
 app.include_router(build_trust_router())
 app.include_router(build_memory_router(sys.modules[__name__]))
 app.include_router(build_openclaw_agent_router(sys.modules[__name__]))

--- a/nova_backend/src/goals/__init__.py
+++ b/nova_backend/src/goals/__init__.py
@@ -1,0 +1,1 @@
+# src/goals/__init__.py

--- a/nova_backend/src/goals/goal_store.py
+++ b/nova_backend/src/goals/goal_store.py
@@ -1,0 +1,233 @@
+# src/goals/goal_store.py
+"""
+Goal state persistence — local JSON file storage.
+
+This module is record-keeping only. It stores goal metadata
+(titles, steps, statuses, permission envelopes, ledger references)
+to a local JSON file so that Goal Cards survive page reloads
+and server restarts.
+
+Authority boundary (enforced by tests):
+  - This module NEVER imports GovernorMediator.
+  - This module NEVER imports any executor.
+  - This module NEVER writes to the ledger.
+  - Saving a goal never executes an action.
+  - Loading a goal never executes an action.
+  - The word "schedule" does not appear in this module
+    (except in this docstring's boundary statement).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import uuid
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from threading import Lock
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_GOALS_FILE = Path(__file__).resolve().parent.parent.parent / "data" / "goals.json"
+
+_VALID_GOAL_STATUSES = frozenset({
+    "planning",
+    "running",
+    "completed",
+    "blocked",
+    "canceled",
+})
+
+_VALID_STEP_STATUSES = frozenset({
+    "planned",
+    "proposed",
+    "waiting_for_approval",
+    "running",
+    "completed",
+    "blocked",
+    "skipped",
+})
+
+_SCHEMA_VERSION = 1
+
+
+def _empty_store() -> dict[str, Any]:
+    return {"version": _SCHEMA_VERSION, "goals": []}
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+class GoalStore:
+    """
+    Thread-safe, file-backed goal state store.
+
+    All public methods are pure state reads/writes.
+    No method dispatches actions, calls executors, or
+    contacts the GovernorMediator.
+    """
+
+    def __init__(self, path: Path | None = None):
+        self._path = path or _GOALS_FILE
+        self._lock = Lock()
+        self._data: dict[str, Any] = _empty_store()
+        self._load()
+
+    # ── read ────────────────────────────────────────────
+
+    def list_goals(self) -> list[dict[str, Any]]:
+        """Return a deep copy of all goals."""
+        with self._lock:
+            return deepcopy(self._data["goals"])
+
+    def get_goal(self, goal_id: str) -> dict[str, Any] | None:
+        """Return a single goal by ID, or None."""
+        with self._lock:
+            for g in self._data["goals"]:
+                if g["goal_id"] == goal_id:
+                    return deepcopy(g)
+            return None
+
+    # ── write ───────────────────────────────────────────
+
+    def create_goal(self, goal: dict[str, Any]) -> dict[str, Any]:
+        """
+        Create a new goal record.
+
+        This is a record update only. It may be initiated by
+        explicit user request or by user-visible workflow state
+        changes. It cannot be inferred silently as autonomous work.
+        """
+        goal = deepcopy(goal)
+
+        if "goal_id" not in goal or not goal["goal_id"]:
+            goal["goal_id"] = f"goal_{uuid.uuid4().hex[:12]}"
+
+        now = _now_iso()
+        goal.setdefault("created_at", now)
+        goal.setdefault("updated_at", now)
+        goal.setdefault("status", "planning")
+        goal.setdefault("steps", [])
+        goal.setdefault("permission_envelope", {
+            "allowed_capabilities": [],
+            "blocked_actions": [],
+            "requires_confirmation": [],
+        })
+        goal.setdefault("ledger_refs", [])
+
+        if goal.get("status") not in _VALID_GOAL_STATUSES:
+            raise ValueError(
+                f"Invalid goal status: {goal['status']!r}. "
+                f"Must be one of {sorted(_VALID_GOAL_STATUSES)}"
+            )
+
+        for step in goal.get("steps", []):
+            if step.get("status") not in _VALID_STEP_STATUSES:
+                raise ValueError(
+                    f"Invalid step status: {step.get('status')!r}. "
+                    f"Must be one of {sorted(_VALID_STEP_STATUSES)}"
+                )
+
+        if "title" not in goal or not goal["title"]:
+            raise ValueError("Goal must have a title.")
+
+        with self._lock:
+            # Reject duplicate goal_id
+            for existing in self._data["goals"]:
+                if existing["goal_id"] == goal["goal_id"]:
+                    raise ValueError(
+                        f"Goal with id {goal['goal_id']!r} already exists."
+                    )
+            self._data["goals"].append(goal)
+            self._save()
+        return deepcopy(goal)
+
+    def update_goal(
+        self, goal_id: str, updates: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        """
+        Update an existing goal record.
+
+        Only updates fields present in `updates`. This is a record
+        update only — it does not dispatch actions.
+        """
+        with self._lock:
+            target = None
+            for g in self._data["goals"]:
+                if g["goal_id"] == goal_id:
+                    target = g
+                    break
+            if target is None:
+                return None
+
+            _UPDATABLE_FIELDS = {
+                "title", "status", "steps",
+                "permission_envelope", "ledger_refs",
+            }
+            for key, value in updates.items():
+                if key in _UPDATABLE_FIELDS:
+                    target[key] = deepcopy(value)
+
+            if "status" in updates:
+                if target["status"] not in _VALID_GOAL_STATUSES:
+                    raise ValueError(
+                        f"Invalid goal status: {target['status']!r}"
+                    )
+
+            if "steps" in updates:
+                for step in target.get("steps", []):
+                    if step.get("status") not in _VALID_STEP_STATUSES:
+                        raise ValueError(
+                            f"Invalid step status: "
+                            f"{step.get('status')!r}"
+                        )
+
+            target["updated_at"] = _now_iso()
+            self._save()
+            return deepcopy(target)
+
+    # ── internal ────────────────────────────────────────
+
+    def _load(self) -> None:
+        """Load goals from disk, or create empty default."""
+        if not self._path.exists():
+            logger.info("No goals.json found — starting with empty goals.")
+            self._data = _empty_store()
+            return
+        try:
+            with open(self._path, "r", encoding="utf-8") as f:
+                raw = json.load(f)
+            if not isinstance(raw, dict) or "goals" not in raw:
+                logger.warning(
+                    "goals.json has unexpected shape — resetting."
+                )
+                self._data = _empty_store()
+                return
+            self._data = raw
+            logger.info(
+                "Loaded %d goals from %s",
+                len(self._data.get("goals", [])),
+                self._path,
+            )
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("Failed to read goals.json: %s", exc)
+            self._data = _empty_store()
+
+    def _save(self) -> None:
+        """Write current state to disk. Must be called under lock."""
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self._path.with_suffix(".tmp")
+            with open(tmp, "w", encoding="utf-8") as f:
+                json.dump(self._data, f, indent=2, ensure_ascii=False)
+                f.write("\n")
+            tmp.replace(self._path)
+        except OSError as exc:
+            logger.error("Failed to write goals.json: %s", exc)
+
+
+# Module-level singleton for API use
+goal_store = GoalStore()

--- a/nova_backend/src/utils/local_request_guard.py
+++ b/nova_backend/src/utils/local_request_guard.py
@@ -11,6 +11,7 @@ _ALLOWED_LOOPBACK_HOSTS = {
     "testserver",
 }
 _LOCAL_ONLY_API_PREFIXES = (
+    "/api/goals",
     "/api/memory",
     "/api/settings",
     "/api/trust",

--- a/nova_backend/tests/goals/test_goal_persistence_boundaries.py
+++ b/nova_backend/tests/goals/test_goal_persistence_boundaries.py
@@ -1,0 +1,335 @@
+# tests/goals/test_goal_persistence_boundaries.py
+"""
+Goal persistence boundary tests.
+
+These tests enforce the design doc invariants:
+
+  1. Saving a goal never executes an action.
+  2. Loading a goal never executes an action.
+  3. Updating a goal status never executes an action.
+  4. Goal persistence code never imports GovernorMediator.
+  5. Goal persistence code never imports any executor.
+  6. Goal persistence code never calls the ledger.
+  7. The word "schedule" does not appear in goal persistence code.
+  8. DISPLAY ONLY badge remains on the Goals page.
+
+Additionally:
+  - API does not expose /run, /execute, or /schedule endpoints.
+  - No execution_schedule, trigger, automation_config, or
+    background_run fields exist in the data model.
+"""
+import ast
+import pytest
+from pathlib import Path
+
+
+# ── source paths ────────────────────────────────────
+
+_GOALS_DIR = (
+    Path(__file__).resolve().parent.parent.parent
+    / "src" / "goals"
+)
+_GOALS_API = (
+    Path(__file__).resolve().parent.parent.parent
+    / "src" / "api" / "goals_api.py"
+)
+_GOAL_STORE = _GOALS_DIR / "goal_store.py"
+_PERSISTENCE_SOURCES = [_GOAL_STORE, _GOALS_API]
+
+
+def _read_source(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _extract_imports(source_text: str) -> list[str]:
+    """Extract all import module paths using AST."""
+    tree = ast.parse(source_text)
+    imports = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imports.append(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                imports.append(node.module)
+    return imports
+
+
+def _extract_code_lines(source_text: str) -> list[tuple[int, str]]:
+    """
+    Return (line_number, text) for lines that are actual code —
+    not inside docstrings, not comments, not blank.
+    """
+    tree = ast.parse(source_text)
+    # Collect line ranges of all string-expression nodes (docstrings)
+    docstring_lines: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Expr) and isinstance(
+            node.value, (ast.Constant, ast.Str)
+        ):
+            for lineno in range(node.lineno, node.end_lineno + 1):
+                docstring_lines.add(lineno)
+
+    lines = source_text.split("\n")
+    result = []
+    for i, line in enumerate(lines, 1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("#"):
+            continue
+        if i in docstring_lines:
+            continue
+        result.append((i, stripped))
+    return result
+
+
+def _extract_route_decorators(source_text: str) -> list[str]:
+    """Extract all route path strings from @router decorators."""
+    import re
+    # Match patterns like @router.get("/api/goals") etc.
+    pattern = r'@router\.\w+\(\s*["\']([^"\']+)["\']'
+    return re.findall(pattern, source_text)
+
+
+# ── invariant 4: no GovernorMediator import ─────────
+
+
+class TestNoGovernorMediatorImport:
+    @pytest.mark.parametrize("source", _PERSISTENCE_SOURCES)
+    def test_no_governor_import(self, source):
+        imports = _extract_imports(_read_source(source))
+        for imp in imports:
+            assert "governor" not in imp.lower(), (
+                f"{source.name} imports governor module: {imp}"
+            )
+
+
+# ── invariant 5: no executor import ────────────────
+
+
+class TestNoExecutorImport:
+    @pytest.mark.parametrize("source", _PERSISTENCE_SOURCES)
+    def test_no_executor_import(self, source):
+        imports = _extract_imports(_read_source(source))
+        for imp in imports:
+            assert "executor" not in imp.lower(), (
+                f"{source.name} imports executor module: {imp}"
+            )
+
+    @pytest.mark.parametrize("source", _PERSISTENCE_SOURCES)
+    def test_no_executor_reference_in_code(self, source):
+        for lineno, line in _extract_code_lines(
+            _read_source(source)
+        ):
+            assert "executor" not in line.lower(), (
+                f"{source.name}:{lineno} references executor: "
+                f"{line!r}"
+            )
+
+
+# ── invariant 6: no ledger calls ────────────────────
+
+
+class TestNoLedgerCalls:
+    @pytest.mark.parametrize("source", _PERSISTENCE_SOURCES)
+    def test_no_ledger_import(self, source):
+        imports = _extract_imports(_read_source(source))
+        for imp in imports:
+            assert "ledger" not in imp.lower(), (
+                f"{source.name} imports ledger module: {imp}"
+            )
+
+    @pytest.mark.parametrize("source", _PERSISTENCE_SOURCES)
+    def test_no_ledger_reference_in_code(self, source):
+        for lineno, line in _extract_code_lines(
+            _read_source(source)
+        ):
+            # ledger_refs is a data field name — allowed
+            cleaned = line.replace("ledger_refs", "")
+            cleaned = cleaned.replace('"ledger_refs"', "")
+            assert "ledger" not in cleaned.lower(), (
+                f"{source.name}:{lineno} references ledger: "
+                f"{line!r}"
+            )
+
+
+# ── invariant 7: no "schedule" in persistence code ──
+
+
+class TestNoScheduleWord:
+    @pytest.mark.parametrize("source", _PERSISTENCE_SOURCES)
+    def test_no_schedule_in_code(self, source):
+        for lineno, line in _extract_code_lines(
+            _read_source(source)
+        ):
+            assert "schedule" not in line.lower(), (
+                f"{source.name}:{lineno} contains 'schedule': "
+                f"{line!r}"
+            )
+
+
+# ── API does not expose execution endpoints ─────────
+
+
+class TestNoExecutionEndpoints:
+    def test_no_run_route(self):
+        routes = _extract_route_decorators(_read_source(_GOALS_API))
+        for route in routes:
+            assert "/run" not in route, (
+                f"goals_api.py exposes a /run route: {route}"
+            )
+
+    def test_no_execute_route(self):
+        routes = _extract_route_decorators(_read_source(_GOALS_API))
+        for route in routes:
+            assert "/execute" not in route, (
+                f"goals_api.py exposes an /execute route: {route}"
+            )
+
+    def test_no_schedule_route(self):
+        routes = _extract_route_decorators(_read_source(_GOALS_API))
+        for route in routes:
+            assert "/schedule" not in route, (
+                f"goals_api.py exposes a /schedule route: {route}"
+            )
+
+    def test_no_delete_decorator(self):
+        import re
+        text = _read_source(_GOALS_API)
+        assert not re.search(
+            r'@router\.delete\(', text
+        ), "goals_api.py must not have a DELETE endpoint"
+
+    def test_only_expected_routes(self):
+        routes = _extract_route_decorators(_read_source(_GOALS_API))
+        expected = {
+            "/api/goals",
+            "/api/goals/{goal_id}",
+        }
+        assert set(routes) == expected, (
+            f"Unexpected routes: {set(routes) - expected}"
+        )
+
+
+# ── no forbidden data model fields ──────────────────
+
+
+class TestNoForbiddenFields:
+    _FORBIDDEN = [
+        "execution_schedule",
+        "trigger",
+        "automation_config",
+        "background_run",
+    ]
+
+    @pytest.mark.parametrize("field", _FORBIDDEN)
+    def test_forbidden_field_not_in_store(self, field):
+        for lineno, line in _extract_code_lines(
+            _read_source(_GOAL_STORE)
+        ):
+            assert field not in line, (
+                f"goal_store.py:{lineno} contains {field!r}"
+            )
+
+    @pytest.mark.parametrize("field", _FORBIDDEN)
+    def test_forbidden_field_not_in_api(self, field):
+        for lineno, line in _extract_code_lines(
+            _read_source(_GOALS_API)
+        ):
+            assert field not in line, (
+                f"goals_api.py:{lineno} contains {field!r}"
+            )
+
+
+# ── invariant 8: DISPLAY ONLY badge ────────────────
+
+
+class TestDisplayOnlyBadge:
+    def test_display_only_badge_in_index_html(self):
+        index_path = (
+            Path(__file__).resolve().parent.parent.parent
+            / "static" / "index.html"
+        )
+        text = index_path.read_text(encoding="utf-8")
+        assert "Display only" in text, (
+            "index.html must still contain the 'Display only' badge"
+        )
+
+
+# ── runtime invariants 1-3: CRUD does not execute ──
+
+
+class TestCrudDoesNotExecute:
+    """
+    Prove that create/read/update operations are pure state
+    operations with no side effects beyond file I/O.
+    """
+
+    def test_create_does_not_import_executor(self, tmp_path):
+        import sys
+        from src.goals.goal_store import GoalStore
+
+        store = GoalStore(path=tmp_path / "goals.json")
+
+        before = set(sys.modules.keys())
+        store.create_goal({"title": "Safe goal"})
+        after = set(sys.modules.keys())
+
+        new_modules = after - before
+        for mod in new_modules:
+            assert "executor" not in mod.lower(), (
+                f"create_goal loaded executor module: {mod}"
+            )
+            assert "governor" not in mod.lower(), (
+                f"create_goal loaded governor module: {mod}"
+            )
+
+    def test_update_does_not_import_executor(self, tmp_path):
+        import sys
+        from src.goals.goal_store import GoalStore
+
+        store = GoalStore(path=tmp_path / "goals.json")
+        store.create_goal({
+            "goal_id": "g1",
+            "title": "Update test",
+        })
+
+        before = set(sys.modules.keys())
+        store.update_goal("g1", {"status": "completed"})
+        after = set(sys.modules.keys())
+
+        new_modules = after - before
+        for mod in new_modules:
+            assert "executor" not in mod.lower()
+            assert "governor" not in mod.lower()
+
+    def test_list_does_not_import_executor(self, tmp_path):
+        import sys
+        from src.goals.goal_store import GoalStore
+
+        store = GoalStore(path=tmp_path / "goals.json")
+        store.create_goal({"title": "List test"})
+
+        before = set(sys.modules.keys())
+        store.list_goals()
+        after = set(sys.modules.keys())
+
+        new_modules = after - before
+        for mod in new_modules:
+            assert "executor" not in mod.lower()
+            assert "governor" not in mod.lower()
+
+
+# ── goals API is local-only ─────────────────────────
+
+
+class TestGoalsApiLocalOnly:
+    def test_goals_prefix_in_local_guard(self):
+        from src.utils.local_request_guard import (
+            _LOCAL_ONLY_API_PREFIXES,
+        )
+        assert any(
+            p.startswith("/api/goals")
+            for p in _LOCAL_ONLY_API_PREFIXES
+        ), "/api/goals must be in the local-only API prefix list"

--- a/nova_backend/tests/goals/test_goal_store.py
+++ b/nova_backend/tests/goals/test_goal_store.py
@@ -1,0 +1,245 @@
+# tests/goals/test_goal_store.py
+"""
+Goal store unit tests.
+
+These tests prove:
+  1. CRUD works (create, read, update)
+  2. goals.json survives reload
+  3. Validation rejects bad data
+  4. Thread safety basics
+"""
+import json
+import pytest
+from pathlib import Path
+
+from src.goals.goal_store import GoalStore
+
+
+@pytest.fixture
+def tmp_store(tmp_path):
+    """Create a GoalStore backed by a temp file."""
+    return GoalStore(path=tmp_path / "goals.json")
+
+
+@pytest.fixture
+def sample_goal():
+    return {
+        "goal_id": "goal_test_001",
+        "title": "Test goal",
+        "status": "planning",
+        "steps": [
+            {
+                "step_id": "step_001",
+                "title": "First step",
+                "status": "planned",
+                "required_capability": None,
+                "approval_required": False,
+            }
+        ],
+        "permission_envelope": {
+            "allowed_capabilities": [],
+            "blocked_actions": ["External writes"],
+            "requires_confirmation": [],
+        },
+        "ledger_refs": [],
+    }
+
+
+# ── create ──────────────────────────────────────────
+
+
+class TestGoalCreate:
+    def test_create_goal_returns_record(self, tmp_store, sample_goal):
+        result = tmp_store.create_goal(sample_goal)
+        assert result["goal_id"] == "goal_test_001"
+        assert result["title"] == "Test goal"
+        assert result["status"] == "planning"
+
+    def test_create_goal_sets_timestamps(self, tmp_store, sample_goal):
+        result = tmp_store.create_goal(sample_goal)
+        assert "created_at" in result
+        assert "updated_at" in result
+
+    def test_create_goal_auto_generates_id(self, tmp_store):
+        goal = {"title": "No explicit ID"}
+        result = tmp_store.create_goal(goal)
+        assert result["goal_id"].startswith("goal_")
+
+    def test_create_goal_rejects_duplicate_id(
+        self, tmp_store, sample_goal
+    ):
+        tmp_store.create_goal(sample_goal)
+        with pytest.raises(ValueError, match="already exists"):
+            tmp_store.create_goal(sample_goal)
+
+    def test_create_goal_rejects_missing_title(self, tmp_store):
+        with pytest.raises(ValueError, match="title"):
+            tmp_store.create_goal({"title": ""})
+
+    def test_create_goal_rejects_invalid_status(self, tmp_store):
+        with pytest.raises(ValueError, match="Invalid goal status"):
+            tmp_store.create_goal({
+                "title": "Bad status",
+                "status": "executing",
+            })
+
+    def test_create_goal_rejects_invalid_step_status(self, tmp_store):
+        with pytest.raises(ValueError, match="Invalid step status"):
+            tmp_store.create_goal({
+                "title": "Bad step",
+                "steps": [
+                    {"step_id": "s1", "title": "x", "status": "running_autonomously"}
+                ],
+            })
+
+    def test_create_goal_defaults(self, tmp_store):
+        result = tmp_store.create_goal({"title": "Minimal goal"})
+        assert result["status"] == "planning"
+        assert result["steps"] == []
+        assert result["ledger_refs"] == []
+        assert "permission_envelope" in result
+
+
+# ── read ────────────────────────────────────────────
+
+
+class TestGoalRead:
+    def test_list_goals_empty(self, tmp_store):
+        assert tmp_store.list_goals() == []
+
+    def test_list_goals_returns_all(self, tmp_store, sample_goal):
+        tmp_store.create_goal(sample_goal)
+        tmp_store.create_goal({
+            "goal_id": "goal_test_002",
+            "title": "Second goal",
+        })
+        goals = tmp_store.list_goals()
+        assert len(goals) == 2
+
+    def test_get_goal_by_id(self, tmp_store, sample_goal):
+        tmp_store.create_goal(sample_goal)
+        result = tmp_store.get_goal("goal_test_001")
+        assert result is not None
+        assert result["title"] == "Test goal"
+
+    def test_get_goal_not_found(self, tmp_store):
+        assert tmp_store.get_goal("nonexistent") is None
+
+    def test_returned_goals_are_copies(self, tmp_store, sample_goal):
+        tmp_store.create_goal(sample_goal)
+        g1 = tmp_store.get_goal("goal_test_001")
+        g2 = tmp_store.get_goal("goal_test_001")
+        assert g1 is not g2
+        g1["title"] = "MUTATED"
+        assert tmp_store.get_goal("goal_test_001")["title"] == "Test goal"
+
+
+# ── update ──────────────────────────────────────────
+
+
+class TestGoalUpdate:
+    def test_update_status(self, tmp_store, sample_goal):
+        tmp_store.create_goal(sample_goal)
+        result = tmp_store.update_goal(
+            "goal_test_001", {"status": "completed"}
+        )
+        assert result["status"] == "completed"
+
+    def test_update_title(self, tmp_store, sample_goal):
+        tmp_store.create_goal(sample_goal)
+        result = tmp_store.update_goal(
+            "goal_test_001", {"title": "Updated title"}
+        )
+        assert result["title"] == "Updated title"
+
+    def test_update_steps(self, tmp_store, sample_goal):
+        tmp_store.create_goal(sample_goal)
+        new_steps = [
+            {"step_id": "s1", "title": "Done", "status": "completed"}
+        ]
+        result = tmp_store.update_goal(
+            "goal_test_001", {"steps": new_steps}
+        )
+        assert result["steps"][0]["status"] == "completed"
+
+    def test_update_sets_updated_at(self, tmp_store, sample_goal):
+        created = tmp_store.create_goal(sample_goal)
+        original_ts = created["updated_at"]
+        import time
+        time.sleep(0.01)
+        updated = tmp_store.update_goal(
+            "goal_test_001", {"status": "running"}
+        )
+        assert updated["updated_at"] >= original_ts
+
+    def test_update_nonexistent_returns_none(self, tmp_store):
+        assert tmp_store.update_goal("nope", {"status": "planning"}) is None
+
+    def test_update_rejects_invalid_status(
+        self, tmp_store, sample_goal
+    ):
+        tmp_store.create_goal(sample_goal)
+        with pytest.raises(ValueError, match="Invalid goal status"):
+            tmp_store.update_goal(
+                "goal_test_001", {"status": "auto_executing"}
+            )
+
+    def test_update_does_not_change_goal_id(
+        self, tmp_store, sample_goal
+    ):
+        tmp_store.create_goal(sample_goal)
+        tmp_store.update_goal(
+            "goal_test_001", {"goal_id": "HIJACKED"}
+        )
+        # goal_id is not in _UPDATABLE_FIELDS, so it's ignored
+        assert tmp_store.get_goal("goal_test_001") is not None
+        assert tmp_store.get_goal("HIJACKED") is None
+
+    def test_update_does_not_change_created_at(
+        self, tmp_store, sample_goal
+    ):
+        created = tmp_store.create_goal(sample_goal)
+        original_ts = created["created_at"]
+        tmp_store.update_goal(
+            "goal_test_001", {"created_at": "1999-01-01T00:00:00Z"}
+        )
+        assert (
+            tmp_store.get_goal("goal_test_001")["created_at"]
+            == original_ts
+        )
+
+
+# ── persistence ─────────────────────────────────────
+
+
+class TestGoalPersistence:
+    def test_goals_survive_reload(self, tmp_path, sample_goal):
+        path = tmp_path / "goals.json"
+        store1 = GoalStore(path=path)
+        store1.create_goal(sample_goal)
+
+        store2 = GoalStore(path=path)
+        goals = store2.list_goals()
+        assert len(goals) == 1
+        assert goals[0]["goal_id"] == "goal_test_001"
+
+    def test_goals_json_is_valid_json(self, tmp_path, sample_goal):
+        path = tmp_path / "goals.json"
+        store = GoalStore(path=path)
+        store.create_goal(sample_goal)
+
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        assert data["version"] == 1
+        assert len(data["goals"]) == 1
+
+    def test_corrupt_file_resets_gracefully(self, tmp_path):
+        path = tmp_path / "goals.json"
+        path.write_text("NOT VALID JSON", encoding="utf-8")
+        store = GoalStore(path=path)
+        assert store.list_goals() == []
+
+    def test_missing_file_starts_empty(self, tmp_path):
+        path = tmp_path / "nonexistent" / "goals.json"
+        store = GoalStore(path=path)
+        assert store.list_goals() == []

--- a/nova_backend/tests/goals/test_goals_api.py
+++ b/nova_backend/tests/goals/test_goals_api.py
@@ -1,0 +1,200 @@
+# tests/goals/test_goals_api.py
+"""
+Goals API endpoint tests.
+
+Uses FastAPI TestClient to verify HTTP behavior of
+GET/POST/PUT /api/goals endpoints.
+"""
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.goals_api import build_goals_router
+from src.goals.goal_store import GoalStore
+
+
+@pytest.fixture
+def tmp_store(tmp_path):
+    """Create a GoalStore backed by a temp file."""
+    return GoalStore(path=tmp_path / "goals.json")
+
+
+@pytest.fixture
+def client(tmp_store):
+    app = FastAPI()
+    router = build_goals_router()
+    app.include_router(router)
+
+    # The route handlers do `from src.goals.goal_store import goal_store`
+    # so we patch the singleton at the module level.
+    with patch(
+        "src.goals.goal_store.goal_store", tmp_store
+    ):
+        yield TestClient(app)
+
+
+@pytest.fixture
+def sample_body():
+    return {
+        "title": "Test API goal",
+        "status": "planning",
+        "steps": [
+            {
+                "step_id": "s1",
+                "title": "First step",
+                "status": "planned",
+            }
+        ],
+    }
+
+
+# ── GET /api/goals ──────────────────────────────────
+
+
+class TestListGoals:
+    def test_empty_list(self, client):
+        resp = client.get("/api/goals")
+        assert resp.status_code == 200
+        assert resp.json() == {"goals": []}
+
+    def test_list_after_create(self, client, sample_body):
+        client.post("/api/goals", json=sample_body)
+        resp = client.get("/api/goals")
+        assert resp.status_code == 200
+        goals = resp.json()["goals"]
+        assert len(goals) == 1
+        assert goals[0]["title"] == "Test API goal"
+
+
+# ── GET /api/goals/{id} ────────────────────────────
+
+
+class TestGetGoal:
+    def test_get_existing(self, client, sample_body):
+        create_resp = client.post("/api/goals", json=sample_body)
+        goal_id = create_resp.json()["goal_id"]
+
+        resp = client.get(f"/api/goals/{goal_id}")
+        assert resp.status_code == 200
+        assert resp.json()["title"] == "Test API goal"
+
+    def test_get_not_found(self, client):
+        resp = client.get("/api/goals/nonexistent")
+        assert resp.status_code == 404
+
+
+# ── POST /api/goals ─────────────────────────────────
+
+
+class TestCreateGoal:
+    def test_create_returns_201(self, client, sample_body):
+        resp = client.post("/api/goals", json=sample_body)
+        assert resp.status_code == 201
+
+    def test_create_auto_id(self, client):
+        resp = client.post(
+            "/api/goals", json={"title": "Auto ID goal"}
+        )
+        assert resp.status_code == 201
+        assert resp.json()["goal_id"].startswith("goal_")
+
+    def test_create_with_explicit_id(self, client):
+        resp = client.post(
+            "/api/goals",
+            json={"goal_id": "my_goal", "title": "Explicit ID"},
+        )
+        assert resp.status_code == 201
+        assert resp.json()["goal_id"] == "my_goal"
+
+    def test_create_rejects_empty_title(self, client):
+        resp = client.post("/api/goals", json={"title": ""})
+        assert resp.status_code == 400
+
+    def test_create_rejects_invalid_status(self, client):
+        resp = client.post(
+            "/api/goals",
+            json={"title": "Bad", "status": "executing"},
+        )
+        assert resp.status_code == 400
+
+    def test_create_duplicate_id_rejected(self, client):
+        body = {"goal_id": "dup", "title": "First"}
+        client.post("/api/goals", json=body)
+        resp = client.post("/api/goals", json=body)
+        assert resp.status_code == 400
+
+
+# ── PUT /api/goals/{id} ────────────────────────────
+
+
+class TestUpdateGoal:
+    def test_update_status(self, client, sample_body):
+        create_resp = client.post("/api/goals", json=sample_body)
+        goal_id = create_resp.json()["goal_id"]
+
+        resp = client.put(
+            f"/api/goals/{goal_id}",
+            json={"status": "completed"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "completed"
+
+    def test_update_not_found(self, client):
+        resp = client.put(
+            "/api/goals/nonexistent",
+            json={"status": "planning"},
+        )
+        assert resp.status_code == 404
+
+    def test_update_empty_body_rejected(self, client, sample_body):
+        create_resp = client.post("/api/goals", json=sample_body)
+        goal_id = create_resp.json()["goal_id"]
+
+        resp = client.put(f"/api/goals/{goal_id}", json={})
+        assert resp.status_code == 400
+
+    def test_update_invalid_status_rejected(
+        self, client, sample_body
+    ):
+        create_resp = client.post("/api/goals", json=sample_body)
+        goal_id = create_resp.json()["goal_id"]
+
+        resp = client.put(
+            f"/api/goals/{goal_id}",
+            json={"status": "auto_running"},
+        )
+        assert resp.status_code == 400
+
+
+# ── endpoint existence ──────────────────────────────
+
+
+class TestEndpointAbsence:
+    """Prove that execution endpoints do not exist."""
+
+    def test_no_run_endpoint(self, client, sample_body):
+        create_resp = client.post("/api/goals", json=sample_body)
+        goal_id = create_resp.json()["goal_id"]
+        resp = client.post(f"/api/goals/{goal_id}/run")
+        assert resp.status_code in (404, 405, 422)
+
+    def test_no_execute_endpoint(self, client, sample_body):
+        create_resp = client.post("/api/goals", json=sample_body)
+        goal_id = create_resp.json()["goal_id"]
+        resp = client.post(f"/api/goals/{goal_id}/execute")
+        assert resp.status_code in (404, 405, 422)
+
+    def test_no_schedule_endpoint(self, client, sample_body):
+        create_resp = client.post("/api/goals", json=sample_body)
+        goal_id = create_resp.json()["goal_id"]
+        resp = client.post(f"/api/goals/{goal_id}/schedule")
+        assert resp.status_code in (404, 405, 422)
+
+    def test_no_delete_endpoint(self, client, sample_body):
+        create_resp = client.post("/api/goals", json=sample_body)
+        goal_id = create_resp.json()["goal_id"]
+        resp = client.delete(f"/api/goals/{goal_id}")
+        assert resp.status_code in (404, 405)


### PR DESCRIPTION
## Summary
- Implements `GoalStore` (thread-safe, file-backed at `nova_backend/data/goals.json`)
- Adds `GET/POST/PUT /api/goals` endpoints (local-only, loopback-guarded)
- 73 tests proving persistence cannot execute: no GovernorMediator, no executors, no ledger, no schedule, no /run /execute /schedule endpoints
- `goals.json` gitignored (personal state, not repo state)
- DISPLAY ONLY badge preserved
- Design doc: `docs/status/GOAL_CARD_PERSISTENCE_DESIGN_2026-05-24.md`

## Authority boundary
```
goal → action:  PROHIBITED
action → goal update:  ALLOWED (record-keeping only)
```

## What does NOT change
- GovernorMediator: no changes
- CapabilityRegistry: no changes
- capability_locks.json: no changes
- ExecuteBoundary: no changes
- Approval gates: no changes
- Ledger: no changes
- Trust surfaces: no changes
- OpenClaw: no changes

## Test plan
- [x] 24 GoalStore CRUD unit tests (create, read, update, persist, validate)
- [x] 18 Goals API endpoint tests (list, get, create, update, errors, absent endpoints)
- [x] 31 boundary/governance tests (no governor imports, no executor imports, no ledger, no schedule word, no forbidden fields, DISPLAY ONLY badge, runtime module loading, local-only guard, route whitelist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)