### PR TITLE
[codex] Lock runtime recovery health truth lane

### DIFF
--- a/.agent_context/current_priority.md
+++ b/.agent_context/current_priority.md
@@ -1,11 +1,11 @@
 # Current Priority
 
-## Second Brain Slice 1 Foundation Activation - 2026-06-10
+## Runtime Recovery And Health Truth - 2026-06-17
 
 Current active lane:
 
 ```text
-Second Brain Slice 1 foundation activation.
+Runtime recovery and health truth.
 ```
 
 Newly landed stack:
@@ -35,14 +35,15 @@ No active blocker remains from this sequence.
 Current objective:
 
 ```text
-Explicitly choose Second Brain Slice 1 foundation as the next lane while
-keeping implementation in a separate PR.
+Scope the next product lane around visible recovery when Nova stalls.
+Make runtime health truth canonical enough that the UI cannot look usable
+while local requests are timing out without telling the user what happened.
 ```
 
 This sync includes:
 
 ```text
-Confirm the existing Second Brain Slice 1 priority lock is still valid.
+Add runtime recovery and health truth priority lock.
 Update current priority, current work status, and Daily Command Center.
 Restate allowed and blocked scope.
 Add no implementation code.
@@ -51,7 +52,7 @@ Add no implementation code.
 Boundary:
 
 ```text
-This activation chooses the next lane but does not implement it.
+This lock chooses the recovery lane but does not implement it.
 No execution authority added.
 No scheduler.
 No GovernorMediator changes.
@@ -59,6 +60,44 @@ No OpenClaw integration.
 No capability expansion.
 No Shopify/browser scope.
 All four certified capabilities remain locked.
+```
+
+Priority lock:
+
+```text
+docs/status/PRIORITY_LOCK_2026-06-17_RUNTIME_RECOVERY_HEALTH_TRUTH.md
+```
+
+Allowed future implementation scope after this lock lands:
+
+```text
+canonical health truth
+runtime timeout/degraded/unavailable status modeling
+stuck-response detection and user-facing recovery copy
+chat/action timeout recovery affordances
+Trust explanation of product failures, not only governed receipts
+tests proving stale/timeout health cannot be shown as Normal
+tests proving no execution authority is added
+```
+
+Explicitly not authorized by this lock:
+
+```text
+Plan My Week, model presets, more agents, more providers, bigger dashboard
+redesign, advanced navigation cleanup, broad empty-state simplification,
+Second Brain implementation, browser/computer-use expansion, OpenClaw
+expansion, scheduler/background loops, external writes, Shopify writes,
+Gmail/calendar writes, autonomous workflow execution, capability_locks.json
+changes, or capability expansion.
+```
+
+Second Brain Slice 1 status:
+
+```text
+Second Brain Slice 1 priority lock remains accepted.
+Its implementation remains limited to schema/parser/wikilink/vault
+health-lint/no-mutation/non-authorizing tests only.
+It is no longer the immediate next product lane while the recovery lock is active.
 ```
 
 Recently closed trust-model hardening:
@@ -79,7 +118,7 @@ PR #252 - merged (2026-06-16, commit a2c6f58).
   No capability expansion. No GovernorMediator changes. No runtime execution authority added.
 ```
 
