### PR TITLE
Goal Card Phase 3 — wire frontend to /api/goals

### DIFF
--- a/Nova-Frontend-Dashboard/dashboard-chat-news.js
+++ b/Nova-Frontend-Dashboard/dashboard-chat-news.js
@@ -2764,6 +2764,11 @@ function setActivePage(page) {
     renderPolicyCenterPage();
   }
   if (target === "goals") {
+    // Refresh goal data from API on each navigation to goals page
+    if (typeof _fetchGoalCards === "function") {
+      _goalCardsFetchState = "idle";
+      _goalCardsData = null;
+    }
     if (typeof renderGoalCardsPage === "function") renderGoalCardsPage();
   }
   if (target === "home") {

--- a/Nova-Frontend-Dashboard/dashboard.js
+++ b/Nova-Frontend-Dashboard/dashboard.js
@@ -2118,9 +2118,9 @@ function renderMemoryCenterSurface() {
  * No execution, no scheduler, no backend authority.
  * Planning is not authority. Goal state is not permission.
  *
- * DEMO_GOAL_CARDS is kept as fallback data only — used when
- * the API is unreachable (e.g., server not running).
- * Once the API responds, this is replaced by real data.
+ * _DEMO_GOAL_CARDS_FALLBACK is kept as fallback data only — used
+ * when the API is unreachable during local development.
+ * Once the API responds, fetched goal data replaces it.
  */
 var _goalCardsData = null;   // null = not yet fetched
 var _goalCardsFetchState = "idle"; // idle | loading | loaded | error
@@ -2823,6 +2823,16 @@ function renderGoalCardsPage() {
   if (_goalCardsData === null && _goalCardsFetchState === "idle") {
     _fetchGoalCards();
     return;
+  }
+
+  // Show visible fallback notice when API failed
+  if (_goalCardsFetchState === "error") {
+    var notice = document.createElement("div");
+    notice.className = "goal-fallback-notice";
+    notice.setAttribute("role", "status");
+    notice.textContent =
+      "Showing demo goals because local goal storage is unavailable.";
+    container.appendChild(notice);
   }
 
   var goals = _getGoalCards();

--- a/Nova-Frontend-Dashboard/dashboard.js
+++ b/Nova-Frontend-Dashboard/dashboard.js
@@ -2114,11 +2114,59 @@ function renderMemoryCenterSurface() {
 /* ── Goal Cards (display-only prototype) ───────────────────────────── */
 
 /**
- * Demo goal card data. This is static/demo state only.
- * No execution, no scheduler, no persistence, no backend authority.
+ * Goal card data — fetched from /api/goals.
+ * No execution, no scheduler, no backend authority.
  * Planning is not authority. Goal state is not permission.
+ *
+ * DEMO_GOAL_CARDS is kept as fallback data only — used when
+ * the API is unreachable (e.g., server not running).
+ * Once the API responds, this is replaced by real data.
  */
-const DEMO_GOAL_CARDS = [
+var _goalCardsData = null;   // null = not yet fetched
+var _goalCardsFetchState = "idle"; // idle | loading | loaded | error
+
+function _fetchGoalCards() {
+  if (_goalCardsFetchState === "loading") return;
+  _goalCardsFetchState = "loading";
+  _renderGoalLoadingState();
+
+  fetch("/api/goals")
+    .then(function (resp) {
+      if (!resp.ok) throw new Error("HTTP " + resp.status);
+      return resp.json();
+    })
+    .then(function (data) {
+      _goalCardsData = Array.isArray(data.goals) ? data.goals : [];
+      _goalCardsFetchState = "loaded";
+      renderGoalCardsPage();
+      renderGoalStatusLegend();
+    })
+    .catch(function (err) {
+      console.warn("Goal Cards API unavailable, using demo data:", err);
+      _goalCardsData = _DEMO_GOAL_CARDS_FALLBACK;
+      _goalCardsFetchState = "error";
+      renderGoalCardsPage();
+      renderGoalStatusLegend();
+    });
+}
+
+function _renderGoalLoadingState() {
+  var container = $("goal-cards-container");
+  var emptyState = $("goal-cards-empty");
+  if (!container) return;
+  container.innerHTML =
+    '<div class="goal-loading-state" aria-live="polite">'
+    + '<p class="goal-loading-text">Loading goals…</p>'
+    + '</div>';
+  if (emptyState) emptyState.hidden = true;
+}
+
+function _getGoalCards() {
+  if (_goalCardsData !== null) return _goalCardsData;
+  return _DEMO_GOAL_CARDS_FALLBACK;
+}
+
+const _DEMO_GOAL_CARDS_FALLBACK = [
   {
     goal_id: "goal_auralis_launch_001",
     title: "Prepare Auralis Shopify launch",
@@ -2672,7 +2720,7 @@ function renderGoalStatusLegend() {
   host.innerHTML = "";
 
   // Only show statuses that exist in the current goal set
-  var goals = DEMO_GOAL_CARDS;
+  var goals = _getGoalCards();
   var activeStatuses = {};
   if (Array.isArray(goals)) {
     goals.forEach(function (g) {
@@ -2771,7 +2819,13 @@ function renderGoalCardsPage() {
 
   container.innerHTML = "";
 
-  var goals = DEMO_GOAL_CARDS;
+  // If not yet fetched, trigger a fetch and show loading
+  if (_goalCardsData === null && _goalCardsFetchState === "idle") {
+    _fetchGoalCards();
+    return;
+  }
+
+  var goals = _getGoalCards();
   var hasGoals = Array.isArray(goals) && goals.length > 0;
 
   // Filter

--- a/Nova-Frontend-Dashboard/style.phase1.css
+++ b/Nova-Frontend-Dashboard/style.phase1.css
@@ -1128,6 +1128,20 @@ body[data-active-page="goals"] .orb-shell {
   50% { opacity: 1; }
 }
 
+/* Goal Card — API fallback notice */
+
+.goal-fallback-notice {
+  padding: 8px 14px;
+  margin-bottom: 8px;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  color: var(--muted);
+  background: rgba(255, 180, 80, 0.06);
+  border: 1px solid rgba(255, 180, 80, 0.15);
+  border-radius: 6px;
+  text-align: center;
+}
+
 /* Goal Card — status legend */
 
 .goal-status-legend {

--- a/Nova-Frontend-Dashboard/style.phase1.css
+++ b/Nova-Frontend-Dashboard/style.phase1.css
@@ -1107,6 +1107,27 @@ body[data-active-page="goals"] .orb-shell {
   color: var(--muted);
 }
 
+/* Goal Card — loading state */
+
+.goal-loading-state {
+  display: grid;
+  justify-items: center;
+  text-align: center;
+  padding: 32px 14px;
+}
+
+.goal-loading-text {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+  animation: goal-loading-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes goal-loading-pulse {
+  0%, 100% { opacity: 0.5; }
+  50% { opacity: 1; }
+}
+
 /* Goal Card — status legend */
 
 .goal-status-legend {

--- a/nova_backend/static/dashboard-chat-news.js
+++ b/nova_backend/static/dashboard-chat-news.js
@@ -2764,6 +2764,11 @@ function setActivePage(page) {
     renderPolicyCenterPage();
   }
   if (target === "goals") {
+    // Refresh goal data from API on each navigation to goals page
+    if (typeof _fetchGoalCards === "function") {
+      _goalCardsFetchState = "idle";
+      _goalCardsData = null;
+    }
     if (typeof renderGoalCardsPage === "function") renderGoalCardsPage();
   }
   if (target === "home") {

--- a/nova_backend/static/dashboard.js
+++ b/nova_backend/static/dashboard.js
@@ -2118,9 +2118,9 @@ function renderMemoryCenterSurface() {
  * No execution, no scheduler, no backend authority.
  * Planning is not authority. Goal state is not permission.
  *
- * DEMO_GOAL_CARDS is kept as fallback data only — used when
- * the API is unreachable (e.g., server not running).
- * Once the API responds, this is replaced by real data.
+ * _DEMO_GOAL_CARDS_FALLBACK is kept as fallback data only — used
+ * when the API is unreachable during local development.
+ * Once the API responds, fetched goal data replaces it.
  */
 var _goalCardsData = null;   // null = not yet fetched
 var _goalCardsFetchState = "idle"; // idle | loading | loaded | error
@@ -2823,6 +2823,16 @@ function renderGoalCardsPage() {
   if (_goalCardsData === null && _goalCardsFetchState === "idle") {
     _fetchGoalCards();
     return;
+  }
+
+  // Show visible fallback notice when API failed
+  if (_goalCardsFetchState === "error") {
+    var notice = document.createElement("div");
+    notice.className = "goal-fallback-notice";
+    notice.setAttribute("role", "status");
+    notice.textContent =
+      "Showing demo goals because local goal storage is unavailable.";
+    container.appendChild(notice);
   }
 
   var goals = _getGoalCards();

--- a/nova_backend/static/dashboard.js
+++ b/nova_backend/static/dashboard.js
@@ -2114,11 +2114,59 @@ function renderMemoryCenterSurface() {
 /* ── Goal Cards (display-only prototype) ───────────────────────────── */
 
 /**
- * Demo goal card data. This is static/demo state only.
- * No execution, no scheduler, no persistence, no backend authority.
+ * Goal card data — fetched from /api/goals.
+ * No execution, no scheduler, no backend authority.
  * Planning is not authority. Goal state is not permission.
+ *
+ * DEMO_GOAL_CARDS is kept as fallback data only — used when
+ * the API is unreachable (e.g., server not running).
+ * Once the API responds, this is replaced by real data.
  */
-const DEMO_GOAL_CARDS = [
+var _goalCardsData = null;   // null = not yet fetched
+var _goalCardsFetchState = "idle"; // idle | loading | loaded | error
+
+function _fetchGoalCards() {
+  if (_goalCardsFetchState === "loading") return;
+  _goalCardsFetchState = "loading";
+  _renderGoalLoadingState();
+
+  fetch("/api/goals")
+    .then(function (resp) {
+      if (!resp.ok) throw new Error("HTTP " + resp.status);
+      return resp.json();
+    })
+    .then(function (data) {
+      _goalCardsData = Array.isArray(data.goals) ? data.goals : [];
+      _goalCardsFetchState = "loaded";
+      renderGoalCardsPage();
+      renderGoalStatusLegend();
+    })
+    .catch(function (err) {
+      console.warn("Goal Cards API unavailable, using demo data:", err);
+      _goalCardsData = _DEMO_GOAL_CARDS_FALLBACK;
+      _goalCardsFetchState = "error";
+      renderGoalCardsPage();
+      renderGoalStatusLegend();
+    });
+}
+
+function _renderGoalLoadingState() {
+  var container = $("goal-cards-container");
+  var emptyState = $("goal-cards-empty");
+  if (!container) return;
+  container.innerHTML =
+    '<div class="goal-loading-state" aria-live="polite">'
+    + '<p class="goal-loading-text">Loading goals…</p>'
+    + '</div>';
+  if (emptyState) emptyState.hidden = true;
+}
+
+function _getGoalCards() {
+  if (_goalCardsData !== null) return _goalCardsData;
+  return _DEMO_GOAL_CARDS_FALLBACK;
+}
+
+const _DEMO_GOAL_CARDS_FALLBACK = [
   {
     goal_id: "goal_auralis_launch_001",
     title: "Prepare Auralis Shopify launch",
@@ -2672,7 +2720,7 @@ function renderGoalStatusLegend() {
   host.innerHTML = "";
 
   // Only show statuses that exist in the current goal set
-  var goals = DEMO_GOAL_CARDS;
+  var goals = _getGoalCards();
   var activeStatuses = {};
   if (Array.isArray(goals)) {
     goals.forEach(function (g) {
@@ -2771,7 +2819,13 @@ function renderGoalCardsPage() {
 
   container.innerHTML = "";
 
-  var goals = DEMO_GOAL_CARDS;
+  // If not yet fetched, trigger a fetch and show loading
+  if (_goalCardsData === null && _goalCardsFetchState === "idle") {
+    _fetchGoalCards();
+    return;
+  }
+
+  var goals = _getGoalCards();
   var hasGoals = Array.isArray(goals) && goals.length > 0;
 
   // Filter

--- a/nova_backend/static/style.phase1.css
+++ b/nova_backend/static/style.phase1.css
@@ -1128,6 +1128,20 @@ body[data-active-page="goals"] .orb-shell {
   50% { opacity: 1; }
 }
 
+/* Goal Card — API fallback notice */
+
+.goal-fallback-notice {
+  padding: 8px 14px;
+  margin-bottom: 8px;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  color: var(--muted);
+  background: rgba(255, 180, 80, 0.06);
+  border: 1px solid rgba(255, 180, 80, 0.15);
+  border-radius: 6px;
+  text-align: center;
+}
+
 /* Goal Card — status legend */
 
 .goal-status-legend {

--- a/nova_backend/static/style.phase1.css
+++ b/nova_backend/static/style.phase1.css
@@ -1107,6 +1107,27 @@ body[data-active-page="goals"] .orb-shell {
   color: var(--muted);
 }
 
+/* Goal Card — loading state */
+
+.goal-loading-state {
+  display: grid;
+  justify-items: center;
+  text-align: center;
+  padding: 32px 14px;
+}
+
+.goal-loading-text {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+  animation: goal-loading-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes goal-loading-pulse {
+  0%, 100% { opacity: 0.5; }
+  50% { opacity: 1; }
+}
+
 /* Goal Card — status legend */
 
 .goal-status-legend {


### PR DESCRIPTION
## Summary
- Frontend Goal Cards now fetch from `GET /api/goals` instead of using hardcoded demo data
- `DEMO_GOAL_CARDS` renamed to `_DEMO_GOAL_CARDS_FALLBACK` — used only when API is unreachable
- Loading state with pulsing "Loading goals…" text while fetch is in progress
- Each navigation to the goals page triggers a fresh API fetch
- All existing UI behavior preserved: filter, sort, expand/collapse, progress bars, legend
- `DISPLAY ONLY` badge preserved
- Frontend mirror synced (6 files changed)

## What does NOT change
- No execution endpoints
- No scheduler
- No GovernorMediator integration
- No capability changes
- No ledger changes
- No OpenClaw integration
- localStorage still used for UI preferences only (not goal data)

## Test plan
- [x] 73 existing goal persistence tests pass (no regressions)
- [ ] Manual: start Nova server, navigate to goals page — should show "Loading goals…" then empty state (no goals in API yet)
- [ ] Manual: POST a goal via curl, refresh goals page — should render the persisted goal
- [ ] Manual: stop server, load page — should fall back to demo data
- [ ] Manual: verify DISPLAY ONLY badge visible
- [ ] Manual: verify filter/sort/expand still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)