### PR TITLE
ci: move Shopify live P5 to manual validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           PYTHONPATH: nova_backend
         run: |
-          pytest nova_backend/tests -q --maxfail=5
+          pytest nova_backend/tests -q --maxfail=5 -m "not live_shopify"
 
   # Windows job: verifies that the entry point resolves, adversarial suite
   # passes, and certification tests pass on the primary shipping platform.
@@ -97,4 +97,4 @@ jobs:
         env:
           PYTHONPATH: nova_backend
         run: |
-          pytest nova_backend/tests/certification -q --tb=short --maxfail=5
+          pytest nova_backend/tests/certification -q --tb=short --maxfail=5 -m "not live_shopify"

--- a/.github/workflows/phase-3.5-verification.yml
+++ b/.github/workflows/phase-3.5-verification.yml
@@ -29,7 +29,7 @@ jobs:
         timeout-minutes: 25
         run: |
           cd nova_backend
-          python -c "import os, sys, pytest; code = pytest.main(['-q', '--maxfail=5']); sys.stdout.flush(); sys.stderr.flush(); os._exit(int(code))"
+          python -c "import os, sys, pytest; code = pytest.main(['-q', '--maxfail=5', '-m', 'not live_shopify']); sys.stdout.flush(); sys.stderr.flush(); os._exit(int(code))"
 
       - name: Enforce generated runtime docs
         run: |

--- a/.github/workflows/shopify-live-p5.yml
+++ b/.github/workflows/shopify-live-p5.yml
@@ -1,0 +1,40 @@
+name: Shopify Live P5 Validation
+
+on:
+  workflow_dispatch:
+
+jobs:
+  shopify-live-p5:
+    runs-on: ubuntu-latest
+    environment: shopify-live-p5
+
+    env:
+      NOVA_SHOPIFY_SHOP_DOMAIN: ${{ secrets.NOVA_SHOPIFY_SHOP_DOMAIN }}
+      NOVA_SHOPIFY_ACCESS_TOKEN: ${{ secrets.NOVA_SHOPIFY_ACCESS_TOKEN }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+
+      - name: Install package + dev extras
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+          pip install -r nova_backend/requirements.txt
+
+      - name: Validate protected Shopify secrets are present
+        run: |
+          test -n "$NOVA_SHOPIFY_SHOP_DOMAIN"
+          test -n "$NOVA_SHOPIFY_ACCESS_TOKEN"
+
+      - name: Run Cap 65 Shopify live P5 proof
+        env:
+          PYTHONPATH: nova_backend
+        run: |
+          pytest nova_backend/tests/certification/cap_65_shopify_intelligence_report/test_p5_live_proof.py -q --tb=short -m live_shopify

--- a/nova_backend/tests/certification/cap_65_shopify_intelligence_report/test_p5_live_proof.py
+++ b/nova_backend/tests/certification/cap_65_shopify_intelligence_report/test_p5_live_proof.py
@@ -16,8 +16,12 @@ Safety boundary:
 from __future__ import annotations
 
 import os
-import sys
 import re
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.live_shopify
 
 # ── Bootstrap ──────────────────────────────────────────────────────────
 # Load .env so the connector can find credentials.
@@ -38,11 +42,8 @@ os.chdir(_backend_root)
 sys.path.insert(0, _backend_root)
 
 from src.connectors.shopify_connector import (
-    HttpShopifyConnector,
     bootstrap_shopify_connector,
-    get_shopify_connector,
     is_shopify_connected,
-    set_shopify_connector,
 )
 from src.executors.shopify_intelligence_report_executor import (
     ShopifyIntelligenceReportExecutor,
@@ -228,13 +229,13 @@ def test_p5_read_only_confirmation():
     assert token_env.startswith("shpat_"), "Token not set"
     # We intentionally do NOT print or assert on the full token value
 
-    print(f"  mutation_blocks_found: 0")
+    print("  mutation_blocks_found: 0")
     print(f"  query_blocks_found: {len(query_matches)}")
-    print(f"  non_gql_write_endpoints: 0")
+    print("  non_gql_write_endpoints: 0")
     print(f"  requires_confirmation: {cap65['requires_confirmation']}")
     print(f"  authority_class: {cap65['authority_class']}")
     print(f"  token_format_valid: {token_env.startswith('shpat_')}")
-    print(f"  token_printed: False")
+    print("  token_printed: False")
 
 
 # ── Runner ─────────────────────────────────────────────────────────────
@@ -256,7 +257,7 @@ if __name__ == "__main__":
         print(f"{'='*60}")
         try:
             fn()
-            print(f"  PASS")
+            print("  PASS")
             passed += 1
         except Exception as e:
             print(f"  FAIL: {e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,4 +85,5 @@ asyncio_mode = "auto"
 timeout = 180
 markers = [
     "slow: marks tests that take >20s (typically websocket/brain_server integration hitting Ollama)",
+    "live_shopify: marks Cap 65 Shopify live P5 proof tests that require protected Shopify credentials",
 ]


### PR DESCRIPTION
## Summary

Moves Cap 65 Shopify live P5 proof out of default PR CI and into an explicit manual/protected validation workflow.

This preserves the live proof while preventing ordinary PR checks from failing only because `NOVA_SHOPIFY_SHOP_DOMAIN` and `NOVA_SHOPIFY_ACCESS_TOKEN` are unavailable.

This PR is intentionally stacked on PR #236's branch (`ci/baseline-unblock-pr235`) so the diff stays limited to Shopify live P5 CI policy while using the baseline dependency cleanup already present there.

## Changes

- Adds a `live_shopify` pytest marker.
- Marks `test_p5_live_proof.py` as `live_shopify`.
- Excludes `live_shopify` tests from default CI and Phase-3.5 pytest runs.
- Adds a manual `Shopify Live P5 Validation` workflow using the protected `shopify-live-p5` environment and required `NOVA_SHOPIFY_*` secrets.
- Cleans unused imports / no-op f-strings in the touched live P5 test file.

## Validation

Ran locally on the stacked branch:

- `python -m ruff check nova_backend/tests/certification/cap_65_shopify_intelligence_report/test_p5_live_proof.py`
- `python -m pytest nova_backend/tests/certification/cap_65_shopify_intelligence_report/test_p5_live_proof.py --collect-only -q`
- `python -m pytest nova_backend/tests/certification/cap_65_shopify_intelligence_report/test_p5_live_proof.py -q -m "not live_shopify"`
- `python -m pytest nova_backend/tests/certification -q --tb=short --maxfail=5 -m "not live_shopify"`
- `PYTHONPATH=nova_backend python -c "from src.brain_server import main; assert callable(main)"`
- `git diff --check origin/ci/baseline-unblock-pr235..HEAD`

Results:

- Live P5 file still collects 5 tests.
- Default marker exclusion deselects those 5 live tests.
- Certification suite with live Shopify excluded: 240 passed, 5 deselected.

## Safety confirmation

This does not:

- add Shopify write authority
- mock, skip, or downgrade the live P5 proof itself
- modify `capability_locks.json`
- modify GovernorMediator
- add runtime authority
- add scheduler/background loops
- add browser/computer-use scope
- add OpenClaw integration
- add Second Brain implementation

The live P5 proof remains real and should be run intentionally through the manual protected workflow with live Shopify credentials.