-Allowed future implementation scope after this activation lands:
+Previously allowed Second Brain implementation scope after its activation:
 
 ```text
 schema
@@ -119,7 +158,7 @@ UI simplification slice: COMPLETED (PR #233, squash-merged 2026-05-26, merge com
   No backend runtime/governance files changed.
 Second Brain Slice 1 priority lock: ACCEPTED (PR #234, squash-merged 2026-05-26, merge commit 3c5b47e).
   Lock-only. No implementation code.
-  Next authorized implementation PR is schema/parser/wikilink/vault lint/no-mutation tests only.
+  Original authorized implementation scope was schema/parser/wikilink/vault lint/no-mutation tests only.
   No vector DB, MCP, dashboard graph, memory promotion, proposal writes,
   execution integration, scheduler, OpenClaw integration, or capability expansion.
 No execution authority added. No scheduler. No GovernorMediator changes.
@@ -437,7 +476,9 @@ UI simplification slice is complete.
 Phase 4 (execution envelopes) requires a separate design doc
   and is not authorized.
 Second Brain Slice 1 priority lock is accepted.
-Next authorized implementation PR is schema/parser/wikilink/vault lint/no-mutation tests only.
+Runtime recovery and health truth is the active next product lane.
+Second Brain Slice 1 implementation remains accepted but deferred behind
+the recovery lane.
 
 Parallel (manual, no Nova runtime changes):
   0. Manual Obsidian setup as project operating notebook
@@ -447,7 +488,13 @@ Parallel (manual, no Nova runtime changes):
      This helps immediately without touching Nova runtime.
 
 Future order (do not start until prior step reviewed):
-  5. Second Brain Slice 1 implementation PR:
+  5. Runtime recovery and health truth implementation PR:
+     canonical health truth + timeout/degraded/unavailable status modeling +
+     stuck-response recovery copy + Trust explanation of product failures +
+     tests proving stale/timeout health cannot be shown as Normal +
+     tests proving no execution authority is added
+     Lock: docs/status/PRIORITY_LOCK_2026-06-17_RUNTIME_RECOVERY_HEALTH_TRUTH.md
+  6. Second Brain Slice 1 implementation PR:
      schema + parser + wikilink extraction + vault health/lint +
      no-mutation and non-authorizing tests only.
      Scope: KnowledgeEntry/Relationship/Event schemas,
@@ -456,14 +503,14 @@ Future order (do not start until prior step reviewed):
             tests proving non-authorizing invariants
      Lock: docs/status/PRIORITY_LOCK_2026-05-26_SECOND_BRAIN_SLICE_1.md
      Research: docs/future/NOVA_SECOND_BRAIN_OBSIDIAN_RESEARCH_AND_IMPLEMENTATION_PLAN_2026-05-18.md
-  6. Second Brain Slice 2: deterministic index (after lint proven)
+  7. Second Brain Slice 2: deterministic index (after lint proven)
      rebuildable index, content hashes, stale/broken link detection
-  7. Second Brain Slice 3: read-only query surface
+  8. Second Brain Slice 3: read-only query surface
      knowledge.search, knowledge.get_note, knowledge.get_graph
-  8. Second Brain Slice 4: proposal-only writes (no auto-edits)
-  9. Second Brain Slice 5: living graph visualization (last)
-  10. Proposal-only planning for Goal Cards (suggest, not execute)
-  11. Single-step governed execution envelopes (much later, requires
+  9. Second Brain Slice 4: proposal-only writes (no auto-edits)
+  10. Second Brain Slice 5: living graph visualization (last)
+  11. Proposal-only planning for Goal Cards (suggest, not execute)
+  12. Single-step governed execution envelopes (much later, requires
       receipts, trust surfaces, approval envelopes, state restoration,
       interrupt handling to be mature first)
 ```

--- a/docs/status/CURRENT_WORK_STATUS.md
+++ b/docs/status/CURRENT_WORK_STATUS.md
@@ -1,6 +1,6 @@
 # Nova Current Work Status
 
-Last reviewed: 2026-06-16 (Route protection audit closure)
+Last reviewed: 2026-06-17 (runtime recovery and health truth lock)
 
 This is a human-maintained continuity note for the current development slice.
 
