### PR TITLE
test: align Phase 4.5 folder-open confirmation

### DIFF
--- a/nova_backend/tests/phase45/test_brain_server_basic_conversation.py
+++ b/nova_backend/tests/phase45/test_brain_server_basic_conversation.py
@@ -19,6 +19,15 @@ from src.utils import path_resolver
 from tests.phase45._websocket_test_helpers import _chat_messages, _ScriptedWebSocket
 
 
+def _has_open_repo_confirmation(chat_messages: list[str]) -> bool:
+    return any(
+        "Here's what this will do: Open" in msg
+        and "Nova-Project" in msg
+        and "Would you like to proceed?" in msg
+        for msg in chat_messages
+    )
+
+
 @pytest.fixture(autouse=True)
 def fake_nova_workspace(tmp_path, monkeypatch):
     """Create a platform-independent Nova-Project workspace for path-dependent tests."""
@@ -70,6 +79,8 @@ def fake_nova_workspace(tmp_path, monkeypatch):
         "src.utils.path_resolver._candidate_local_project_paths",
         _patched_candidates,
     )
+    monkeypatch.setattr(brain_server, "_resolve_existing_local_path", _patched_resolve)
+    monkeypatch.setattr(brain_server, "_candidate_local_project_paths", _patched_candidates)
     return workspace
 
 
@@ -761,7 +772,7 @@ def test_open_folder_named_workspace_resolves_to_repo_confirmation(monkeypatch):
         asyncio.run(brain_server.websocket_endpoint(ws))
 
     chat_messages = _chat_messages(ws)
-    assert any("Open" in msg and "Nova-Project?" in msg for msg in chat_messages)
+    assert _has_open_repo_confirmation(chat_messages)
     assert not any("I couldn't find that path: folder Nova-Project" in msg for msg in chat_messages)
 
 
@@ -794,7 +805,7 @@ def test_open_this_repo_confirmation_executes_resolved_repo_path(monkeypatch, fa
         asyncio.run(brain_server.websocket_endpoint(ws))
 
     chat_messages = _chat_messages(ws)
-    assert any("Open" in msg and "Nova-Project?" in msg for msg in chat_messages)
+    assert _has_open_repo_confirmation(chat_messages)
     assert any("Opened folder:" in msg and "Nova-Project" in msg for msg in chat_messages)
 
 
@@ -827,7 +838,7 @@ def test_open_explicit_repo_path_confirmation_executes_resolved_repo_path(monkey
         asyncio.run(brain_server.websocket_endpoint(ws))
 
     chat_messages = _chat_messages(ws)
-    assert any("Open" in msg and "Nova-Project?" in msg for msg in chat_messages)
+    assert _has_open_repo_confirmation(chat_messages)
     assert any("Opened folder:" in msg and "Nova-Project" in msg for msg in chat_messages)
 
 


### PR DESCRIPTION
## Summary
- Aligns the Phase 4.5 folder-opening confirmation assertions with the current deterministic approval-gate wording.
- Patches the test fixture to update both `src.utils.path_resolver` and `src.brain_server` bound resolver aliases so the fake `Nova-Project` workspace is used by the implementation path under test.
- Keeps the fix limited to `nova_backend/tests/phase45/test_brain_server_basic_conversation.py`.

## Root cause
The tests expected the older confirmation phrase `Open Nova-Project?`, but the current deterministic gate emits `Here's what this will do: Open ... Would you like to proceed?`.

The fake workspace fixture also patched the path resolver module but not the already-imported resolver aliases in `brain_server.py`, so the test did not reliably exercise its intended fake workspace path.

## Validation
- `python -m pytest nova_backend/tests/phase45/test_brain_server_basic_conversation.py::test_open_folder_named_workspace_resolves_to_repo_confirmation nova_backend/tests/phase45/test_brain_server_basic_conversation.py::test_open_this_repo_confirmation_executes_resolved_repo_path nova_backend/tests/phase45/test_brain_server_basic_conversation.py::test_open_explicit_repo_path_confirmation_executes_resolved_repo_path -q` -> 3 passed
- `python -m pytest nova_backend/tests/phase45/test_brain_server_basic_conversation.py -q` -> 36 passed
- `python -m ruff check nova_backend/tests/phase45/test_brain_server_basic_conversation.py` -> passed
- `git diff --check` -> passed

The broader default CI-equivalent command on this branch is not independently clean because this branch intentionally does not include PR #238's Shopify live P5 marker/policy change; it stops on the known Cap 65 Shopify live credential failures.

## Safety confirmation
- No runtime behavior changes.
- No Shopify policy changes.
- No `capability_locks.json` changes.
- No GovernorMediator changes.
- No capability registry changes.
- No scheduler/background-loop, browser/computer-use, OpenClaw, or Second Brain scope changes.

## Follow-up
After this lands into the PR #236 baseline branch, update PR #238 so the Shopify live P5 policy checks can rerun past the Phase 4.5 folder-opening baseline failure.