@@ -19,6 +19,56 @@ See FIVE_PASS_STABILITY_AND_OPERATIONAL_ROADMAP_2026-05-12.md for the post-audit
 ## Current Active Task
 
 ```text
+Phase: Runtime recovery and health truth priority lock (2026-06-17).
+
+Current active lane:
+  Runtime recovery and health truth.
+
+Product signal:
+  Nova can look alive while the local runtime is not actually responding.
+  A deeper browser/computer-use pass observed visible UI, visible buttons,
+  CONNECTING status, stuck chat, and local API timeouts in the same user
+  experience. That is now the highest-value trust gap.
+
+Current objective:
+  Scope a focused recovery lane before broader UX cleanup or new capability
+  work. When Nova stalls, the user must know what happened, whether anything
+  ran, whether anything left the device, whether Nova is healthy, and what to
+  do next.
+
+Priority lock:
+  docs/status/PRIORITY_LOCK_2026-06-17_RUNTIME_RECOVERY_HEALTH_TRUTH.md
+
+Allowed future implementation scope after this lock lands:
+  canonical health truth
+  runtime timeout/degraded/unavailable status modeling
+  stuck-response detection and user-facing recovery copy
+  chat/action timeout recovery affordances
+  Trust explanation of product failures, not only governed receipts
+  tests proving stale/timeout health cannot be shown as Normal
+  tests proving no execution authority is added
+
+This lock does not implement the lane.
+No execution authority added. No scheduler. No GovernorMediator changes.
+No OpenClaw integration. No capability expansion. No Shopify/browser scope.
+All four certified capabilities remain locked.
+
+Not authorized in this lane:
+  Plan My Week, model presets, more agents, more providers, bigger dashboard
+  redesign, advanced navigation cleanup, broad empty-state simplification,
+  Second Brain implementation, browser/computer-use expansion, OpenClaw
+  expansion, scheduler/background loops, external writes, Shopify writes,
+  Gmail/calendar writes, autonomous workflow execution, capability_locks.json
+  changes, or capability expansion.
+
+Second Brain Slice 1 status:
+  Second Brain Slice 1 priority lock remains accepted.
+  Its implementation remains limited to schema/parser/wikilink/vault
+  health-lint/no-mutation/non-authorizing tests only.
+  It is deferred behind the active runtime recovery lane.
+
+Historical context follows:
+
 Phase: Second Brain Slice 1 foundation activation (2026-06-10).
 
 Recently landed:
@@ -42,8 +92,8 @@ Stable outcome:
 Current active lane:
   Second Brain Slice 1 foundation activation.
 
-Current objective:
-  Explicitly choose Second Brain Slice 1 foundation as the next lane while
+Historical objective at that time:
+  Explicitly choose the Second Brain foundation lane while
   keeping implementation in a separate PR.
 
 Chosen next lane:
@@ -81,7 +131,7 @@ UI simplification slice: COMPLETED (PR #233, squash-merged 2026-05-26).
   No backend runtime/governance files changed.
 Second Brain Slice 1 priority lock: ACCEPTED (PR #234, squash-merged 2026-05-26).
   Lock-only. No implementation code.
-  Next authorized implementation PR is schema/parser/wikilink/vault lint/no-mutation tests only.
+  Original authorized implementation scope was schema/parser/wikilink/vault lint/no-mutation tests only.
   No vector DB, MCP, dashboard graph, memory promotion, proposal writes,
   execution integration, scheduler, OpenClaw integration, or capability expansion.
 No execution authority added. No scheduler. No GovernorMediator changes.
@@ -929,11 +979,14 @@ Current sequence:
 6. Do not reopen the approval-gate lane unless registry truth changes.
 7. Goal Card Phase 4 (execution) requires separate design doc.
 8. No runtime lane is authorized by the repo-doc operating-loop proof.
-9. Next lane is Second Brain Slice 1 foundation.
-10. This activation PR does not implement that lane.
-11. The future implementation PR scope is schema/parser/wikilink/vault
-    health-lint/no-mutation/non-authorizing tests only.
-12. No vector DB, MCP, dashboard graph, memory promotion, proposal writes,
+9. Next lane is Runtime recovery and health truth.
+10. This priority lock does not implement that lane.
+11. The future implementation PR scope is canonical health truth,
+    timeout/degraded/unavailable status modeling, stuck-response recovery,
+    Trust explanation of product failures, and tests proving stale/timeout
+    health cannot be shown as Normal.
+12. Second Brain Slice 1 remains accepted but deferred behind recovery.
+13. No vector DB, MCP, dashboard graph, memory promotion, proposal writes,
     execution integration, scheduler, OpenClaw integration, or capability
     expansion.
 
@@ -950,7 +1003,7 @@ Historical May 26 sequence:
 9. Do not reopen the approval-gate lane unless registry truth changes.
 10. Goal Card Phase 4 (execution) requires separate design doc.
 11. Second Brain Slice 1 priority lock accepted (PR #234).
-12. Next authorized implementation PR is schema/parser/wikilink/vault lint/no-mutation tests only.
+12. At that time, next authorized implementation PR was schema/parser/wikilink/vault lint/no-mutation tests only.
 13. No vector DB, MCP, dashboard graph, memory promotion, proposal writes,
     execution integration, scheduler, OpenClaw integration, or capability expansion.
 ```

--- a/docs/status/DAILY_COMMAND_CENTER.md
+++ b/docs/status/DAILY_COMMAND_CENTER.md
@@ -1,8 +1,8 @@
 # Daily Command Center
 
 Status: manual continuity surface.
-Last reviewed: 2026-06-16.
-Source: Route protection audit closure after Second Brain Slice 1 activation.
+Last reviewed: 2026-06-17.
+Source: runtime recovery and health truth product lock after deeper browser pass.
 
 This note is a human-facing command surface for current repo/vault orientation.
 It is not generated runtime truth and it does not authorize execution.
@@ -17,10 +17,11 @@ For exact runtime facts, use:
 ## Current Priorities
 
 ```text
-1. Activate Second Brain Slice 1 foundation as the next lane.
-2. Preserve the Obsidian authority boundary.
-3. Keep implementation separate from this activation PR.
-4. Treat PR #252 route-protection audit item as closed.
+1. Runtime recovery and health truth.
+2. Preserve visible user trust when Nova stalls.
+3. Keep this as a focused lock before implementation.
+4. Preserve the Obsidian authority boundary.
+5. Treat PR #252 route-protection audit item as closed.
 ```
 
 ## Current Blockers
@@ -28,40 +29,51 @@ For exact runtime facts, use:
 ```text
 No active blocker remains from the #236 / #237 / #235 / #240 / #241 sequence.
 No active blocker remains from the PR #252 route-protection trust patch.
+The active product trust blocker is recovery clarity: Nova can look alive while
+local runtime requests are timing out.
 ```
 
 ## Decisions Needed
 
 ```text
-Review this docs-only activation lane.
-If it lands cleanly, prepare the separate Slice 1 implementation PR.
+Review this docs-only recovery priority lock.
+If it lands cleanly, prepare a separate implementation PR scoped to runtime
+recovery and health truth only.
 No action needed on the third-pass route-protection audit item; PR #252 is merged.
 ```
 
 ## This Week
 
 ```text
-1. Keep Obsidian as context/navigation only.
-2. Do not treat repo-doc proof as runtime authorization.
-3. Keep Second Brain implementation separate from the activation lane.
-4. Do not reopen route-protection scope unless a new audit or CI failure proves a missed sensitive route.
+1. Scope runtime recovery and health truth before broader UX cleanup.
+2. Keep Obsidian as context/navigation only.
+3. Do not treat repo-doc proof as runtime authorization.
+4. Keep Second Brain implementation deferred behind the active recovery lane.
+5. Do not reopen route-protection scope unless a new audit or CI failure proves a missed sensitive route.
 ```
 
 ## Chosen Next Lane
 
 ```text
-Second Brain Slice 1 foundation.
+Runtime recovery and health truth.
 ```
 
-Allowed implementation scope after this activation lands:
+Priority lock:
 
 ```text
-schema
-frontmatter parser
-wikilink extraction
-vault health/lint
-no-mutation tests
-non-authorizing tests only
+docs/status/PRIORITY_LOCK_2026-06-17_RUNTIME_RECOVERY_HEALTH_TRUTH.md
+```
+
+Allowed implementation scope after this lock lands:
+
+```text
+canonical health truth
+runtime timeout/degraded/unavailable status modeling
+stuck-response detection and user-facing recovery copy
+chat/action timeout recovery affordances
+Trust explanation of product failures, not only governed receipts
+tests proving stale/timeout health cannot be shown as Normal
+tests proving no execution authority is added
 ```
 
 ## Recent Landed Stack
@@ -94,9 +106,19 @@ See docs/status/RECENT_WORKSTREAM_CLOSEOUT_2026-06-17.md.
 Provider governance and budget control are complete for current scope.
 Latest synthetic-user testing reached 98%.
 Deep audit pass 3 produced the route-protection finding closed by PR #252.
-The active next lane remains Second Brain Slice 1.
+The active next lane is now Runtime recovery and health truth.
 Real-use observation, Morning Brief usage, friction logging, and workflow
 validation continue as operating practice, not a new authority lane.
+```
+
+## Recent Product Finding
+
+```text
+The deeper browser/computer-use pass found the clearest current product signal:
+Nova can look alive while the local runtime is not actually responding.
+
+The next successful product improvement is not making Nova do more.
+It is making Nova fail clearly.
 ```
 
 ## Boundary
@@ -120,6 +142,13 @@ browser/computer-use expansion
 scheduler or background loops
 external writes
 memory promotion
-Second Brain implementation in this activation PR
+Second Brain implementation in this recovery lock
+Plan My Week
+model presets
+more agents
+more providers
+bigger dashboard redesign
+advanced navigation cleanup
+autonomous workflow execution
 Obsidian execution authority
 ```

--- a/docs/status/PRIORITY_LOCK_2026-06-17_RUNTIME_RECOVERY_HEALTH_TRUTH.md
+++ b/docs/status/PRIORITY_LOCK_2026-06-17_RUNTIME_RECOVERY_HEALTH_TRUTH.md
@@ -1,0 +1,188 @@
+# Runtime Recovery And Health Truth Priority Lock - 2026-06-17
+
+Status: proposed next product lane.
+
+Scope: make Nova fail clearly when the local runtime stalls, without adding
+new capabilities or broad UX redesign.
+
+## Product Signal
+
+The latest deeper browser/computer-use product pass found the clearest current
+trust gap:
+
+```text
+Nova can look alive while the local runtime is not actually responding.
+```
+
+Observed user-facing state:
+
+```text
+UI still visible
+buttons still visible
+pages still visible
+status says CONNECTING
+Trust can still imply Normal
+local APIs time out
+chat can remain stuck
+```
+
+This creates the highest-risk product state:
+
+```text
+The system looks usable, but the user cannot tell whether it actually is.
+```
+
+## Decision
+
+The next highest-value product lane is:
+
+```text
+P1: Runtime recovery and health truth.
+```
+
+This supersedes broad UX cleanup as the immediate product priority.
+
+The core question for this lane:
+
+```text
+When Nova stalls, does the user know what happened and what to do?
+```
+
+Current answer:
+
+```text
+Not reliably.
+```
+
+## Allowed Scope
+
+This lock allows a focused future implementation PR for:
+
+```text
+canonical health truth
+runtime timeout/degraded/unavailable status modeling
+stuck-response detection and user-facing recovery copy
+chat/action timeout recovery affordances
+Trust explanation of product failures, not only governed receipts
+tests proving stale/timeout health cannot be shown as Normal
+tests proving no execution authority is added
+```
+
+User-facing recovery copy should answer:
+
+```text
+What happened?
+Did anything run?
+Did anything leave my device?
+Is Nova healthy?
+What can I do next?
+```
+
+Example stuck-response state:
+
+```text
+Nova is taking longer than expected.
+Your request may not have completed.
+Nothing new was confirmed.
+[Retry] [Check status]
+```
+
+Example backend-unreachable state:
+
+```text
+Nova's local runtime is not responding.
+The page is still open, but requests are timing out.
+Try restarting Nova or checking status.
+```
+
+## Canonical Health States
+
+The future implementation should converge pages onto one health truth model:
+
+```text
+Connected
+Connecting
+Degraded
+Unavailable
+Timed out
+Recovering
+```
+
+No page should report:
+
+```text
+Failure state: Normal
+```
+
+while local API probes are timing out or core runtime health is stale.
+
+## Explicit Non-Goals
+
+This lock does not authorize:
+
+```text
+Plan My Week
+model presets
+more agents
+more providers
+bigger dashboard redesign
+advanced navigation cleanup
+empty-state simplification as a broad lane
+Second Brain implementation
+browser/computer-use expansion
+OpenClaw expansion
+GovernorMediator changes unless strictly needed for read-only health truth
+CapabilityRegistry changes
+ExecuteBoundary changes
+capability_locks.json changes
+scheduler or background loops
+external writes
+Shopify writes
+Gmail/calendar writes
+autonomous workflow execution
+```
+
+## Priority Stack
+
+Current product priority order:
+
+```text
+P1: Runtime recovery and health truth
+P2: First-run simplification
+P3: Status/trust surface consolidation
+P4: Advanced navigation hiding
+P5: Empty-state simplification
+```
+
+Only P1 is authorized by this lock.
+
+## Authority Boundary
+
+Recovery visibility is not execution authority.
+
+This lane may make runtime health clearer, make stalls visible, and help the
+user choose a recovery step. It must not cause Nova to execute, retry, repair,
+restart, or mutate anything silently.
+
+Any recovery action with side effects must remain explicit and user-visible.
+
+## Success Criteria
+
+The future implementation PR should prove:
+
+```text
+stuck chat/action states become visible before user trust collapses
+backend timeout/unreachable states are reflected in canonical health truth
+Trust explains product/runtime failures even when no governed action ran
+no stale timeout state is shown as Normal
+the user receives a clear next step
+no new execution capability is added
+no autonomous recovery action is introduced
+```
+
+## Final Rule
+
+```text
+The next product improvement is not making Nova do more.
+It is making Nova fail clearly.
+```

--- a/docs/todo/ACTIVE_TODO.md
+++ b/docs/todo/ACTIVE_TODO.md
@@ -1,12 +1,42 @@
 # Active TODO - Nova
 
-Last reviewed: 2026-05-26 (post-PR #234)
+Last reviewed: 2026-06-17 (runtime recovery and health truth lock)
 
 ---
 
 ## Current Active Task
 
 ```text
+Runtime recovery and health truth priority lock: ACTIVE (2026-06-17).
+  Product signal: Nova can look alive while the local runtime is not actually
+  responding. The user can see UI/buttons/pages while status says CONNECTING,
+  chat is stuck, Trust can imply Normal, and local APIs time out.
+  Highest-value next question:
+    When Nova stalls, does the user know what happened and what to do?
+  Current answer: not reliably.
+  Lock:
+    docs/status/PRIORITY_LOCK_2026-06-17_RUNTIME_RECOVERY_HEALTH_TRUTH.md
+  Allowed future implementation scope:
+    canonical health truth
+    runtime timeout/degraded/unavailable status modeling
+    stuck-response detection and user-facing recovery copy
+    chat/action timeout recovery affordances
+    Trust explanation of product failures, not only governed receipts
+    tests proving stale/timeout health cannot be shown as Normal
+    tests proving no execution authority is added
+  Not authorized:
+    Plan My Week, model presets, more agents, more providers, broad dashboard
+    redesign, advanced navigation cleanup, broad empty-state simplification,
+    Second Brain implementation, browser/computer-use expansion, OpenClaw
+    expansion, scheduler/background loops, external writes, Shopify writes,
+    Gmail/calendar writes, autonomous workflow execution, capability_locks.json
+    changes, or capability expansion.
+
+Second Brain Slice 1 priority lock remains ACCEPTED but is deferred behind
+the active runtime recovery lane.
+
+Historical context follows:
+
 Phase: Goal Card persistence complete through Phase 3 (2026-05-26).
 Goal Card local display-state: COMPLETED (PR #229, 2026-05-23).
 Goal Card UX polish: COMPLETED (PR #230, 2026-05-24).
@@ -27,7 +57,7 @@ UI simplification slice: COMPLETED (PR #233, 2026-05-26).
   No backend runtime/governance changes.
 Second Brain Slice 1 priority lock: ACCEPTED (PR #234, 2026-05-26).
   Lock-only. No implementation code.
-  Next authorized implementation PR is schema/parser/wikilink/vault lint/no-mutation tests only.
+  Original authorized implementation scope was schema/parser/wikilink/vault lint/no-mutation tests only.
   No vector DB, MCP, dashboard graph, memory promotion, proposal writes,
   execution integration, scheduler, OpenClaw integration, or capability expansion.
 
@@ -172,7 +202,13 @@ Phase 4 (execution envelopes) requires a separate design doc
 and is not authorized.
 
 Next authorized implementation PR:
-  - Second Brain Slice 1: schema/parser/wikilink/vault lint/no-mutation tests only
+  - Runtime recovery and health truth:
+    canonical health truth, timeout/degraded/unavailable status modeling,
+    stuck-response recovery affordances, Trust explanation of product failures,
+    and tests proving stale/timeout health cannot be shown as Normal.
+
+Second Brain Slice 1 remains accepted but deferred:
+  - schema/parser/wikilink/vault lint/no-mutation tests only
 ```
 
 Important boundary:
@@ -186,6 +222,14 @@ Goal Card != action engine
 Do not start next:
 
 ```text
+Plan My Week
+model presets
+more agents
+more providers
+bigger dashboard redesign
+advanced navigation cleanup
+broad empty-state simplification
+Second Brain implementation while the recovery lock is active
 Goal Card execution or click-to-run
 Shopify writes
 Printify automation
@@ -210,8 +254,8 @@ PR #231 backend + PR #232 frontend wiring). UI simplification
 is complete (PR #233). Dashboard clarity improved without
 authority expansion. Goal Cards remain display-only. No
 execution, no scheduler, no GovernorMediator changes. Second
-Brain Slice 1 priority lock is accepted (PR #234). Next
-implementation PR is limited to schema, parser, wikilink
-extraction, vault health/lint, and non-authorizing/no-mutation
-tests only.
+Brain Slice 1 priority lock is accepted (PR #234) but deferred
+behind the active runtime recovery and health truth lock. Next
+implementation PR is limited to recovery clarity and canonical
+health truth without new execution authority.
 ```


### PR DESCRIPTION
## Summary

- Adds a docs-only priority lock for `Runtime recovery and health truth`.
- Updates current continuity surfaces to make recovery clarity the active lane.
- Keeps Second Brain Slice 1 accepted, but explicitly deferred behind the recovery lock.

## Why

The deeper browser usability pass showed the clearest current product trust gap: Nova can look alive while the local runtime is not actually responding. The next lane should make stalls, timeouts, degraded health, and recovery paths visible before broader UX cleanup or new capability work.

## Scope

This PR authorizes no implementation code. The future implementation scope is limited to canonical health truth, stuck-response recovery, Trust explanations for product/runtime failures, and tests proving stale or timeout health cannot be shown as Normal.

Explicit non-goals include Plan My Week, new providers, new agents, dashboard redesign, Second Brain implementation, browser/computer-use expansion, OpenClaw expansion, external writes, and new execution authority.

## Validation

- `git diff --check --cached`
- docs-only change; backend tests not run